### PR TITLE
fix(ci): avoid mojo benchmark timeout flake

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -112,8 +112,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Resolve benchmark timeout
+        id: benchmark-timeout
+        run: |
+          timeout_seconds=300
+          if [ "${{ matrix.engine }}" = "mojo" ]; then
+            timeout_seconds=600
+          fi
+          echo "seconds=${timeout_seconds}" >> "$GITHUB_OUTPUT"
+          echo "Using timeout ${timeout_seconds}s for ${{ matrix.engine }}"
+
       - name: Run benchmark for ${{ matrix.name }}
-        run: ./workflow run-benchmark ${{ matrix.engine }} --timeout 300
+        run: ./workflow run-benchmark ${{ matrix.engine }} --timeout ${{ steps.benchmark-timeout.outputs.seconds }}
 
       - name: Upload benchmark results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- make benchmark timeout configurable per implementation in CI
- keep default timeout at 300s
- use 600s for `mojo` to avoid flaky timeout failures observed on `main`

## Why
`Benchmark Suite & Release` failed on `main` (run 22598040786, job 65473055917) because `mojo` timed out at 300s.

## Validation
- local: `./workflow run-benchmark mojo --timeout 600`
- CI branch run: 22598704288 (success)

Closes #97
