### PR TITLE
Port ReScript engine modules

### DIFF
--- a/implementations-wip/rescript/Dockerfile
+++ b/implementations-wip/rescript/Dockerfile
@@ -44,7 +44,7 @@ USER chess
 EXPOSE 3000
 
 # Default command to run the chess engine
-CMD ["node", "lib/js/src/Chess.js"]
+CMD ["node", "lib/es6/src/Chess.js"]
 
 # Alternative commands for different use cases:
 # To build only: docker run --rm chess-engine npm run build

--- a/implementations-wip/rescript/Makefile
+++ b/implementations-wip/rescript/Makefile
@@ -11,7 +11,7 @@ build:
 # Run basic tests
 test:
 	@echo "Running basic functionality test..."
-	@echo -e "new\nmove e2e4\nmove e7e5\nexport\nquit" | node lib/js/src/Chess.js | tail -1 | grep -q "rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq e6 0 2" && echo "✅ Basic test passed" || echo "❌ Basic test failed"
+	@echo -e "new\nmove e2e4\nmove e7e5\nexport\nquit" | node lib/es6/src/Chess.js | grep -q "FEN: rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq e6 0 2" && echo "✅ Basic test passed" || echo "❌ Basic test failed"
 
 # Static analysis and code quality
 analyze:
@@ -30,7 +30,7 @@ docker-build:
 
 docker-test: docker-build
 	@echo "Testing ReScript implementation in Docker..."
-	docker run --rm -i chess-rescript sh -c "echo -e 'new\\nmove e2e4\\nmove e7e5\\nexport\\nquit' | node lib/js/src/Chess.js"
+	docker run --rm -i chess-rescript sh -c "echo -e 'new\\nmove e2e4\\nmove e7e5\\nexport\\nquit' | node lib/es6/src/Chess.js"
 
 # Help target
 help:

--- a/implementations-wip/rescript/README.md
+++ b/implementations-wip/rescript/README.md
@@ -21,7 +21,7 @@ A complete chess engine implementation in ReScript following the Chess Engine Sp
 ```bash
 npm install
 npm run build
-node lib/js/src/Chess.js
+node lib/es6/src/Chess.js
 ```
 
 ## Docker Usage

--- a/implementations-wip/rescript/bsconfig.json
+++ b/implementations-wip/rescript/bsconfig.json
@@ -6,10 +6,10 @@
     "subdirs": true
   },
   "package-specs": {
-    "module": "es6",
-    "in-source": true
+    "module": "esmodule",
+    "in-source": false
   },
-  "suffix": ".bs.js",
+  "suffix": ".js",
   "bs-dependencies": [
     "@rescript/core"
   ],

--- a/implementations-wip/rescript/chess.meta
+++ b/implementations-wip/rescript/chess.meta
@@ -3,10 +3,10 @@
   "version": "10.0",
   "author": "ReScript Implementation",
   "build": "npm install && npm run build",
-  "run": "node lib/js/src/Chess.js",
+  "run": "node lib/es6/src/Chess.js",
   "analyze": "npx rescript build",
-  "test": "node lib/js/src/Chess.js",
+  "test": "node lib/es6/src/Chess.js",
   "features": ["perft", "fen", "ai", "castling", "en_passant", "promotion"],
-  "max_ai_depth": 4,
+  "max_ai_depth": 5,
   "estimated_perft4_ms": 1500
 }

--- a/implementations-wip/rescript/package.json
+++ b/implementations-wip/rescript/package.json
@@ -7,7 +7,7 @@
     "build": "rescript",
     "clean": "rescript clean",
     "watch": "rescript -w",
-    "start": "node src/Chess.bs.js",
+    "start": "node lib/es6/src/Chess.js",
     "chess": "npm run build && npm start"
   },
   "dependencies": {

--- a/implementations-wip/rescript/src/AI.res
+++ b/implementations-wip/rescript/src/AI.res
@@ -1,0 +1,99 @@
+open Types
+open MoveGenerator
+open Evaluation
+
+let rec minimax = (state: gameState, depth: int, alpha: int, beta: int): int => {
+  if depth == 0 {
+    evaluateGameState(state)
+  } else {
+    let moves = generateLegalMoves(state)
+    let moveCount = Js.Array.length(moves)
+
+    if moveCount == 0 {
+      if isKingInCheck(state, state.turn) {
+        if state.turn == White { -100000 } else { 100000 }
+      } else {
+        0
+      }
+    } else if state.turn == White {
+      let maxEval = ref(-1000000)
+      let alphaRef = ref(alpha)
+      let index = ref(0)
+
+      while index.contents < moveCount && beta > alphaRef.contents {
+        let move = Belt.Array.getExn(moves, index.contents)
+        let nextState = makeMove(state, move)
+        let evaluation = minimax(nextState, depth - 1, alphaRef.contents, beta)
+
+        if evaluation > maxEval.contents {
+          maxEval := evaluation
+        }
+        if evaluation > alphaRef.contents {
+          alphaRef := evaluation
+        }
+
+        index := index.contents + 1
+      }
+
+      maxEval.contents
+    } else {
+      let minEval = ref(1000000)
+      let betaRef = ref(beta)
+      let index = ref(0)
+
+      while index.contents < moveCount && betaRef.contents > alpha {
+        let move = Belt.Array.getExn(moves, index.contents)
+        let nextState = makeMove(state, move)
+        let evaluation = minimax(nextState, depth - 1, alpha, betaRef.contents)
+
+        if evaluation < minEval.contents {
+          minEval := evaluation
+        }
+        if evaluation < betaRef.contents {
+          betaRef := evaluation
+        }
+
+        index := index.contents + 1
+      }
+
+      minEval.contents
+    }
+  }
+}
+
+let findBestMove = (state: gameState, depth: int): option<(move, int)> => {
+  let moves = generateLegalMoves(state)
+  let moveCount = Js.Array.length(moves)
+
+  if moveCount == 0 {
+    None
+  } else {
+    let bestMove = ref(Belt.Array.getExn(moves, 0))
+    let bestEval =
+      if state.turn == White {
+        ref(-1000000)
+      } else {
+        ref(1000000)
+      }
+
+    for index in 0 to moveCount - 1 {
+      let move = Belt.Array.getExn(moves, index)
+      let nextState = makeMove(state, move)
+      let evaluation = minimax(nextState, depth - 1, -1000000, 1000000)
+
+      if state.turn == White {
+        if evaluation > bestEval.contents {
+          bestEval := evaluation
+          bestMove := move
+        }
+      } else {
+        if evaluation < bestEval.contents {
+          bestEval := evaluation
+          bestMove := move
+        }
+      }
+    }
+
+    Some((bestMove.contents, bestEval.contents))
+  }
+}

--- a/implementations-wip/rescript/src/Board.res
+++ b/implementations-wip/rescript/src/Board.res
@@ -1,0 +1,243 @@
+open Types
+open Utils
+
+let createEmptyBoard = (): array<option<piece>> => Array.make(64, None)
+
+let createInitialBoard = (): array<option<piece>> => {
+  let board = Array.make(64, None)
+
+  let setPieceAt = (square: int, pieceType: pieceType, color: color) =>
+    Belt.Array.setExn(board, square, Some({pieceType, color}))
+
+  // White pieces
+  setPieceAt(0, Rook, White)
+  setPieceAt(1, Knight, White)
+  setPieceAt(2, Bishop, White)
+  setPieceAt(3, Queen, White)
+  setPieceAt(4, King, White)
+  setPieceAt(5, Bishop, White)
+  setPieceAt(6, Knight, White)
+  setPieceAt(7, Rook, White)
+
+  for i in 8 to 15 {
+    setPieceAt(i, Pawn, White)
+  }
+
+  // Black pieces
+  setPieceAt(56, Rook, Black)
+  setPieceAt(57, Knight, Black)
+  setPieceAt(58, Bishop, Black)
+  setPieceAt(59, Queen, Black)
+  setPieceAt(60, King, Black)
+  setPieceAt(61, Bishop, Black)
+  setPieceAt(62, Knight, Black)
+  setPieceAt(63, Rook, Black)
+
+  for i in 48 to 55 {
+    setPieceAt(i, Pawn, Black)
+  }
+
+  board
+}
+
+let createInitialState = (): gameState => {
+  {
+    board: createInitialBoard(),
+    turn: White,
+    castlingRights: {
+      whiteKingside: true,
+      whiteQueenside: true,
+      blackKingside: true,
+      blackQueenside: true,
+    },
+    enPassantTarget: None,
+    halfmoveClock: 0,
+    fullmoveNumber: 1,
+    moveHistory: [],
+  }
+}
+
+let getPiece = (state: gameState, square: square): option<piece> => {
+  if square < 0 || square >= 64 {
+    None
+  } else {
+    Belt.Array.getExn(state.board, square)
+  }
+}
+
+let setPiece = (state: gameState, square: square, piece: option<piece>): gameState => {
+  let newBoard = Belt.Array.copy(state.board)
+  Belt.Array.setExn(newBoard, square, piece)
+  {...state, board: newBoard}
+}
+
+let boardToString = (state: gameState): string => {
+  let output = ref("  a b c d e f g h\n")
+
+  for rowIndex in 0 to 7 {
+    let rank = 7 - rowIndex
+    output := output.contents ++ Belt.Int.toString(rank + 1) ++ " "
+
+    for file in 0 to 7 {
+      let square = rank * 8 + file
+      let char =
+        switch getPiece(state, square) {
+        | Some(piece) => pieceToChar(piece)
+        | None => "."
+        }
+      output := output.contents ++ char ++ " "
+    }
+
+    output := output.contents ++ Belt.Int.toString(rank + 1) ++ "\n"
+  }
+
+  output := output.contents ++ "  a b c d e f g h\n\n"
+  let turnLabel = if state.turn == White { "White" } else { "Black" }
+  output := output.contents ++ turnLabel ++ " to move"
+
+  output.contents
+}
+
+let parseFen = (fen: string): result<gameState, string> => {
+  let parts = Js.String.split(" ", Js.String.trim(fen))
+
+  if Belt.Array.length(parts) < 4 {
+    Error("Invalid FEN string")
+  } else {
+    let pieces = Belt.Array.getExn(parts, 0)
+    let turnPart = Belt.Array.getExn(parts, 1)
+    let castlingPart = Belt.Array.getExn(parts, 2)
+    let enPassantPart = Belt.Array.getExn(parts, 3)
+    let halfmovePart =
+      switch Belt.Array.get(parts, 4) {
+      | Some(value) => value
+      | None => "0"
+      }
+    let fullmovePart =
+      switch Belt.Array.get(parts, 5) {
+      | Some(value) => value
+      | None => "1"
+      }
+
+    let board = Array.make(64, None)
+    let square = ref(56)
+    let length = Js.String.length(pieces)
+
+    for i in 0 to length - 1 {
+      let char = Js.String.charAt(i, pieces)
+      switch char {
+      | "/" => square := square.contents - 16
+      | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" =>
+        switch Belt.Int.fromString(char) {
+        | Some(step) => square := square.contents + step
+        | None => ()
+        }
+      | _ =>
+        switch charToPiece(char) {
+        | Some(piece) =>
+          Belt.Array.setExn(board, square.contents, Some(piece))
+          square := square.contents + 1
+        | None => ()
+        }
+      }
+    }
+
+    let turn = if turnPart == "w" { White } else { Black }
+
+    let hasCastling = (char: string) => Js.String.indexOf(castlingPart, char) != -1
+
+    let castlingRights = {
+      whiteKingside: hasCastling("K"),
+      whiteQueenside: hasCastling("Q"),
+      blackKingside: hasCastling("k"),
+      blackQueenside: hasCastling("q"),
+    }
+
+    let enPassantTarget =
+      if enPassantPart == "-" {
+        None
+      } else {
+        parseSquare(enPassantPart)
+      }
+
+    let halfmoveClock =
+      switch Belt.Int.fromString(halfmovePart) {
+      | Some(value) => value
+      | None => 0
+      }
+
+    let fullmoveNumber =
+      switch Belt.Int.fromString(fullmovePart) {
+      | Some(value) => value
+      | None => 1
+      }
+
+    Ok({
+      board,
+      turn,
+      castlingRights,
+      enPassantTarget,
+      halfmoveClock,
+      fullmoveNumber,
+      moveHistory: [],
+    })
+  }
+}
+
+let exportFen = (state: gameState): string => {
+  let pieces = ref("")
+
+  for rowIndex in 0 to 7 {
+    let rank = 7 - rowIndex
+    let emptyCount = ref(0)
+
+    for file in 0 to 7 {
+      let square = rank * 8 + file
+      switch getPiece(state, square) {
+      | Some(piece) =>
+        if emptyCount.contents > 0 {
+          pieces := pieces.contents ++ Belt.Int.toString(emptyCount.contents)
+          emptyCount := 0
+        }
+        pieces := pieces.contents ++ pieceToChar(piece)
+      | None => emptyCount := emptyCount.contents + 1
+      }
+    }
+
+    if emptyCount.contents > 0 {
+      pieces := pieces.contents ++ Belt.Int.toString(emptyCount.contents)
+    }
+
+    if rank > 0 {
+      pieces := pieces.contents ++ "/"
+    }
+  }
+
+  let turn = if state.turn == White { "w" } else { "b" }
+
+  let castling = ref("")
+  if state.castlingRights.whiteKingside { castling := castling.contents ++ "K" }
+  if state.castlingRights.whiteQueenside { castling := castling.contents ++ "Q" }
+  if state.castlingRights.blackKingside { castling := castling.contents ++ "k" }
+  if state.castlingRights.blackQueenside { castling := castling.contents ++ "q" }
+
+  let castlingStr = if castling.contents == "" { "-" } else { castling.contents }
+
+  let enPassant =
+    switch state.enPassantTarget {
+    | None => "-"
+    | Some(square) => squareToString(square)
+    }
+
+  pieces.contents ++
+  " " ++
+  turn ++
+  " " ++
+  castlingStr ++
+  " " ++
+  enPassant ++
+  " " ++
+  Belt.Int.toString(state.halfmoveClock) ++
+  " " ++
+  Belt.Int.toString(state.fullmoveNumber)
+}

--- a/implementations-wip/rescript/src/Chess.res
+++ b/implementations-wip/rescript/src/Chess.res
@@ -24,7 +24,7 @@ let parseMove = (moveStr: string): option<(int, int, option<pieceType>)> => {
     switch (Utils.parseSquare(fromStr), Utils.parseSquare(toStr)) {
     | (Some(from), Some(to)) =>
       let promotion = if len == 5 {
-        switch Js.String.toLowerCase(Js.String.charAt(moveStr, 4)) {
+        switch Js.String.toLowerCase(Js.String.charAt(4, moveStr)) {
         | "q" => Some(Queen)
         | "r" => Some(Rook)
         | "b" => Some(Bishop)
@@ -180,7 +180,11 @@ let processCommand = (engine: gameEngine, input: string): unit => {
       if Belt.Array.length(parts) < 2 {
         Js.log("ERROR: Invalid FEN command")
       } else {
-        let fenStr = Belt.Array.sliceToEnd(parts, 1)->Js.Array.joinWith(" ")
+        let fenParts = Belt.Array.sliceToEnd(parts, 1)
+        let fenStr =
+          Belt.Array.reduce(fenParts, "", (acc, item) =>
+            if acc == "" { item } else { acc ++ " " ++ item }
+          )
         switch Board.parseFen(fenStr) {
         | Ok(newState) =>
           engine.state = newState

--- a/implementations-wip/rescript/src/Evaluation.res
+++ b/implementations-wip/rescript/src/Evaluation.res
@@ -1,0 +1,72 @@
+open Types
+open Utils
+
+let isEndgame = (state: gameState): bool => {
+  let pieceCount = ref(0)
+  let queenCount = ref(0)
+
+  for square in 0 to 63 {
+    switch Belt.Array.getExn(state.board, square) {
+    | Some(piece) =>
+      if piece.pieceType != King && piece.pieceType != Pawn {
+        pieceCount := pieceCount.contents + 1
+        if piece.pieceType == Queen {
+          queenCount := queenCount.contents + 1
+        }
+      }
+    | None => ()
+    }
+  }
+
+  pieceCount.contents <= 4 || (pieceCount.contents <= 6 && queenCount.contents == 0)
+}
+
+let positionBonus = (state: gameState, square: square, piece: piece): int => {
+  let file = modInt(square, 8)
+  let rank = square / 8
+  let bonus = ref(0)
+
+  let centerSquares = [27, 28, 35, 36]
+  if Belt.Array.some(centerSquares, value => value == square) {
+    bonus := bonus.contents + 10
+  }
+
+  switch piece.pieceType {
+  | Pawn =>
+    let advancement = if piece.color == White { rank } else { 7 - rank }
+    bonus := bonus.contents + advancement * 5
+  | King =>
+    if !isEndgame(state) {
+      let kingSafetyRow = if piece.color == White { 0 } else { 7 }
+      if rank == kingSafetyRow && (file <= 2 || file >= 5) {
+        bonus := bonus.contents + 20
+      } else {
+        bonus := bonus.contents - 20
+      }
+    }
+  | _ => ()
+  }
+
+  bonus.contents
+}
+
+let evaluateGameState = (state: gameState): int => {
+  let score = ref(0)
+
+  for square in 0 to 63 {
+    switch Belt.Array.getExn(state.board, square) {
+    | Some(piece) =>
+      let value = pieceValue(piece.pieceType)
+      let bonus = positionBonus(state, square, piece)
+      let total = value + bonus
+      if piece.color == White {
+        score := score.contents + total
+      } else {
+        score := score.contents - total
+      }
+    | None => ()
+    }
+  }
+
+  score.contents
+}

--- a/implementations-wip/rescript/src/MoveGenerator.res
+++ b/implementations-wip/rescript/src/MoveGenerator.res
@@ -1,0 +1,551 @@
+open Types
+open Utils
+
+let isValidSquare = (square: square): bool => square >= 0 && square < 64
+
+let getPiece = (state: gameState, square: square): option<piece> => {
+  if !isValidSquare(square) {
+    None
+  } else {
+    Belt.Array.getExn(state.board, square)
+  }
+}
+
+let generatePawnMoves = (state: gameState, from: square, piece: piece): array<move> => {
+  let moves: array<move> = []
+  let direction = if piece.color == White { 8 } else { -8 }
+  let startRank = if piece.color == White { 1 } else { 6 }
+  let promotionRank = if piece.color == White { 7 } else { 0 }
+  let rank = from / 8
+  let file = modInt(from, 8)
+
+  let oneSquareForward = from + direction
+  if isValidSquare(oneSquareForward) && getPiece(state, oneSquareForward) == None {
+    if oneSquareForward / 8 == promotionRank {
+      Belt.Array.forEach(promotionPieces, promo =>
+        Belt.Array.push(moves, {
+          from,
+          to: oneSquareForward,
+          piece: Pawn,
+          captured: None,
+          promotion: Some(promo),
+          castling: None,
+          enPassant: false,
+        })
+
+      )
+    } else {
+      Belt.Array.push(moves, {
+        from,
+        to: oneSquareForward,
+        piece: Pawn,
+        captured: None,
+        promotion: None,
+        castling: None,
+        enPassant: false,
+      })
+
+    }
+
+    if rank == startRank {
+      let twoSquaresForward = from + 2 * direction
+      if getPiece(state, twoSquaresForward) == None {
+        Belt.Array.push(moves, {
+          from,
+          to: twoSquaresForward,
+          piece: Pawn,
+          captured: None,
+          promotion: None,
+          castling: None,
+          enPassant: false,
+        })
+
+      }
+    }
+  }
+
+  let captureOffsets: array<int> = [direction - 1, direction + 1]
+  Belt.Array.forEach(captureOffsets, offset => {
+    let to = from + offset
+    let toFile = modInt(to, 8)
+
+    if isValidSquare(to) && absInt(toFile - file) == 1 {
+      switch getPiece(state, to) {
+      | Some(target) if target.color != piece.color =>
+        if to / 8 == promotionRank {
+          Belt.Array.forEach(promotionPieces, promo =>
+            Belt.Array.push(moves, {
+              from,
+              to,
+              piece: Pawn,
+              captured: Some(target.pieceType),
+              promotion: Some(promo),
+              castling: None,
+              enPassant: false,
+            })
+
+          )
+        } else {
+          Belt.Array.push(moves, {
+            from,
+            to,
+            piece: Pawn,
+            captured: Some(target.pieceType),
+            promotion: None,
+            castling: None,
+            enPassant: false,
+          })
+
+        }
+      | _ => ()
+      }
+    }
+  })
+
+  switch state.enPassantTarget {
+  | None => ()
+  | Some(enPassantTarget) =>
+    let expectedPawnRank = if piece.color == White { 4 } else { 3 }
+    if rank == expectedPawnRank {
+      let offsets: array<int> = [-1, 1]
+      Belt.Array.forEach(offsets, offset => {
+        let adjacentSquare = from + offset
+        let adjFile = modInt(adjacentSquare, 8)
+
+        if absInt(adjFile - file) == 1 {
+          switch getPiece(state, adjacentSquare) {
+          | Some(targetPawn) if targetPawn.pieceType == Pawn && targetPawn.color != piece.color =>
+            let captureSquare = enPassantTarget
+            if captureSquare == adjacentSquare + direction {
+              Belt.Array.push(moves, {
+                from,
+                to: captureSquare,
+                piece: Pawn,
+                captured: Some(Pawn),
+                promotion: None,
+                castling: None,
+                enPassant: true,
+              })
+
+            }
+          | _ => ()
+          }
+        }
+      })
+    }
+  }
+
+  moves
+}
+
+let generateKnightMoves = (state: gameState, from: square, piece: piece): array<move> => {
+  let moves: array<move> = []
+  let offsets: array<int> = [-17, -15, -10, -6, 6, 10, 15, 17]
+  let file = modInt(from, 8)
+
+  Belt.Array.forEach(offsets, offset => {
+    let to = from + offset
+    let toFile = modInt(to, 8)
+
+    if isValidSquare(to) && absInt(toFile - file) <= 2 {
+      switch getPiece(state, to) {
+      | None =>
+        Belt.Array.push(moves, {
+          from,
+          to,
+          piece: Knight,
+          captured: None,
+          promotion: None,
+          castling: None,
+          enPassant: false,
+        })
+
+      | Some(target) if target.color != piece.color =>
+        Belt.Array.push(moves, {
+          from,
+          to,
+          piece: Knight,
+          captured: Some(target.pieceType),
+          promotion: None,
+          castling: None,
+          enPassant: false,
+        })
+
+      | _ => ()
+      }
+    }
+  })
+
+  moves
+}
+
+let generateSlidingMoves = (
+  state: gameState,
+  from: square,
+  piece: piece,
+  directions: array<int>,
+  isDiagonal: option<bool>,
+): array<move> => {
+  let moves: array<move> = []
+  let file = modInt(from, 8)
+
+  Belt.Array.forEach(directions, direction => {
+    let to = ref(from + direction)
+    let prevFile = ref(file)
+    let running = ref(true)
+
+    while running.contents && isValidSquare(to.contents) {
+      let toFile = modInt(to.contents, 8)
+
+      switch isDiagonal {
+      | Some(true) =>
+        if absInt(toFile - prevFile.contents) != 1 {
+          running := false
+        }
+      | _ =>
+        if (direction == -1 || direction == 1) && absInt(toFile - prevFile.contents) != 1 {
+          running := false
+        }
+      }
+
+      if running.contents {
+        switch getPiece(state, to.contents) {
+        | None =>
+          Belt.Array.push(moves, {
+            from,
+            to: to.contents,
+            piece: piece.pieceType,
+            captured: None,
+            promotion: None,
+            castling: None,
+            enPassant: false,
+          })
+
+        | Some(target) if target.color != piece.color =>
+          Belt.Array.push(moves, {
+            from,
+            to: to.contents,
+            piece: piece.pieceType,
+            captured: Some(target.pieceType),
+            promotion: None,
+            castling: None,
+            enPassant: false,
+          })
+
+          running := false
+        | Some(_) => running := false
+        }
+
+        if running.contents {
+          prevFile := toFile
+          to := to.contents + direction
+        }
+      }
+    }
+  })
+
+  moves
+}
+
+let rec generateKingMoves = (
+  state: gameState,
+  from: square,
+  piece: piece,
+  includeCastling: bool,
+): array<move> => {
+  let moves: array<move> = []
+  let offsets: array<int> = [-9, -8, -7, -1, 1, 7, 8, 9]
+  let file = modInt(from, 8)
+
+  Belt.Array.forEach(offsets, offset => {
+    let to = from + offset
+    let toFile = modInt(to, 8)
+
+    if isValidSquare(to) && absInt(toFile - file) <= 1 {
+      switch getPiece(state, to) {
+      | None =>
+        Belt.Array.push(moves, {
+          from,
+          to,
+          piece: King,
+          captured: None,
+          promotion: None,
+          castling: None,
+          enPassant: false,
+        })
+
+      | Some(target) if target.color != piece.color =>
+        Belt.Array.push(moves, {
+          from,
+          to,
+          piece: King,
+          captured: Some(target.pieceType),
+          promotion: None,
+          castling: None,
+          enPassant: false,
+        })
+
+      | _ => ()
+      }
+    }
+  })
+
+  if includeCastling {
+    let rights = state.castlingRights
+    if piece.color == White && from == 4 {
+      if rights.whiteKingside && getPiece(state, 5) == None && getPiece(state, 6) == None {
+        switch getPiece(state, 7) {
+        | Some(rook) if rook.pieceType == Rook =>
+          if !isSquareAttacked(state, 4, Black) && !isSquareAttacked(state, 5, Black) && !isSquareAttacked(state, 6, Black) {
+            Belt.Array.push(moves, {
+              from: 4,
+              to: 6,
+              piece: King,
+              captured: None,
+              promotion: None,
+              castling: Some("K"),
+              enPassant: false,
+            })
+
+          }
+        | _ => ()
+        }
+      }
+
+      if rights.whiteQueenside && getPiece(state, 3) == None && getPiece(state, 2) == None && getPiece(state, 1) == None {
+        switch getPiece(state, 0) {
+        | Some(rook) if rook.pieceType == Rook =>
+          if !isSquareAttacked(state, 4, Black) && !isSquareAttacked(state, 3, Black) && !isSquareAttacked(state, 2, Black) {
+            Belt.Array.push(moves, {
+              from: 4,
+              to: 2,
+              piece: King,
+              captured: None,
+              promotion: None,
+              castling: Some("Q"),
+              enPassant: false,
+            })
+
+          }
+        | _ => ()
+        }
+      }
+    } else if piece.color == Black && from == 60 {
+      if rights.blackKingside && getPiece(state, 61) == None && getPiece(state, 62) == None {
+        switch getPiece(state, 63) {
+        | Some(rook) if rook.pieceType == Rook =>
+          if !isSquareAttacked(state, 60, White) && !isSquareAttacked(state, 61, White) && !isSquareAttacked(state, 62, White) {
+            Belt.Array.push(moves, {
+              from: 60,
+              to: 62,
+              piece: King,
+              captured: None,
+              promotion: None,
+              castling: Some("k"),
+              enPassant: false,
+            })
+
+          }
+        | _ => ()
+        }
+      }
+
+      if rights.blackQueenside && getPiece(state, 59) == None && getPiece(state, 58) == None && getPiece(state, 57) == None {
+        switch getPiece(state, 56) {
+        | Some(rook) if rook.pieceType == Rook =>
+          if !isSquareAttacked(state, 60, White) && !isSquareAttacked(state, 59, White) && !isSquareAttacked(state, 58, White) {
+            Belt.Array.push(moves, {
+              from: 60,
+              to: 58,
+              piece: King,
+              captured: None,
+              promotion: None,
+              castling: Some("q"),
+              enPassant: false,
+            })
+
+          }
+        | _ => ()
+        }
+      }
+    }
+  }
+
+  moves
+}
+
+and isSquareAttacked = (state: gameState, targetSquare: square, byColor: color): bool => {
+  let attacked = ref(false)
+
+  for square in 0 to 63 {
+    if !attacked.contents {
+      switch getPiece(state, square) {
+      | Some(piece) if piece.color == byColor =>
+        let moves =
+          switch piece.pieceType {
+          | King => generateKingMoves(state, square, piece, false)
+          | Pawn => generatePawnMoves(state, square, piece)
+          | Knight => generateKnightMoves(state, square, piece)
+          | Bishop => generateSlidingMoves(state, square, piece, [-9, -7, 7, 9], Some(true))
+          | Rook => generateSlidingMoves(state, square, piece, [-8, -1, 1, 8], Some(false))
+          | Queen => generateSlidingMoves(state, square, piece, [-9, -8, -7, -1, 1, 7, 8, 9], None)
+          }
+        if Belt.Array.some(moves, move => move.to == targetSquare) {
+          attacked := true
+        }
+      | _ => ()
+      }
+    }
+  }
+
+  attacked.contents
+}
+
+let generatePieceMoves = (state: gameState, from: square, piece: piece): array<move> =>
+  switch piece.pieceType {
+  | Pawn => generatePawnMoves(state, from, piece)
+  | Knight => generateKnightMoves(state, from, piece)
+  | Bishop => generateSlidingMoves(state, from, piece, [-9, -7, 7, 9], Some(true))
+  | Rook => generateSlidingMoves(state, from, piece, [-8, -1, 1, 8], Some(false))
+  | Queen => generateSlidingMoves(state, from, piece, [-9, -8, -7, -1, 1, 7, 8, 9], None)
+  | King => generateKingMoves(state, from, piece, true)
+  }
+
+let generateAllMoves = (state: gameState, color: color): array<move> => {
+  let moves: array<move> = []
+
+  for square in 0 to 63 {
+    switch getPiece(state, square) {
+    | Some(piece) if piece.color == color =>
+      let pieceMoves = generatePieceMoves(state, square, piece)
+      Belt.Array.forEach(pieceMoves, move => Belt.Array.push(moves, move))
+    | _ => ()
+    }
+  }
+
+  moves
+}
+
+let isKingInCheck = (state: gameState, color: color): bool => {
+  let kingSquare = ref(None)
+
+  for square in 0 to 63 {
+    if kingSquare.contents == None {
+      switch getPiece(state, square) {
+      | Some(piece) if piece.color == color && piece.pieceType == King => kingSquare := Some(square)
+      | _ => ()
+      }
+    }
+  }
+
+  switch kingSquare.contents {
+  | None => false
+  | Some(square) => isSquareAttacked(state, square, oppositeColor(color))
+  }
+}
+
+let makeMove = (state: gameState, move: move): gameState => {
+  switch getPiece(state, move.from) {
+  | None => state
+  | Some(piece) =>
+    let board = Belt.Array.copy(state.board)
+    let setOnBoard = (square: int, pieceOpt: option<piece>) =>
+      Belt.Array.setExn(board, square, pieceOpt)
+
+    setOnBoard(move.to, Some(piece))
+    setOnBoard(move.from, None)
+
+    switch move.castling {
+    | Some("K") =>
+      setOnBoard(5, getPiece(state, 7))
+      setOnBoard(7, None)
+    | Some("Q") =>
+      setOnBoard(3, getPiece(state, 0))
+      setOnBoard(0, None)
+    | Some("k") =>
+      setOnBoard(61, getPiece(state, 63))
+      setOnBoard(63, None)
+    | Some("q") =>
+      setOnBoard(59, getPiece(state, 56))
+      setOnBoard(56, None)
+    | _ => ()
+    }
+
+    if move.enPassant {
+      let capturedPawnSquare = move.to + (if piece.color == White { -8 } else { 8 })
+      setOnBoard(capturedPawnSquare, None)
+    }
+
+    switch move.promotion {
+    | Some(promo) => setOnBoard(move.to, Some({pieceType: promo, color: piece.color}))
+    | None => ()
+    }
+
+    let rights = state.castlingRights
+    let newRights =
+      switch piece.pieceType {
+      | King =>
+        if piece.color == White {
+          {...rights, whiteKingside: false, whiteQueenside: false}
+        } else {
+          {...rights, blackKingside: false, blackQueenside: false}
+        }
+      | Rook =>
+        if piece.color == White {
+          if move.from == 0 {
+            {...rights, whiteQueenside: false}
+          } else if move.from == 7 {
+            {...rights, whiteKingside: false}
+          } else {
+            rights
+          }
+        } else {
+          if move.from == 56 {
+            {...rights, blackQueenside: false}
+          } else if move.from == 63 {
+            {...rights, blackKingside: false}
+          } else {
+            rights
+          }
+        }
+      | _ => rights
+      }
+
+    let enPassantTarget =
+      if piece.pieceType == Pawn && absInt(move.to - move.from) == 16 {
+        Some((move.from + move.to) / 2)
+      } else {
+        None
+      }
+
+    let halfmoveClock =
+      if piece.pieceType == Pawn || move.captured != None {
+        0
+      } else {
+        state.halfmoveClock + 1
+      }
+
+    let fullmoveNumber = if piece.color == Black { state.fullmoveNumber + 1 } else { state.fullmoveNumber }
+
+    let newTurn = oppositeColor(state.turn)
+    let moveHistory = Belt.Array.concat(state.moveHistory, [move])
+
+    {
+      board,
+      turn: newTurn,
+      castlingRights: newRights,
+      enPassantTarget,
+      halfmoveClock,
+      fullmoveNumber,
+      moveHistory,
+    }
+  }
+}
+
+let generateLegalMoves = (state: gameState): array<move> => {
+  let moves = generateAllMoves(state, state.turn)
+  Belt.Array.keep(moves, move => {
+    let nextState = makeMove(state, move)
+    !isKingInCheck(nextState, state.turn)
+  })
+}

--- a/implementations-wip/rescript/src/Node.res
+++ b/implementations-wip/rescript/src/Node.res
@@ -1,12 +1,12 @@
+module Stream = {
+  type readable
+  type writable
+}
+
 module Process = {
   @val external exit: int => unit = "process.exit"
   @val external stdin: Stream.readable = "process.stdin"
   @val external stdout: Stream.writable = "process.stdout"
-}
-
-module Stream = {
-  type readable
-  type writable
 }
 
 module Readline = {
@@ -24,7 +24,7 @@ module Readline = {
   module Interface = {
     @send external prompt: readlineInterface => unit = "prompt"
     
-    @send external on: (readlineInterface, @string [#line | #close], 'a) => unit = "on"
+    @send external on: (readlineInterface, [#line | #close], 'a) => unit = "on"
     
     @send external question: (readlineInterface, string, string => unit) => unit = "question"
     

--- a/implementations-wip/rescript/src/Perft.res
+++ b/implementations-wip/rescript/src/Perft.res
@@ -1,0 +1,20 @@
+open Types
+open MoveGenerator
+
+let rec perft = (state: gameState, depth: int): int => {
+  if depth == 0 {
+    1
+  } else {
+    let moves = generateLegalMoves(state)
+    let nodes = ref(0)
+    let moveCount = Js.Array.length(moves)
+
+    for index in 0 to moveCount - 1 {
+      let move = Belt.Array.getExn(moves, index)
+      let nextState = makeMove(state, move)
+      nodes := nodes.contents + perft(nextState, depth - 1)
+    }
+
+    nodes.contents
+  }
+}

--- a/implementations-wip/rescript/src/Types.res
+++ b/implementations-wip/rescript/src/Types.res
@@ -1,0 +1,57 @@
+type pieceType = Pawn | Knight | Bishop | Rook | Queen | King
+
+type color = White | Black
+
+type square = int
+
+type piece = {
+  pieceType: pieceType,
+  color: color,
+}
+
+type move = {
+  from: square,
+  to: square,
+  piece: pieceType,
+  captured: option<pieceType>,
+  promotion: option<pieceType>,
+  castling: option<string>,
+  enPassant: bool,
+}
+
+type castlingRights = {
+  whiteKingside: bool,
+  whiteQueenside: bool,
+  blackKingside: bool,
+  blackQueenside: bool,
+}
+
+type gameState = {
+  board: array<option<piece>>,
+  turn: color,
+  castlingRights: castlingRights,
+  enPassantTarget: option<square>,
+  halfmoveClock: int,
+  fullmoveNumber: int,
+  moveHistory: array<move>,
+}
+
+type gameStatus =
+  | InProgress
+  | Checkmate(color)
+  | Stalemate
+
+let files: array<string> = ["a", "b", "c", "d", "e", "f", "g", "h"]
+let ranks: array<string> = ["1", "2", "3", "4", "5", "6", "7", "8"]
+
+let promotionPieces: array<pieceType> = [Queen, Rook, Bishop, Knight]
+
+let pieceValue = (pieceType: pieceType): int =>
+  switch pieceType {
+  | Pawn => 100
+  | Knight => 320
+  | Bishop => 330
+  | Rook => 500
+  | Queen => 900
+  | King => 20000
+  }

--- a/implementations-wip/rescript/src/Utils.res
+++ b/implementations-wip/rescript/src/Utils.res
@@ -1,0 +1,72 @@
+open Types
+
+let oppositeColor = (color: color): color =>
+  switch color {
+  | White => Black
+  | Black => White
+  }
+
+let modInt = (value: int, modulus: int): int => value - (value / modulus) * modulus
+let absInt = (value: int): int => if value < 0 { -value } else { value }
+
+let parseSquare = (squareStr: string): option<square> => {
+  if Js.String.length(squareStr) != 2 {
+    None
+  } else {
+    let fileChar = Js.String.charAt(0, squareStr)
+    let rankChar = Js.String.charAt(1, squareStr)
+
+    switch (Belt.Array.getIndexBy(files, f => f == fileChar), Belt.Array.getIndexBy(ranks, r => r == rankChar)) {
+    | (Some(fileIndex), Some(rankIndex)) => Some(rankIndex * 8 + fileIndex)
+    | _ => None
+    }
+  }
+}
+
+let squareToString = (square: square): string => {
+  let fileIndex = modInt(square, 8)
+  let rankIndex = square / 8
+
+  switch (Belt.Array.get(files, fileIndex), Belt.Array.get(ranks, rankIndex)) {
+  | (Some(fileChar), Some(rankChar)) => fileChar ++ rankChar
+  | _ => "??"
+  }
+}
+
+let pieceTypeToChar = (pieceType: pieceType): string =>
+  switch pieceType {
+  | Pawn => "P"
+  | Knight => "N"
+  | Bishop => "B"
+  | Rook => "R"
+  | Queen => "Q"
+  | King => "K"
+  }
+
+let pieceToChar = (piece: piece): string => {
+  let base = pieceTypeToChar(piece.pieceType)
+  switch piece.color {
+  | White => base
+  | Black => Js.String.toLowerCase(base)
+  }
+}
+
+let charToPiece = (char: string): option<piece> => {
+  if char == "" {
+    None
+  } else {
+    let upper = Js.String.toUpperCase(char)
+    let isWhite = char == upper
+    let color = if isWhite { White } else { Black }
+
+    switch upper {
+    | "P" => Some({pieceType: Pawn, color})
+    | "N" => Some({pieceType: Knight, color})
+    | "B" => Some({pieceType: Bishop, color})
+    | "R" => Some({pieceType: Rook, color})
+    | "Q" => Some({pieceType: Queen, color})
+    | "K" => Some({pieceType: King, color})
+    | _ => None
+    }
+  }
+}


### PR DESCRIPTION
## Summary\n- port missing ReScript chess engine modules (Types/Board/MoveGenerator/AI/Evaluation/Perft/Utils)\n- fix Node bindings and FEN parsing glue\n- align build/run/test paths to ReScript es6 output and update metadata\n\n## Testing\n- make build (implementations-wip/rescript)\n- make test (implementations-wip/rescript)