### PR TITLE
Feat/000 core5 wave1 tt time management

### DIFF
--- a/.github/workflows/scripts/workflow.py
+++ b/.github/workflows/scripts/workflow.py
@@ -345,7 +345,7 @@ class WorkflowTool:
             print(f"❌ Implementation directory not found: {impl_dir}")
             return False
 
-        image = docker_image or f"chess-{impl_name}-test"
+        image = docker_image or f"chess-{impl_name}"
         cmd = [
             "python3",
             "test/test_harness.py",
@@ -994,13 +994,13 @@ def main():
     # test-chess-engine command
     test_engine_parser = subparsers.add_parser('test-chess-engine', help='Run shared chess-engine harness')
     test_engine_parser.add_argument('impl_name', help='Implementation name')
-    test_engine_parser.add_argument('--track', default='v1', help='Track name (v1, v2-foundation, v2-functional, v2-system, v2-full)')
-    test_engine_parser.add_argument('--docker-image', help='Docker image name (default: chess-<impl>-test)')
+    test_engine_parser.add_argument('--track', default='v1', help='Track name (v1, v2-foundation, v2-functional, v2-system, v2-full, v3-book)')
+    test_engine_parser.add_argument('--docker-image', help='Docker image name (default: chess-<impl>)')
 
     # benchmark-stress command
     stress_parser = subparsers.add_parser('benchmark-stress', help='Run stress benchmark suite')
     stress_parser.add_argument('impl_name', help='Implementation name')
-    stress_parser.add_argument('--track', default='v1', help='Track name (v1, v2-foundation, v2-functional, v2-system, v2-full)')
+    stress_parser.add_argument('--track', default='v1', help='Track name (v1, v2-foundation, v2-functional, v2-system, v2-full, v3-book)')
     stress_parser.add_argument('--profile', default='quick', choices=['quick', 'full'], help='Benchmark profile')
     stress_parser.add_argument('--timeout', type=int, default=300, help='Timeout in seconds')
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -121,11 +121,11 @@ jobs:
 
       - name: V2 Foundation (Core Blocking)
         if: steps.v2-core.outputs.enabled == 'true'
-        run: ./workflow test-chess-engine ${{ matrix.engine }} --track v2-foundation --docker-image chess-${{ matrix.engine }}-test
+        run: ./workflow test-chess-engine ${{ matrix.engine }} --track v2-foundation --docker-image chess-${{ matrix.engine }}
 
       - name: V2 Functional (Core Blocking)
         if: steps.v2-core.outputs.enabled == 'true'
-        run: ./workflow test-chess-engine ${{ matrix.engine }} --track v2-functional --docker-image chess-${{ matrix.engine }}-test
+        run: ./workflow test-chess-engine ${{ matrix.engine }} --track v2-functional --docker-image chess-${{ matrix.engine }}
 
       - name: Ensure workspace clean for ${{ matrix.engine }}
         run: |

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ help:
 	@echo "  make build [DIR=<impl>]             - Run compilation command(s) only"
 	@echo "  make analyze [DIR=<impl>]           - Run static analysis/lint command(s) only"
 	@echo "  make test [DIR=<impl>]              - Run internal implementation test command(s) only"
-	@echo "  make test-chess-engine [DIR=<impl>] [TRACK=v1|v2-foundation|v2-functional|v2-system|v2-full]"
+	@echo "  make test-chess-engine [DIR=<impl>] [TRACK=v1|v2-foundation|v2-functional|v2-system|v2-full|v3-book]"
 	@echo "                                     - Run shared chess engine suite only"
 	@echo "  make benchmark-stress [DIR=<impl>] [TRACK=...] [PROFILE=quick|full] [TIMEOUT=<s>]"
 	@echo "                                     - Run performance benchmark suite with normalized metrics"

--- a/implementations/dart/Dockerfile
+++ b/implementations/dart/Dockerfile
@@ -11,6 +11,7 @@ LABEL org.chess.author="Dart Implementation"
 LABEL org.chess.features="perft,fen,ai,castling,en_passant,promotion"
 LABEL org.chess.max_ai_depth=5
 LABEL org.chess.estimated_perft4_ms=900
+LABEL org.chess.benchmark.build="skip"
 LABEL org.chess.build="printf 'quit\n' | dart --packages=package_config.json bin/main.dart"
 LABEL org.chess.test="printf 'new\nmove e2e4\nmove e7e5\nexport\nquit\n' | dart --packages=package_config.json bin/main.dart"
 LABEL org.chess.analyze="dart format --output=none bin lib"

--- a/implementations/dart/bin/main.dart
+++ b/implementations/dart/bin/main.dart
@@ -5,9 +5,19 @@ import 'package:chess_engine/chess_engine.dart';
 
 void main() {
   final game = Game();
-  final ai = AI();
+  var ai = AI();
   String? pgnPath;
   List<String> pgnMoves = [];
+  String? bookPath;
+  bool bookEnabled = false;
+  Map<String, List<BookEntry>> bookEntries = {};
+  int bookEntryCount = 0;
+  int bookLookups = 0;
+  int bookHits = 0;
+  int bookMisses = 0;
+  int bookPlayed = 0;
+  var uciHashMb = 16;
+  var uciThreads = 1;
   int chess960Id = 0;
   bool traceEnabled = false;
   String traceLevel = 'info';
@@ -24,6 +34,93 @@ void main() {
     if (traceEvents.length > 256) {
       traceEvents.removeRange(0, traceEvents.length - 256);
     }
+  }
+
+  String? chooseBookMove() {
+    bookLookups++;
+    if (!bookEnabled || bookEntries.isEmpty) {
+      bookMisses++;
+      return null;
+    }
+
+    final key = _bookPositionKeyFromFen(game.board.toFen());
+    final entries = bookEntries[key];
+    if (entries == null || entries.isEmpty) {
+      bookMisses++;
+      return null;
+    }
+
+    final legalByNotation = <String, Move>{};
+    for (final legalMove in game.board.generateMoves()) {
+      legalByNotation[legalMove.toString().toLowerCase()] = legalMove;
+    }
+
+    final weighted = <({Move move, int weight})>[];
+    var totalWeight = 0;
+    for (final entry in entries) {
+      final legal = legalByNotation[entry.move];
+      if (legal == null) continue;
+      final weight = entry.weight > 0 ? entry.weight : 1;
+      weighted.add((move: legal, weight: weight));
+      totalWeight += weight;
+    }
+
+    if (weighted.isEmpty || totalWeight <= 0) {
+      bookMisses++;
+      return null;
+    }
+
+    final selector =
+        ((game.board.zobristHash.toUnsigned(64).toInt()) + bookLookups) %
+        totalWeight;
+    var acc = 0;
+    Move chosen = weighted.first.move;
+    for (final item in weighted) {
+      acc += item.weight;
+      if (selector < acc) {
+        chosen = item.move;
+        break;
+      }
+    }
+
+    bookHits++;
+    return chosen.toString().toLowerCase();
+  }
+
+  ({String move, EndgameInfo info})? chooseEndgameMove() {
+    final rootInfo = _detectEndgame(game.board);
+    if (rootInfo == null) {
+      return null;
+    }
+
+    final legalMoves = game.board.generateMoves();
+    if (legalMoves.isEmpty) {
+      return null;
+    }
+
+    final rootIsWhite = game.board.turn == 'w';
+    var bestMove = legalMoves.first;
+    var bestNotation = bestMove.toString().toLowerCase();
+    var bestScore = -1 << 30;
+
+    for (final candidate in legalMoves) {
+      final clone = game.board.clone();
+      clone.move(candidate.toString());
+      final nextInfo = _detectEndgame(clone);
+      var score = nextInfo?.scoreWhite ?? ai.evaluate(clone);
+      if (!rootIsWhite) {
+        score = -score;
+      }
+      final notation = candidate.toString().toLowerCase();
+      if (score > bestScore ||
+          (score == bestScore && notation.compareTo(bestNotation) < 0)) {
+        bestScore = score;
+        bestMove = candidate;
+        bestNotation = notation;
+      }
+    }
+
+    return (move: bestMove.toString().toLowerCase(), info: rootInfo);
   }
 
   while (true) {
@@ -58,6 +155,7 @@ void main() {
         break;
       case 'new':
         game.init();
+        ai = AI();
         print('OK: New game started');
         game.printBoard();
         break;
@@ -71,7 +169,16 @@ void main() {
           print('ERROR: AI depth must be 1-5');
           break;
         }
-        _runAiMove(game, ai, depth);
+        final endgameChoice = chooseEndgameMove();
+        _runAiMove(
+          game,
+          ai,
+          depth,
+          bookMove: chooseBookMove(),
+          onBookPlayed: () => bookPlayed++,
+          endgameMove: endgameChoice?.move,
+          endgameInfo: endgameChoice?.info,
+        );
         break;
       case 'fen':
         if (parts.length < 2) {
@@ -132,6 +239,45 @@ void main() {
           break;
         }
         final sub = parts[1].toLowerCase();
+        if (sub == 'depth') {
+          if (parts.length < 3) {
+            print('ERROR: go depth requires a value');
+            break;
+          }
+          final depth = int.tryParse(parts[2]);
+          if (depth == null) {
+            print('ERROR: go depth requires an integer value');
+            break;
+          }
+          var boundedDepth = depth;
+          if (boundedDepth < 1) boundedDepth = 1;
+          if (boundedDepth > 5) boundedDepth = 5;
+          final bookMove = chooseBookMove();
+          if (bookMove != null) {
+            print('info string bookmove $bookMove');
+            print('bestmove $bookMove');
+            break;
+          }
+          final endgameChoice = chooseEndgameMove();
+          if (endgameChoice != null) {
+            print(
+              'info string endgame ${endgameChoice.info.type} score cp ${endgameChoice.info.scoreWhite}',
+            );
+            print('bestmove ${endgameChoice.move}');
+            break;
+          }
+          final result = ai.search(game.board, boundedDepth, movetimeMs: 0);
+          final move = result.move;
+          if (move == null) {
+            print('bestmove 0000');
+            break;
+          }
+          print(
+            'info depth ${result.depth} score cp ${result.score} time ${result.elapsedMs} nodes 0',
+          );
+          print('bestmove ${move.toString()}');
+          break;
+        }
         if (sub == 'movetime') {
           if (parts.length < 3) {
             print('ERROR: go movetime requires a value in milliseconds');
@@ -146,7 +292,17 @@ void main() {
             print('ERROR: go movetime must be > 0');
             break;
           }
-          _runAiTimedMove(game, ai, 5, movetime);
+          final endgameChoice = chooseEndgameMove();
+          _runAiTimedMove(
+            game,
+            ai,
+            5,
+            movetime,
+            bookMove: chooseBookMove(),
+            onBookPlayed: () => bookPlayed++,
+            endgameMove: endgameChoice?.move,
+            endgameInfo: endgameChoice?.info,
+          );
           break;
         }
         if (sub == 'wtime') {
@@ -158,12 +314,32 @@ void main() {
             print('ERROR: ${parsed.$2}');
             break;
           }
-          _runAiTimedMove(game, ai, 5, parsed.$1);
+          final endgameChoice = chooseEndgameMove();
+          _runAiTimedMove(
+            game,
+            ai,
+            5,
+            parsed.$1,
+            bookMove: chooseBookMove(),
+            onBookPlayed: () => bookPlayed++,
+            endgameMove: endgameChoice?.move,
+            endgameInfo: endgameChoice?.info,
+          );
           break;
         }
         if (sub == 'infinite') {
           print('OK: go infinite acknowledged (bounded search mode)');
-          _runAiTimedMove(game, ai, 5, 15000);
+          final endgameChoice = chooseEndgameMove();
+          _runAiTimedMove(
+            game,
+            ai,
+            5,
+            15000,
+            bookMove: chooseBookMove(),
+            onBookPlayed: () => bookPlayed++,
+            endgameMove: endgameChoice?.move,
+            endgameInfo: endgameChoice?.info,
+          );
           break;
         }
         print('ERROR: Unsupported go command');
@@ -210,11 +386,163 @@ void main() {
         }
         print('ERROR: Unsupported pgn command');
         break;
+      case 'book':
+        if (parts.length < 2) {
+          print('ERROR: book requires subcommand (load|on|off|stats)');
+          break;
+        }
+        final sub = parts[1].toLowerCase();
+        if (sub == 'load') {
+          if (parts.length < 3) {
+            print('ERROR: book load requires a file path');
+            break;
+          }
+          final path = parts.sublist(2).join(' ');
+          try {
+            final content = File(path).readAsStringSync();
+            final parsed = _parseBookEntries(content);
+            bookPath = path;
+            bookEntries = parsed.$1;
+            bookEntryCount = parsed.$2;
+            bookEnabled = true;
+            bookLookups = 0;
+            bookHits = 0;
+            bookMisses = 0;
+            bookPlayed = 0;
+            print(
+              'BOOK: loaded path="$path"; positions=${bookEntries.length}; entries=$bookEntryCount; enabled=true',
+            );
+          } catch (e) {
+            print('ERROR: book load failed: $e');
+          }
+          break;
+        }
+        if (sub == 'on') {
+          bookEnabled = true;
+          print('BOOK: enabled=true');
+          break;
+        }
+        if (sub == 'off') {
+          bookEnabled = false;
+          print('BOOK: enabled=false');
+          break;
+        }
+        if (sub == 'stats') {
+          final path = bookPath ?? '(none)';
+          final enabled = bookEnabled ? 'true' : 'false';
+          print(
+            'BOOK: enabled=$enabled; path=$path; positions=${bookEntries.length}; entries=$bookEntryCount; lookups=$bookLookups; hits=$bookHits; misses=$bookMisses; played=$bookPlayed',
+          );
+          break;
+        }
+        print('ERROR: Unsupported book command');
+        break;
+      case 'endgame':
+        final info = _detectEndgame(game.board);
+        if (info == null) {
+          final active = game.board.turn == 'w' ? 'white' : 'black';
+          print('ENDGAME: type=none; active=$active; score=0');
+          break;
+        }
+        final choice = chooseEndgameMove();
+        var output =
+            'ENDGAME: type=${info.type}; strong=${info.strong}; weak=${info.weak}; score=${info.scoreWhite}';
+        if (choice != null) {
+          output += '; bestmove=${choice.move}';
+        }
+        output += '; detail=${info.detail}';
+        print(output);
+        break;
       case 'uci':
         print('uciok');
         break;
       case 'isready':
         print('readyok');
+        break;
+      case 'setoption':
+        if (parts.length < 5 || parts[1].toLowerCase() != 'name') {
+          print(
+            "ERROR: setoption format is 'setoption name <Hash|Threads> value <n>'",
+          );
+          break;
+        }
+        int valueIdx = -1;
+        for (int i = 2; i < parts.length; i++) {
+          if (parts[i].toLowerCase() == 'value') {
+            valueIdx = i;
+            break;
+          }
+        }
+        if (valueIdx <= 2 || valueIdx + 1 >= parts.length) {
+          print("ERROR: setoption requires 'value <n>'");
+          break;
+        }
+        final optionName = parts.sublist(2, valueIdx).join(' ').toLowerCase();
+        final value = int.tryParse(parts[valueIdx + 1]);
+        if (value == null) {
+          print('ERROR: setoption value must be an integer');
+          break;
+        }
+        if (optionName == 'hash') {
+          uciHashMb = value.clamp(1, 1024).toInt();
+          print('info string option Hash=$uciHashMb');
+          break;
+        }
+        if (optionName == 'threads') {
+          uciThreads = value.clamp(1, 64).toInt();
+          print('info string option Threads=$uciThreads');
+          break;
+        }
+        print(
+          'info string unsupported option ${parts.sublist(2, valueIdx).join(' ')}',
+        );
+        break;
+      case 'ucinewgame':
+        game.init();
+        ai = AI();
+        break;
+      case 'position':
+        if (parts.length < 2) {
+          print("ERROR: position requires 'startpos' or 'fen <...>'");
+          break;
+        }
+        var idx = 2;
+        final keyword = parts[1].toLowerCase();
+        if (keyword == 'startpos') {
+          game.init();
+          ai = AI();
+        } else if (keyword == 'fen') {
+          final fenTokens = <String>[];
+          while (idx < parts.length && parts[idx].toLowerCase() != 'moves') {
+            fenTokens.add(parts[idx]);
+            idx++;
+          }
+          if (fenTokens.isEmpty) {
+            print('ERROR: position fen requires a FEN string');
+            break;
+          }
+          try {
+            game.loadFen(fenTokens.join(' '));
+          } catch (e) {
+            print('ERROR: Invalid FEN string: $e');
+            break;
+          }
+        } else {
+          print("ERROR: position requires 'startpos' or 'fen <...>'");
+          break;
+        }
+
+        if (idx < parts.length && parts[idx].toLowerCase() == 'moves') {
+          idx++;
+          for (int i = idx; i < parts.length; i++) {
+            try {
+              _applyMoveSilently(game, parts[i]);
+            } catch (e) {
+              print('ERROR: position move ${parts[i]} failed: $e');
+              break;
+            }
+          }
+        }
         break;
       case 'new960':
         var id = 0;
@@ -341,11 +669,17 @@ draws
 history
 go movetime <ms>
 go wtime <ms> btime <ms> winc <ms> binc <ms> [movestogo <n>]
+go depth <n>
 go infinite
 stop
 pgn load|show|moves
+book load|on|off|stats
+endgame
 uci
 isready
+setoption name <Hash|Threads> value <n>
+ucinewgame
+position startpos|fen ... [moves ...]
 new960 [id]
 position960
 trace on|off|level|report|reset|export|chrome
@@ -360,6 +694,305 @@ quit''');
         print('ERROR: Invalid command');
     }
   }
+}
+
+class BookEntry {
+  final String move;
+  final int weight;
+
+  const BookEntry(this.move, this.weight);
+}
+
+String _bookPositionKeyFromFen(String fen) {
+  final parts = fen.trim().split(RegExp(r'\s+'));
+  if (parts.length >= 4) {
+    return parts.sublist(0, 4).join(' ');
+  }
+  return fen.trim();
+}
+
+(Map<String, List<BookEntry>>, int) _parseBookEntries(String content) {
+  final entries = <String, List<BookEntry>>{};
+  var totalEntries = 0;
+  final movePattern = RegExp(r'^[a-h][1-8][a-h][1-8][qrbn]?$');
+
+  final lines = content.split(RegExp(r'\r?\n'));
+  for (var i = 0; i < lines.length; i++) {
+    final lineNo = i + 1;
+    final line = lines[i].trim();
+    if (line.isEmpty || line.startsWith('#')) {
+      continue;
+    }
+
+    final arrowIdx = line.indexOf('->');
+    if (arrowIdx < 0) {
+      throw FormatException(
+        "line $lineNo: expected '<fen> -> <move> [weight]'",
+      );
+    }
+
+    final key = _bookPositionKeyFromFen(line.substring(0, arrowIdx));
+    if (key.isEmpty) {
+      throw FormatException('line $lineNo: empty position key');
+    }
+
+    final rhsParts = line
+        .substring(arrowIdx + 2)
+        .trim()
+        .split(RegExp(r'\s+'))
+        .where((token) => token.isNotEmpty)
+        .toList();
+    if (rhsParts.isEmpty) {
+      throw FormatException('line $lineNo: missing move');
+    }
+
+    final move = rhsParts.first.toLowerCase();
+    if (!movePattern.hasMatch(move)) {
+      throw FormatException('line $lineNo: invalid move "$move"');
+    }
+
+    var weight = 1;
+    if (rhsParts.length > 1) {
+      weight =
+          int.tryParse(rhsParts[1]) ??
+          (throw FormatException(
+            'line $lineNo: invalid weight "${rhsParts[1]}"',
+          ));
+      if (weight <= 0) {
+        throw FormatException('line $lineNo: weight must be > 0');
+      }
+    }
+
+    entries.putIfAbsent(key, () => <BookEntry>[]).add(BookEntry(move, weight));
+    totalEntries++;
+  }
+
+  return (entries, totalEntries);
+}
+
+class EndgameInfo {
+  final String type;
+  final String strong;
+  final String weak;
+  final int scoreWhite;
+  final String detail;
+
+  const EndgameInfo({
+    required this.type,
+    required this.strong,
+    required this.weak,
+    required this.scoreWhite,
+    required this.detail,
+  });
+}
+
+int _manhattan((int, int) a, (int, int) b) {
+  return (a.$1 - b.$1).abs() + (a.$2 - b.$2).abs();
+}
+
+int _nonKingMaterial(
+  Map<PieceColor, Map<PieceType, int>> counts,
+  PieceColor color,
+) {
+  return (counts[color]![PieceType.pawn] ?? 0) +
+      (counts[color]![PieceType.knight] ?? 0) +
+      (counts[color]![PieceType.bishop] ?? 0) +
+      (counts[color]![PieceType.rook] ?? 0) +
+      (counts[color]![PieceType.queen] ?? 0);
+}
+
+String _squareToAlgebraic((int, int) square) {
+  return '${String.fromCharCode('a'.codeUnitAt(0) + square.$2)}${8 - square.$1}';
+}
+
+EndgameInfo? _detectEndgame(Board board) {
+  final counts = <PieceColor, Map<PieceType, int>>{
+    PieceColor.white: {for (final type in PieceType.values) type: 0},
+    PieceColor.black: {for (final type in PieceType.values) type: 0},
+  };
+  final kings = <PieceColor, (int, int)>{};
+  final pawns = <PieceColor, (int, int)>{};
+  final rooks = <PieceColor, (int, int)>{};
+  final queens = <PieceColor, (int, int)>{};
+
+  for (var row = 0; row < 8; row++) {
+    for (var col = 0; col < 8; col++) {
+      final piece = board.squares[row][col];
+      if (piece == null) continue;
+      counts[piece.color]![piece.type] =
+          (counts[piece.color]![piece.type] ?? 0) + 1;
+      if (piece.type == PieceType.king) {
+        kings[piece.color] = (row, col);
+      } else if (piece.type == PieceType.pawn &&
+          !pawns.containsKey(piece.color)) {
+        pawns[piece.color] = (row, col);
+      } else if (piece.type == PieceType.rook &&
+          !rooks.containsKey(piece.color)) {
+        rooks[piece.color] = (row, col);
+      } else if (piece.type == PieceType.queen &&
+          !queens.containsKey(piece.color)) {
+        queens[piece.color] = (row, col);
+      }
+    }
+  }
+
+  if (!kings.containsKey(PieceColor.white) ||
+      !kings.containsKey(PieceColor.black)) {
+    return null;
+  }
+
+  final whiteMaterial = _nonKingMaterial(counts, PieceColor.white);
+  final blackMaterial = _nonKingMaterial(counts, PieceColor.black);
+
+  // KQK
+  if ((counts[PieceColor.white]![PieceType.queen] ?? 0) == 1 &&
+      whiteMaterial == 1 &&
+      blackMaterial == 0) {
+    final weakKing = kings[PieceColor.black]!;
+    final strongKing = kings[PieceColor.white]!;
+    final edge = min(
+      min(weakKing.$1, 7 - weakKing.$1),
+      min(weakKing.$2, 7 - weakKing.$2),
+    );
+    final kingDistance = _manhattan(strongKing, weakKing);
+    final score = 900 + (14 - kingDistance) * 6 + (3 - edge) * 20;
+    return EndgameInfo(
+      type: 'KQK',
+      strong: 'white',
+      weak: 'black',
+      scoreWhite: score,
+      detail: 'queen=${_squareToAlgebraic(queens[PieceColor.white]!)}',
+    );
+  }
+  if ((counts[PieceColor.black]![PieceType.queen] ?? 0) == 1 &&
+      blackMaterial == 1 &&
+      whiteMaterial == 0) {
+    final weakKing = kings[PieceColor.white]!;
+    final strongKing = kings[PieceColor.black]!;
+    final edge = min(
+      min(weakKing.$1, 7 - weakKing.$1),
+      min(weakKing.$2, 7 - weakKing.$2),
+    );
+    final kingDistance = _manhattan(strongKing, weakKing);
+    final score = 900 + (14 - kingDistance) * 6 + (3 - edge) * 20;
+    return EndgameInfo(
+      type: 'KQK',
+      strong: 'black',
+      weak: 'white',
+      scoreWhite: -score,
+      detail: 'queen=${_squareToAlgebraic(queens[PieceColor.black]!)}',
+    );
+  }
+
+  // KPK
+  if ((counts[PieceColor.white]![PieceType.pawn] ?? 0) == 1 &&
+      whiteMaterial == 1 &&
+      blackMaterial == 0) {
+    final pawn = pawns[PieceColor.white]!;
+    final strongKing = kings[PieceColor.white]!;
+    final weakKing = kings[PieceColor.black]!;
+    final promotion = (0, pawn.$2);
+    final pawnSteps = pawn.$1;
+    var score =
+        120 +
+        (6 - pawnSteps) * 35 +
+        _manhattan(weakKing, promotion) * 6 -
+        _manhattan(strongKing, pawn) * 8;
+    if (pawnSteps <= 1) {
+      score += 80;
+    }
+    if (score < 30) {
+      score = 30;
+    }
+    return EndgameInfo(
+      type: 'KPK',
+      strong: 'white',
+      weak: 'black',
+      scoreWhite: score,
+      detail: 'pawn=${_squareToAlgebraic(pawn)}',
+    );
+  }
+  if ((counts[PieceColor.black]![PieceType.pawn] ?? 0) == 1 &&
+      blackMaterial == 1 &&
+      whiteMaterial == 0) {
+    final pawn = pawns[PieceColor.black]!;
+    final strongKing = kings[PieceColor.black]!;
+    final weakKing = kings[PieceColor.white]!;
+    final promotion = (7, pawn.$2);
+    final pawnSteps = 7 - pawn.$1;
+    var score =
+        120 +
+        (6 - pawnSteps) * 35 +
+        _manhattan(weakKing, promotion) * 6 -
+        _manhattan(strongKing, pawn) * 8;
+    if (pawnSteps <= 1) {
+      score += 80;
+    }
+    if (score < 30) {
+      score = 30;
+    }
+    return EndgameInfo(
+      type: 'KPK',
+      strong: 'black',
+      weak: 'white',
+      scoreWhite: -score,
+      detail: 'pawn=${_squareToAlgebraic(pawn)}',
+    );
+  }
+
+  // KRKP
+  if ((counts[PieceColor.white]![PieceType.rook] ?? 0) == 1 &&
+      whiteMaterial == 1 &&
+      (counts[PieceColor.black]![PieceType.pawn] ?? 0) == 1 &&
+      blackMaterial == 1) {
+    final strongKing = kings[PieceColor.white]!;
+    final weakKing = kings[PieceColor.black]!;
+    final weakPawn = pawns[PieceColor.black]!;
+    final pawnSteps = 7 - weakPawn.$1;
+    var score =
+        380 -
+        pawnSteps * 25 +
+        (_manhattan(weakKing, weakPawn) - _manhattan(strongKing, weakPawn)) *
+            12;
+    if (score < 50) {
+      score = 50;
+    }
+    return EndgameInfo(
+      type: 'KRKP',
+      strong: 'white',
+      weak: 'black',
+      scoreWhite: score,
+      detail:
+          'rook=${_squareToAlgebraic(rooks[PieceColor.white]!)},pawn=${_squareToAlgebraic(weakPawn)}',
+    );
+  }
+  if ((counts[PieceColor.black]![PieceType.rook] ?? 0) == 1 &&
+      blackMaterial == 1 &&
+      (counts[PieceColor.white]![PieceType.pawn] ?? 0) == 1 &&
+      whiteMaterial == 1) {
+    final strongKing = kings[PieceColor.black]!;
+    final weakKing = kings[PieceColor.white]!;
+    final weakPawn = pawns[PieceColor.white]!;
+    final pawnSteps = weakPawn.$1;
+    var score =
+        380 -
+        pawnSteps * 25 +
+        (_manhattan(weakKing, weakPawn) - _manhattan(strongKing, weakPawn)) *
+            12;
+    if (score < 50) {
+      score = 50;
+    }
+    return EndgameInfo(
+      type: 'KRKP',
+      strong: 'black',
+      weak: 'white',
+      scoreWhite: -score,
+      detail:
+          'rook=${_squareToAlgebraic(rooks[PieceColor.black]!)},pawn=${_squareToAlgebraic(weakPawn)}',
+    );
+  }
+
+  return null;
 }
 
 int _depthForMovetime(int movetimeMs) {
@@ -492,11 +1125,64 @@ Map<String, dynamic> _buildConcurrencyPayload(String profile) {
   };
 }
 
-void _runAiMove(Game game, AI ai, int depth) {
-  _runAiTimedMove(game, ai, depth, 0);
+void _runAiMove(
+  Game game,
+  AI ai,
+  int depth, {
+  String? bookMove,
+  void Function()? onBookPlayed,
+  String? endgameMove,
+  EndgameInfo? endgameInfo,
+}) {
+  _runAiTimedMove(
+    game,
+    ai,
+    depth,
+    0,
+    bookMove: bookMove,
+    onBookPlayed: onBookPlayed,
+    endgameMove: endgameMove,
+    endgameInfo: endgameInfo,
+  );
 }
 
-void _runAiTimedMove(Game game, AI ai, int maxDepth, int movetimeMs) {
+void _runAiTimedMove(
+  Game game,
+  AI ai,
+  int maxDepth,
+  int movetimeMs, {
+  String? bookMove,
+  void Function()? onBookPlayed,
+  String? endgameMove,
+  EndgameInfo? endgameInfo,
+}) {
+  if (bookMove != null) {
+    try {
+      game.move(bookMove);
+      onBookPlayed?.call();
+      print('AI: $bookMove (book)');
+      game.printBoard();
+      _checkGameState(game);
+      return;
+    } catch (_) {
+      // Ignore unusable book move and fallback to search.
+    }
+  }
+
+  if (endgameMove != null && endgameInfo != null) {
+    try {
+      game.move(endgameMove);
+      print(
+        'AI: $endgameMove (endgame ${endgameInfo.type}, score=${endgameInfo.scoreWhite})',
+      );
+      game.printBoard();
+      _checkGameState(game);
+      return;
+    } catch (_) {
+      // Ignore unusable endgame move and fallback to search.
+    }
+  }
+
   final result = ai.search(game.board, maxDepth, movetimeMs: movetimeMs);
   final move = result.move;
   if (move == null) {
@@ -509,6 +1195,10 @@ void _runAiTimedMove(Game game, AI ai, int maxDepth, int movetimeMs) {
   );
   game.printBoard();
   _checkGameState(game);
+}
+
+void _applyMoveSilently(Game game, String moveStr) {
+  game.move(moveStr);
 }
 
 void _checkGameState(Game game) {

--- a/implementations/go/ai.go
+++ b/implementations/go/ai.go
@@ -13,14 +13,6 @@ const (
 	NEG_INFINITY = -999999
 )
 
-type ttFlag int
-
-const (
-	ttExact ttFlag = iota
-	ttLowerBound
-	ttUpperBound
-)
-
 var pieceValues = map[PieceType]int{
 	Pawn:   100,
 	Knight: 320,
@@ -97,163 +89,212 @@ var kingMiddlegameTable = [8][8]int{
 	{20, 30, 10, 0, 0, 10, 30, 20},
 }
 
+type AI struct {
+	nodesEvaluated int
+	tt            map[uint64]TTEntry
+	deadline      time.Time
+	timedOut      bool
+}
+
+type TTFlag int
+
+const (
+	TTExact TTFlag = iota
+	TTLowerBound
+	TTUpperBound
+)
+
 type TTEntry struct {
-	Depth       int
-	Score       int
-	Flag        ttFlag
-	BestMove    Move
-	HasBestMove bool
+	Depth    int
+	Score    int
+	Flag     TTFlag
+	BestMove Move
 }
 
 type SearchResult struct {
-	Move   Move
-	Score  int
-	Depth  int
-	Aborted bool
-}
-
-type searchContext struct {
-	deadline    time.Time
-	hasDeadline bool
-	aborted     bool
-}
-
-func (ctx *searchContext) shouldStop() bool {
-	if !ctx.hasDeadline || ctx.aborted {
-		return ctx.aborted
-	}
-
-	if !time.Now().Before(ctx.deadline) {
-		ctx.aborted = true
-	}
-
-	return ctx.aborted
-}
-
-type AI struct {
-	nodesEvaluated int
-	transposition  map[uint64]TTEntry
+	Move      Move
+	Score     int
+	Depth     int
+	TimedOut  bool
+	ElapsedMS int64
 }
 
 func NewAI() *AI {
 	return &AI{
 		nodesEvaluated: 0,
-		transposition:  make(map[uint64]TTEntry, 1<<16),
+		tt:            make(map[uint64]TTEntry, 1<<16),
 	}
 }
 
 func (ai *AI) FindBestMove(gs *GameState, depth int) Move {
-	if depth < 1 || depth > MAX_DEPTH {
-		depth = 3
-	}
-
-	result := ai.findBestMoveIterative(gs, depth, 0)
+	result := ai.Search(gs, depth, 0)
 	return result.Move
 }
 
-func (ai *AI) FindBestMoveWithDepth(gs *GameState, depth int) SearchResult {
+func (ai *AI) Search(gs *GameState, depth int, movetimeMs int) SearchResult {
+	ai.nodesEvaluated = 0
+	ai.timedOut = false
+
 	if depth < 1 || depth > MAX_DEPTH {
 		depth = 3
 	}
-	return ai.findBestMoveIterative(gs, depth, 0)
-}
 
-func (ai *AI) FindBestMoveTimed(gs *GameState, movetime time.Duration, maxDepth int) SearchResult {
-	if maxDepth < 1 || maxDepth > MAX_DEPTH {
-		maxDepth = MAX_DEPTH
+	start := time.Now()
+	if movetimeMs > 0 {
+		ai.deadline = start.Add(time.Duration(movetimeMs) * time.Millisecond)
+	} else {
+		ai.deadline = time.Time{}
 	}
-	if movetime < 0 {
-		movetime = 0
-	}
-	return ai.findBestMoveIterative(gs, maxDepth, movetime)
-}
-
-func (ai *AI) findBestMoveIterative(gs *GameState, maxDepth int, movetime time.Duration) SearchResult {
-	ai.nodesEvaluated = 0
 
 	legalMoves := gs.GenerateLegalMoves()
 	if len(legalMoves) == 0 {
-		return SearchResult{}
+		return SearchResult{
+			Move:      Move{},
+			Score:     DRAW_VALUE,
+			Depth:     0,
+			TimedOut:  false,
+			ElapsedMS: time.Since(start).Milliseconds(),
+		}
 	}
 
-	ctx := &searchContext{}
-	if movetime > 0 {
-		ctx.hasDeadline = true
-		ctx.deadline = time.Now().Add(movetime)
-	}
+	bestMove := legalMoves[0]
+	bestScore := NEG_INFINITY
+	completedDepth := 0
 
-	ttMove, hasTTMove := ai.getTTMove(gs.ZobristHash)
-	orderedFallback := ai.orderMoves(legalMoves, ttMove, hasTTMove)
-
-	result := SearchResult{
-		Move:   orderedFallback[0],
-		Score:  ai.evaluate(gs),
-		Depth:  0,
-		Aborted: false,
-	}
-
-	for depth := 1; depth <= maxDepth; depth++ {
-		if ctx.shouldStop() {
+	// Iterative deepening: keep the last fully completed depth result.
+	for currentDepth := 1; currentDepth <= depth; currentDepth++ {
+		score, move, ok := ai.searchRoot(gs, currentDepth)
+		if !ok {
 			break
 		}
-
-		score, bestMove, completed := ai.negamaxRoot(gs, depth, ctx)
-		if !completed {
-			break
-		}
-
-		result.Score = score
-		result.Move = bestMove
-		result.Depth = depth
+		bestMove = move
+		bestScore = score
+		completedDepth = currentDepth
 	}
 
-	result.Aborted = ctx.aborted
-	return result
+	if completedDepth == 0 {
+		// Fallback when timeout happens before completing depth=1.
+		bestMove = legalMoves[0]
+		bestScore = ai.evaluate(gs)
+		completedDepth = 1
+	}
+
+	return SearchResult{
+		Move:      bestMove,
+		Score:     bestScore,
+		Depth:     completedDepth,
+		TimedOut:  ai.timedOut,
+		ElapsedMS: time.Since(start).Milliseconds(),
+	}
 }
 
-func (ai *AI) negamaxRoot(gs *GameState, depth int, ctx *searchContext) (int, Move, bool) {
+func (ai *AI) searchRoot(gs *GameState, depth int) (int, Move, bool) {
+	if ai.timeExceeded() {
+		return 0, Move{}, false
+	}
+
+	moves := gs.GenerateLegalMoves()
+	if len(moves) == 0 {
+		return DRAW_VALUE, Move{}, true
+	}
+
+	ttMove := Move{}
+	if entry, ok := ai.tt[gs.ZobristHash]; ok {
+		ttMove = entry.BestMove
+	}
+	orderedMoves := ai.orderMoves(moves, ttMove)
+
+	bestScore := NEG_INFINITY
+	bestMove := orderedMoves[0]
+	alpha := NEG_INFINITY
+	beta := INFINITY
+
+	for _, move := range orderedMoves {
+		if ai.timeExceeded() {
+			return 0, Move{}, false
+		}
+		testState := gs.Clone()
+		testState.MakeMove(move)
+
+		score, _, ok := ai.negamax(testState, depth-1, -beta, -alpha)
+		if !ok {
+			return 0, Move{}, false
+		}
+		score = -score
+
+		if score > bestScore {
+			bestScore = score
+			bestMove = move
+		}
+		if score > alpha {
+			alpha = score
+		}
+	}
+
+	return bestScore, bestMove, true
+}
+
+func (ai *AI) negamax(gs *GameState, depth int, alpha int, beta int) (int, Move, bool) {
+	if ai.timeExceeded() {
+		return 0, Move{}, false
+	}
+	ai.nodesEvaluated++
+
+	originalAlpha := alpha
+	bestMove := Move{}
+
+	if entry, ok := ai.tt[gs.ZobristHash]; ok && entry.Depth >= depth {
+		switch entry.Flag {
+		case TTExact:
+			return entry.Score, entry.BestMove, true
+		case TTLowerBound:
+			if entry.Score > alpha {
+				alpha = entry.Score
+			}
+		case TTUpperBound:
+			if entry.Score < beta {
+				beta = entry.Score
+			}
+		}
+		if alpha >= beta {
+			return entry.Score, entry.BestMove, true
+		}
+		bestMove = entry.BestMove
+	}
+
+	if depth == 0 {
+		return ai.evaluate(gs), Move{}, true
+	}
+
 	moves := gs.GenerateLegalMoves()
 	if len(moves) == 0 {
 		if gs.IsInCheck(gs.ActiveColor) {
-			return -MATE_VALUE, Move{}, true
+			return -MATE_VALUE + (MAX_DEPTH - depth), Move{}, true
 		}
 		return DRAW_VALUE, Move{}, true
 	}
 
-	alpha := NEG_INFINITY
-	beta := INFINITY
-	alphaOrig := alpha
-	betaOrig := beta
-
-	ttMove, hasTTMove, cutoff, ttScore := ai.probeTT(gs.ZobristHash, depth, &alpha, &beta)
-	if cutoff {
-		ordered := ai.orderMoves(moves, ttMove, hasTTMove)
-		return ttScore, ordered[0], true
-	}
-
-	orderedMoves := ai.orderMoves(moves, ttMove, hasTTMove)
+	orderedMoves := ai.orderMoves(moves, bestMove)
 	bestScore := NEG_INFINITY
-	bestMove := orderedMoves[0]
+	bestSoFar := orderedMoves[0]
 
-	for i, move := range orderedMoves {
-		if ctx.shouldStop() {
+	for _, move := range orderedMoves {
+		if ai.timeExceeded() {
 			return 0, Move{}, false
 		}
-
 		testState := gs.Clone()
 		testState.MakeMove(move)
 
-		score, completed := ai.negamax(testState, depth-1, -beta, -alpha, 1, ctx)
-		if !completed {
+		score, _, ok := ai.negamax(testState, depth-1, -beta, -alpha)
+		if !ok {
 			return 0, Move{}, false
 		}
 		score = -score
 
-		if i == 0 || score > bestScore {
+		if score > bestScore {
 			bestScore = score
-			bestMove = move
+			bestSoFar = move
 		}
-
 		if score > alpha {
 			alpha = score
 		}
@@ -262,217 +303,150 @@ func (ai *AI) negamaxRoot(gs *GameState, depth int, ctx *searchContext) (int, Mo
 		}
 	}
 
-	ai.storeTT(gs.ZobristHash, depth, bestScore, alphaOrig, betaOrig, bestMove)
-	return bestScore, bestMove, true
+	flag := TTExact
+	if bestScore <= originalAlpha {
+		flag = TTUpperBound
+	} else if bestScore >= beta {
+		flag = TTLowerBound
+	}
+
+	ai.tt[gs.ZobristHash] = TTEntry{
+		Depth:    depth,
+		Score:    bestScore,
+		Flag:     flag,
+		BestMove: bestSoFar,
+	}
+
+	return bestScore, bestSoFar, true
 }
 
-func (ai *AI) negamax(gs *GameState, depth int, alpha, beta int, ply int, ctx *searchContext) (int, bool) {
-	if ctx.shouldStop() {
-		return 0, false
+func (ai *AI) orderMoves(moves []Move, ttMove Move) []Move {
+	type scoredMove struct {
+		move  Move
+		score int
 	}
-
-	ai.nodesEvaluated++
-
-	if depth == 0 {
-		return ai.evaluate(gs), true
-	}
-
-	moves := gs.GenerateLegalMoves()
-	if len(moves) == 0 {
-		if gs.IsInCheck(gs.ActiveColor) {
-			return -MATE_VALUE + ply, true
-		}
-		return DRAW_VALUE, true
-	}
-
-	alphaOrig := alpha
-	betaOrig := beta
-
-	ttMove, hasTTMove, cutoff, ttScore := ai.probeTT(gs.ZobristHash, depth, &alpha, &beta)
-	if cutoff {
-		return ttScore, true
-	}
-
-	orderedMoves := ai.orderMoves(moves, ttMove, hasTTMove)
-	bestScore := NEG_INFINITY
-	bestMove := orderedMoves[0]
-
-	for i, move := range orderedMoves {
-		if ctx.shouldStop() {
-			return 0, false
-		}
-
-		testState := gs.Clone()
-		testState.MakeMove(move)
-
-		score, completed := ai.negamax(testState, depth-1, -beta, -alpha, ply+1, ctx)
-		if !completed {
-			return 0, false
-		}
-		score = -score
-
-		if i == 0 || score > bestScore {
-			bestScore = score
-			bestMove = move
-		}
-
-		if score > alpha {
-			alpha = score
-		}
-		if alpha >= beta {
-			break
-		}
-	}
-
-	ai.storeTT(gs.ZobristHash, depth, bestScore, alphaOrig, betaOrig, bestMove)
-	return bestScore, true
-}
-
-func (ai *AI) probeTT(hash uint64, depth int, alpha, beta *int) (Move, bool, bool, int) {
-	entry, ok := ai.transposition[hash]
-	if !ok {
-		return Move{}, false, false, 0
-	}
-
-	if entry.Depth < depth {
-		return entry.BestMove, entry.HasBestMove, false, 0
-	}
-
-	switch entry.Flag {
-	case ttExact:
-		return entry.BestMove, entry.HasBestMove, true, entry.Score
-	case ttLowerBound:
-		if entry.Score > *alpha {
-			*alpha = entry.Score
-		}
-	case ttUpperBound:
-		if entry.Score < *beta {
-			*beta = entry.Score
-		}
-	}
-
-	if *alpha >= *beta {
-		return entry.BestMove, entry.HasBestMove, true, entry.Score
-	}
-
-	return entry.BestMove, entry.HasBestMove, false, 0
-}
-
-func (ai *AI) storeTT(hash uint64, depth int, score int, alphaOrig int, betaOrig int, bestMove Move) {
-	flag := ttExact
-	if score <= alphaOrig {
-		flag = ttUpperBound
-	} else if score >= betaOrig {
-		flag = ttLowerBound
-	}
-
-	if existing, ok := ai.transposition[hash]; ok && existing.Depth > depth {
-		return
-	}
-
-	if len(ai.transposition) >= 1<<20 {
-		ai.transposition = make(map[uint64]TTEntry, 1<<16)
-	}
-
-	ai.transposition[hash] = TTEntry{
-		Depth:       depth,
-		Score:       score,
-		Flag:        flag,
-		BestMove:    bestMove,
-		HasBestMove: true,
-	}
-}
-
-func (ai *AI) getTTMove(hash uint64) (Move, bool) {
-	entry, ok := ai.transposition[hash]
-	if !ok || !entry.HasBestMove {
-		return Move{}, false
-	}
-	return entry.BestMove, true
-}
-
-type scoredMove struct {
-	move     Move
-	score    int
-	notation string
-}
-
-func (ai *AI) orderMoves(moves []Move, ttMove Move, hasTTMove bool) []Move {
 	scored := make([]scoredMove, 0, len(moves))
 	for _, move := range moves {
-		score := ai.moveOrderScore(move)
-		if hasTTMove && movesEqual(move, ttMove) {
-			score += 1_000_000
+		score := 0
+		if sameMove(move, ttMove) {
+			score += 100000
 		}
-		scored = append(scored, scoredMove{
-			move:     move,
-			score:    score,
-			notation: moveToNotation(move),
-		})
+		if move.IsCapture {
+			score += 10000
+			if move.Captured != nil {
+				score += pieceValues[move.Captured.Type]
+			}
+		}
+		if move.IsPromotion {
+			score += 9000
+			score += pieceValues[move.PromoteTo]
+		}
+		if move.IsCastle {
+			score += 100
+		}
+		scored = append(scored, scoredMove{move: move, score: score})
 	}
 
-	sort.SliceStable(scored, func(i, j int) bool {
-		if scored[i].score != scored[j].score {
-			return scored[i].score > scored[j].score
-		}
-		return scored[i].notation < scored[j].notation
+	sort.Slice(scored, func(i, j int) bool {
+		return scored[i].score > scored[j].score
 	})
 
-	ordered := make([]Move, len(scored))
-	for i := range scored {
-		ordered[i] = scored[i].move
+	ordered := make([]Move, 0, len(scored))
+	for _, s := range scored {
+		ordered = append(ordered, s.move)
 	}
 	return ordered
 }
 
-func (ai *AI) moveOrderScore(move Move) int {
-	score := 0
-
-	if move.IsCapture {
-		victimValue := 0
-		if move.Captured != nil {
-			victimValue = pieceValues[move.Captured.Type]
-		}
-		attackerValue := pieceValues[move.Piece.Type]
-		score += victimValue*10 - attackerValue
-	}
-
-	if move.IsPromotion {
-		score += pieceValues[move.PromoteTo] * 10
-	}
-
-	if move.IsCastle {
-		score += 25
-	}
-
-	return score
+func sameMove(a Move, b Move) bool {
+	return a.From == b.From &&
+		a.To == b.To &&
+		a.IsPromotion == b.IsPromotion &&
+		(!a.IsPromotion || a.PromoteTo == b.PromoteTo)
 }
 
-func moveToNotation(move Move) string {
-	notation := move.From.ToAlgebraic() + move.To.ToAlgebraic()
-	if move.IsPromotion {
-		switch move.PromoteTo {
-		case Queen:
-			notation += "q"
-		case Rook:
-			notation += "r"
-		case Bishop:
-			notation += "b"
-		case Knight:
-			notation += "n"
-		}
-	}
-	return notation
-}
-
-func movesEqual(a, b Move) bool {
-	if a.From != b.From || a.To != b.To || a.IsPromotion != b.IsPromotion {
+func (ai *AI) timeExceeded() bool {
+	if ai.deadline.IsZero() {
 		return false
 	}
-	if a.IsPromotion {
-		return a.PromoteTo == b.PromoteTo
+	if time.Now().After(ai.deadline) {
+		ai.timedOut = true
+		return true
 	}
-	return true
+	return false
+}
+
+func (ai *AI) minimax(gs *GameState, depth int, alpha, beta int, maximizingPlayer bool) (int, Move) {
+	ai.nodesEvaluated++
+
+	if depth == 0 {
+		return ai.evaluate(gs), Move{}
+	}
+
+	moves := gs.GenerateLegalMoves()
+
+	// Check for terminal positions
+	if len(moves) == 0 {
+		if gs.IsInCheck(gs.ActiveColor) {
+			// Checkmate
+			if maximizingPlayer {
+				return -MATE_VALUE + (MAX_DEPTH - depth), Move{}
+			} else {
+				return MATE_VALUE - (MAX_DEPTH - depth), Move{}
+			}
+		} else {
+			// Stalemate
+			return DRAW_VALUE, Move{}
+		}
+	}
+
+	var bestMove Move
+
+	if maximizingPlayer {
+		maxEval := NEG_INFINITY
+
+		for _, move := range moves {
+			// Make move
+			testState := gs.Clone()
+			testState.MakeMove(move)
+
+			eval, _ := ai.minimax(testState, depth-1, alpha, beta, false)
+
+			if eval > maxEval {
+				maxEval = eval
+				bestMove = move
+			}
+
+			alpha = max(alpha, eval)
+			if beta <= alpha {
+				break // Alpha-beta pruning
+			}
+		}
+
+		return maxEval, bestMove
+	} else {
+		minEval := INFINITY
+
+		for _, move := range moves {
+			// Make move
+			testState := gs.Clone()
+			testState.MakeMove(move)
+
+			eval, _ := ai.minimax(testState, depth-1, alpha, beta, true)
+
+			if eval < minEval {
+				minEval = eval
+				bestMove = move
+			}
+
+			beta = min(beta, eval)
+			if beta <= alpha {
+				break // Alpha-beta pruning
+			}
+		}
+
+		return minEval, bestMove
+	}
 }
 
 func (ai *AI) evaluate(gs *GameState) int {

--- a/implementations/go/chess.go
+++ b/implementations/go/chess.go
@@ -21,6 +21,16 @@ type ChessEngine struct {
 	ai                *AI
 	pgnPath           string
 	pgnMoves          []string
+	bookPath          string
+	bookEnabled       bool
+	bookEntries       map[string][]BookEntry
+	bookEntryCount    int
+	bookLookups       int
+	bookHits          int
+	bookMisses        int
+	bookPlayed        int
+	uciHashMB         int
+	uciThreads        int
 	chess960ID        int
 	traceEnabled      bool
 	traceLevel        string
@@ -34,12 +44,30 @@ type TraceEvent struct {
 	Detail string `json:"detail"`
 }
 
+type BookEntry struct {
+	Move   string
+	Weight int
+}
+
+type EndgameInfo struct {
+	Kind       string
+	Strong     Color
+	Weak       Color
+	WhiteScore int
+	Detail     string
+}
+
 func NewChessEngine() *ChessEngine {
 	return &ChessEngine{
 		gameState:    NewGameState(),
 		ai:           NewAI(),
 		pgnPath:      "",
 		pgnMoves:     make([]string, 0),
+		bookPath:     "",
+		bookEnabled:  false,
+		bookEntries:  make(map[string][]BookEntry),
+		uciHashMB:    16,
+		uciThreads:   1,
 		traceLevel:   "info",
 		traceEvents:  make([]TraceEvent, 0),
 	}
@@ -116,10 +144,20 @@ func (engine *ChessEngine) Run() {
 			fmt.Println("OK: stop")
 		case "pgn":
 			engine.handlePGN(parts[1:])
+		case "book":
+			engine.handleBook(parts[1:])
+		case "endgame":
+			engine.handleEndgame(parts[1:])
 		case "uci":
 			engine.handleUCI()
 		case "isready":
 			engine.handleIsReady()
+		case "setoption":
+			engine.handleSetOption(parts[1:])
+		case "ucinewgame":
+			engine.handleUCINewGame()
+		case "position":
+			engine.handlePosition(parts[1:])
 		case "new960":
 			engine.handleNew960(parts[1:])
 		case "position960":
@@ -300,78 +338,24 @@ func (engine *ChessEngine) handleStatus() {
 }
 
 func (engine *ChessEngine) handleAI(depth int) {
-	if depth < 1 || depth > MAX_DEPTH {
-		depth = 3
-	}
-	engine.handleAISearch(depth, 0, depth)
-}
-
-func (engine *ChessEngine) handleAISearch(maxDepth int, movetime time.Duration, reportedDepth int) {
-	start := time.Now()
-
 	legalMoves := engine.gameState.GenerateLegalMoves()
 	if len(legalMoves) == 0 {
 		fmt.Println("ERROR: No legal moves available")
 		return
 	}
 
-	var searchResult SearchResult
-	if movetime > 0 {
-		searchResult = engine.ai.FindBestMoveTimed(engine.gameState, movetime, maxDepth)
-	} else {
-		searchResult = engine.ai.FindBestMoveWithDepth(engine.gameState, maxDepth)
+	if bookMove, ok := engine.chooseBookMove(legalMoves); ok {
+		engine.applyBookAIMove(bookMove)
+		return
 	}
 
-	bestMove := searchResult.Move
-
-	// Validate that we got a legal move
-	validMove := false
-	for _, move := range legalMoves {
-		if movesEqual(move, bestMove) || (!bestMove.IsPromotion && move.From == bestMove.From && move.To == bestMove.To) {
-			bestMove = move // Use the complete move with all flags
-			validMove = true
-			break
-		}
+	if endgameMove, info, ok := engine.chooseEndgameMove(legalMoves); ok {
+		engine.applyEndgameAIMove(endgameMove, info)
+		return
 	}
 
-	if !validMove {
-		// Fallback to first legal move
-		bestMove = legalMoves[0]
-	}
-
-	engine.gameState.MakeMove(bestMove)
-
-	elapsed := time.Since(start)
-	score := engine.ai.evaluate(engine.gameState)
-	depthToReport := reportedDepth
-	if depthToReport <= 0 {
-		depthToReport = searchResult.Depth
-	}
-	if depthToReport <= 0 {
-		depthToReport = 1
-	}
-
-	moveStr := moveToNotation(bestMove)
-
-	// Check for game end conditions
-	nextLegalMoves := engine.gameState.GenerateLegalMoves()
-	if len(nextLegalMoves) == 0 {
-		if engine.gameState.IsInCheck(engine.gameState.ActiveColor) {
-			fmt.Printf("AI: %s (CHECKMATE)\n", moveStr)
-		} else {
-			fmt.Printf("AI: %s (STALEMATE)\n", moveStr)
-		}
-	} else {
-		drawReason := engine.gameState.GetDrawReason()
-		if drawReason != "" {
-			fmt.Printf("AI: %s (DRAW: by %s)\n", moveStr, drawReason)
-		} else {
-			fmt.Printf("AI: %s (depth=%d, eval=%d, time=%d)\n",
-				moveStr, depthToReport, score, elapsed.Milliseconds())
-		}
-	}
-
-	fmt.Print(engine.gameState.Display())
+	result := engine.ai.Search(engine.gameState, depth, 0)
+	engine.applyAIMove(result, legalMoves, depth)
 }
 
 func (engine *ChessEngine) repetitionCount() int {
@@ -389,114 +373,46 @@ func (engine *ChessEngine) repetitionCount() int {
 	return count
 }
 
-type goTimeControl struct {
-	wtime     int
-	btime     int
-	winc      int
-	binc      int
-	movestogo int
-}
-
-func parseGoTimeControl(args []string) (goTimeControl, error) {
-	tc := goTimeControl{movestogo: 0}
-	seen := map[string]bool{
-		"wtime": false,
-		"btime": false,
-		"winc":  false,
-		"binc":  false,
+func depthForMovetime(movetimeMs int) int {
+	if movetimeMs <= 200 {
+		return 1
 	}
-
-	for i := 0; i < len(args); i++ {
-		key := strings.ToLower(args[i])
-		switch key {
-		case "wtime", "btime", "winc", "binc", "movestogo":
-			if i+1 >= len(args) {
-				return tc, fmt.Errorf("go %s requires an integer value", key)
-			}
-
-			value, err := strconv.Atoi(args[i+1])
-			if err != nil {
-				return tc, fmt.Errorf("go %s requires an integer value", key)
-			}
-			if value < 0 {
-				return tc, fmt.Errorf("go %s must be >= 0", key)
-			}
-
-			switch key {
-			case "wtime":
-				tc.wtime = value
-			case "btime":
-				tc.btime = value
-			case "winc":
-				tc.winc = value
-			case "binc":
-				tc.binc = value
-			case "movestogo":
-				if value == 0 {
-					return tc, fmt.Errorf("go movestogo must be > 0")
-				}
-				tc.movestogo = value
-			}
-
-			if _, ok := seen[key]; ok {
-				seen[key] = true
-			}
-			i++
-		default:
-			return tc, fmt.Errorf("unsupported go token: %s", args[i])
-		}
+	if movetimeMs <= 500 {
+		return 2
 	}
-
-	if !seen["wtime"] || !seen["btime"] || !seen["winc"] || !seen["binc"] {
-		return tc, fmt.Errorf("go requires wtime <ms> btime <ms> winc <ms> binc <ms> [movestogo <n>]")
+	if movetimeMs <= 2000 {
+		return 3
 	}
-
-	return tc, nil
-}
-
-func deriveThinkTimeMs(activeColor Color, tc goTimeControl) int {
-	remaining := tc.wtime
-	increment := tc.winc
-	if activeColor == Black {
-		remaining = tc.btime
-		increment = tc.binc
+	if movetimeMs <= 5000 {
+		return 4
 	}
-
-	movesToGo := tc.movestogo
-	if movesToGo <= 0 {
-		movesToGo = 30
-	}
-
-	thinkMs := remaining/movesToGo + increment/2
-	if thinkMs < 20 {
-		thinkMs = 20
-	}
-
-	maxSpend := remaining - 50
-	if maxSpend < 1 {
-		maxSpend = remaining / 2
-	}
-	if maxSpend < 1 {
-		maxSpend = 1
-	}
-
-	if thinkMs > maxSpend {
-		thinkMs = maxSpend
-	}
-	if thinkMs > 5000 {
-		thinkMs = 5000
-	}
-
-	return thinkMs
+	return 5
 }
 
 func (engine *ChessEngine) handleGo(args []string) {
 	if len(args) == 0 {
-		fmt.Println("ERROR: go requires movetime <ms>|wtime <ms> btime <ms> winc <ms> binc <ms> [movestogo <n>]|infinite")
+		fmt.Println("ERROR: go requires subcommand (movetime <ms>|wtime <ms> btime <ms> winc <ms> binc <ms> [movestogo <n>]|infinite)")
 		return
 	}
 
 	switch strings.ToLower(args[0]) {
+	case "depth":
+		if len(args) < 2 {
+			fmt.Println("ERROR: go depth requires a value")
+			return
+		}
+		depth, err := strconv.Atoi(args[1])
+		if err != nil {
+			fmt.Println("ERROR: go depth requires an integer value")
+			return
+		}
+		if depth < 1 {
+			depth = 1
+		}
+		if depth > MAX_DEPTH {
+			depth = MAX_DEPTH
+		}
+		engine.handleUCIDepthSearch(depth)
 	case "movetime":
 		if len(args) < 2 {
 			fmt.Println("ERROR: go movetime requires a value in milliseconds")
@@ -511,19 +427,700 @@ func (engine *ChessEngine) handleGo(args []string) {
 			fmt.Println("ERROR: go movetime must be > 0")
 			return
 		}
-		engine.handleAISearch(MAX_DEPTH, time.Duration(movetimeMs)*time.Millisecond, 0)
-	case "infinite":
-		// "Infinite" remains bounded in this wave; search uses iterative deepening + deadline.
-		engine.handleAISearch(MAX_DEPTH, 2*time.Second, 0)
-	default:
-		tc, err := parseGoTimeControl(args)
+		engine.handleAITimed(MAX_DEPTH, movetimeMs)
+	case "wtime":
+		movetimeMs, err := deriveMovetimeFromClockArgs(args, engine.gameState.ActiveColor)
 		if err != nil {
 			fmt.Printf("ERROR: %s\n", err.Error())
 			return
 		}
-		thinkMs := deriveThinkTimeMs(engine.gameState.ActiveColor, tc)
-		engine.handleAISearch(MAX_DEPTH, time.Duration(thinkMs)*time.Millisecond, 0)
+		engine.handleAITimed(MAX_DEPTH, movetimeMs)
+	case "infinite":
+		fmt.Println("OK: go infinite acknowledged (bounded search mode)")
+		// Cooperative bounded search in this synchronous CLI.
+		engine.handleAITimed(MAX_DEPTH, 15000)
+	default:
+		fmt.Println("ERROR: Unsupported go command")
 	}
+}
+
+func (engine *ChessEngine) handleUCIDepthSearch(depth int) {
+	legalMoves := engine.gameState.GenerateLegalMoves()
+	if len(legalMoves) == 0 {
+		fmt.Println("bestmove 0000")
+		return
+	}
+
+	if bookMove, ok := engine.chooseBookMove(legalMoves); ok {
+		moveStr := moveToString(bookMove)
+		fmt.Printf("info string bookmove %s\n", moveStr)
+		fmt.Printf("bestmove %s\n", moveStr)
+		return
+	}
+
+	if endgameMove, info, ok := engine.chooseEndgameMove(legalMoves); ok {
+		moveStr := moveToString(endgameMove)
+		fmt.Printf("info string endgame %s score cp %d\n", info.Kind, info.WhiteScore)
+		fmt.Printf("bestmove %s\n", moveStr)
+		return
+	}
+
+	result := engine.ai.Search(engine.gameState, depth, 0)
+	bestMove := normalizeBestMove(result.Move, legalMoves)
+	moveStr := moveToString(bestMove)
+	fmt.Printf("info depth %d score cp %d time %d nodes 0\n", result.Depth, result.Score, result.ElapsedMS)
+	fmt.Printf("bestmove %s\n", moveStr)
+}
+
+func deriveMovetimeFromClockArgs(args []string, active Color) (int, error) {
+	values := map[string]int{
+		"winc":     0,
+		"binc":     0,
+		"movestogo": 30,
+	}
+
+	i := 0
+	for i < len(args) {
+		key := strings.ToLower(strings.TrimSpace(args[i]))
+		i++
+		if i >= len(args) {
+			return 0, fmt.Errorf("go %s requires a value", key)
+		}
+		value, err := strconv.Atoi(args[i])
+		if err != nil {
+			return 0, fmt.Errorf("go %s requires an integer value", key)
+		}
+		i++
+
+		switch key {
+		case "wtime", "btime", "winc", "binc", "movestogo":
+			values[key] = value
+		default:
+			return 0, fmt.Errorf("unsupported go parameter: %s", key)
+		}
+	}
+
+	wtime, hasWtime := values["wtime"]
+	btime, hasBtime := values["btime"]
+	if !hasWtime || !hasBtime {
+		return 0, fmt.Errorf("go wtime/btime parameters are required")
+	}
+	if wtime <= 0 || btime <= 0 {
+		return 0, fmt.Errorf("go wtime/btime must be > 0")
+	}
+	if values["movestogo"] <= 0 {
+		values["movestogo"] = 30
+	}
+
+	base := wtime
+	increment := values["winc"]
+	if active == Black {
+		base = btime
+		increment = values["binc"]
+	}
+
+	budget := base/(values["movestogo"]+1) + increment/2
+	if budget < 50 {
+		budget = 50
+	}
+	if budget >= base {
+		budget = base / 2
+	}
+	if budget <= 0 {
+		return 0, fmt.Errorf("unable to derive positive movetime from clocks")
+	}
+	return budget, nil
+}
+
+func (engine *ChessEngine) handleAITimed(maxDepth int, movetimeMs int) {
+	legalMoves := engine.gameState.GenerateLegalMoves()
+	if len(legalMoves) == 0 {
+		fmt.Println("ERROR: No legal moves available")
+		return
+	}
+
+	if bookMove, ok := engine.chooseBookMove(legalMoves); ok {
+		engine.applyBookAIMove(bookMove)
+		return
+	}
+
+	if endgameMove, info, ok := engine.chooseEndgameMove(legalMoves); ok {
+		engine.applyEndgameAIMove(endgameMove, info)
+		return
+	}
+
+	result := engine.ai.Search(engine.gameState, maxDepth, movetimeMs)
+	engine.applyAIMove(result, legalMoves, maxDepth)
+}
+
+func (engine *ChessEngine) applyAIMove(result SearchResult, legalMoves []Move, requestedDepth int) {
+	bestMove := normalizeBestMove(result.Move, legalMoves)
+
+	engine.gameState.MakeMove(bestMove)
+
+	moveStr := moveToString(bestMove)
+
+	// Check for game end conditions
+	nextLegalMoves := engine.gameState.GenerateLegalMoves()
+	if len(nextLegalMoves) == 0 {
+		if engine.gameState.IsInCheck(engine.gameState.ActiveColor) {
+			fmt.Printf("AI: %s (CHECKMATE)\n", moveStr)
+		} else {
+			fmt.Printf("AI: %s (STALEMATE)\n", moveStr)
+		}
+	} else {
+		drawReason := engine.gameState.GetDrawReason()
+		if drawReason != "" {
+			fmt.Printf("AI: %s (DRAW: by %s)\n", moveStr, drawReason)
+		} else {
+			depthUsed := result.Depth
+			if depthUsed == 0 {
+				depthUsed = requestedDepth
+			}
+			fmt.Printf("AI: %s (depth=%d, eval=%d, time=%d)\n",
+				moveStr, depthUsed, result.Score, result.ElapsedMS)
+		}
+	}
+
+	fmt.Print(engine.gameState.Display())
+}
+
+func normalizeBestMove(bestMove Move, legalMoves []Move) Move {
+	validMove := false
+	for _, move := range legalMoves {
+		if move.From == bestMove.From && move.To == bestMove.To {
+			if !bestMove.IsPromotion || move.PromoteTo == bestMove.PromoteTo {
+				bestMove = move
+				validMove = true
+				break
+			}
+		}
+	}
+	if !validMove {
+		return legalMoves[0]
+	}
+	return bestMove
+}
+
+func moveToString(move Move) string {
+	moveStr := fmt.Sprintf("%s%s", move.From.ToAlgebraic(), move.To.ToAlgebraic())
+	if move.IsPromotion {
+		switch move.PromoteTo {
+		case Queen:
+			moveStr += "q"
+		case Rook:
+			moveStr += "r"
+		case Bishop:
+			moveStr += "b"
+		case Knight:
+			moveStr += "n"
+		}
+	}
+	return moveStr
+}
+
+func bookPositionKeyFromFEN(fen string) string {
+	parts := strings.Fields(strings.TrimSpace(fen))
+	if len(parts) >= 4 {
+		return strings.Join(parts[:4], " ")
+	}
+	return strings.TrimSpace(fen)
+}
+
+func parseBookEntries(content string) (map[string][]BookEntry, int, error) {
+	entries := make(map[string][]BookEntry)
+	totalEntries := 0
+	movePattern := regexp.MustCompile(`^[a-h][1-8][a-h][1-8][qrbn]?$`)
+	lines := strings.Split(content, "\n")
+
+	for idx, raw := range lines {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		parts := strings.SplitN(line, "->", 2)
+		if len(parts) != 2 {
+			return nil, 0, fmt.Errorf("line %d: expected '<fen> -> <move> [weight]'", idx+1)
+		}
+
+		key := bookPositionKeyFromFEN(parts[0])
+		if key == "" {
+			return nil, 0, fmt.Errorf("line %d: empty position key", idx+1)
+		}
+
+		rhsFields := strings.Fields(strings.TrimSpace(parts[1]))
+		if len(rhsFields) == 0 {
+			return nil, 0, fmt.Errorf("line %d: missing move", idx+1)
+		}
+
+		move := strings.ToLower(rhsFields[0])
+		if !movePattern.MatchString(move) {
+			return nil, 0, fmt.Errorf("line %d: invalid move %q", idx+1, move)
+		}
+
+		weight := 1
+		if len(rhsFields) > 1 {
+			parsedWeight, err := strconv.Atoi(rhsFields[1])
+			if err != nil {
+				return nil, 0, fmt.Errorf("line %d: invalid weight %q", idx+1, rhsFields[1])
+			}
+			if parsedWeight <= 0 {
+				return nil, 0, fmt.Errorf("line %d: weight must be > 0", idx+1)
+			}
+			weight = parsedWeight
+		}
+
+		entries[key] = append(entries[key], BookEntry{
+			Move:   move,
+			Weight: weight,
+		})
+		totalEntries++
+	}
+
+	return entries, totalEntries, nil
+}
+
+func (engine *ChessEngine) handleBook(args []string) {
+	if len(args) == 0 {
+		fmt.Println("ERROR: book requires subcommand (load|on|off|stats)")
+		return
+	}
+
+	switch strings.ToLower(args[0]) {
+	case "load":
+		if len(args) < 2 {
+			fmt.Println("ERROR: book load requires a file path")
+			return
+		}
+
+		path := strings.Join(args[1:], " ")
+		content, err := os.ReadFile(path)
+		if err != nil {
+			fmt.Printf("ERROR: book load failed: %s\n", err.Error())
+			return
+		}
+
+		entries, totalEntries, parseErr := parseBookEntries(string(content))
+		if parseErr != nil {
+			fmt.Printf("ERROR: book load failed: %s\n", parseErr.Error())
+			return
+		}
+
+		engine.bookPath = path
+		engine.bookEntries = entries
+		engine.bookEntryCount = totalEntries
+		engine.bookEnabled = true
+		engine.bookLookups = 0
+		engine.bookHits = 0
+		engine.bookMisses = 0
+		engine.bookPlayed = 0
+
+		fmt.Printf(
+			"BOOK: loaded path=\"%s\"; positions=%d; entries=%d; enabled=%t\n",
+			path,
+			len(entries),
+			totalEntries,
+			engine.bookEnabled,
+		)
+	case "on":
+		engine.bookEnabled = true
+		fmt.Println("BOOK: enabled=true")
+	case "off":
+		engine.bookEnabled = false
+		fmt.Println("BOOK: enabled=false")
+	case "stats":
+		path := engine.bookPath
+		if path == "" {
+			path = "(none)"
+		}
+		fmt.Printf(
+			"BOOK: enabled=%t; path=%s; positions=%d; entries=%d; lookups=%d; hits=%d; misses=%d; played=%d\n",
+			engine.bookEnabled,
+			path,
+			len(engine.bookEntries),
+			engine.bookEntryCount,
+			engine.bookLookups,
+			engine.bookHits,
+			engine.bookMisses,
+			engine.bookPlayed,
+		)
+	default:
+		fmt.Println("ERROR: Unsupported book command")
+	}
+}
+
+func (engine *ChessEngine) chooseBookMove(legalMoves []Move) (Move, bool) {
+	engine.bookLookups++
+	if !engine.bookEnabled || len(engine.bookEntries) == 0 {
+		engine.bookMisses++
+		return Move{}, false
+	}
+
+	key := bookPositionKeyFromFEN(engine.gameState.ToFEN())
+	entries := engine.bookEntries[key]
+	if len(entries) == 0 {
+		engine.bookMisses++
+		return Move{}, false
+	}
+
+	legalByNotation := make(map[string]Move, len(legalMoves))
+	for _, move := range legalMoves {
+		legalByNotation[strings.ToLower(moveToString(move))] = move
+	}
+
+	type weightedCandidate struct {
+		move   Move
+		weight int
+	}
+
+	candidates := make([]weightedCandidate, 0, len(entries))
+	totalWeight := 0
+	for _, entry := range entries {
+		move, ok := legalByNotation[entry.Move]
+		if !ok {
+			continue
+		}
+		weight := entry.Weight
+		if weight <= 0 {
+			weight = 1
+		}
+		candidates = append(candidates, weightedCandidate{
+			move:   move,
+			weight: weight,
+		})
+		totalWeight += weight
+	}
+
+	if len(candidates) == 0 || totalWeight <= 0 {
+		engine.bookMisses++
+		return Move{}, false
+	}
+
+	selector := int((uint64(engine.gameState.ZobristHash) + uint64(engine.bookLookups)) % uint64(totalWeight))
+	acc := 0
+	chosen := candidates[0].move
+	for _, candidate := range candidates {
+		acc += candidate.weight
+		if selector < acc {
+			chosen = candidate.move
+			break
+		}
+	}
+
+	engine.bookHits++
+	return chosen, true
+}
+
+func (engine *ChessEngine) applyBookAIMove(bestMove Move) {
+	engine.gameState.MakeMove(bestMove)
+	engine.bookPlayed++
+
+	moveStr := moveToString(bestMove)
+	nextLegalMoves := engine.gameState.GenerateLegalMoves()
+	if len(nextLegalMoves) == 0 {
+		if engine.gameState.IsInCheck(engine.gameState.ActiveColor) {
+			fmt.Printf("AI: %s (book, CHECKMATE)\n", moveStr)
+		} else {
+			fmt.Printf("AI: %s (book, STALEMATE)\n", moveStr)
+		}
+	} else {
+		drawReason := engine.gameState.GetDrawReason()
+		if drawReason != "" {
+			fmt.Printf("AI: %s (book, DRAW: by %s)\n", moveStr, drawReason)
+		} else {
+			fmt.Printf("AI: %s (book)\n", moveStr)
+		}
+	}
+
+	fmt.Print(engine.gameState.Display())
+}
+
+func (engine *ChessEngine) handleEndgame(_ []string) {
+	info, ok := detectEndgame(engine.gameState)
+	if !ok {
+		fmt.Printf("ENDGAME: type=none; active=%s; score=0\n", colorName(engine.gameState.ActiveColor))
+		return
+	}
+
+	output := fmt.Sprintf(
+		"ENDGAME: type=%s; strong=%s; weak=%s; score=%d",
+		info.Kind,
+		colorName(info.Strong),
+		colorName(info.Weak),
+		info.WhiteScore,
+	)
+
+	legalMoves := engine.gameState.GenerateLegalMoves()
+	if len(legalMoves) > 0 {
+		if bestMove, _, ok := engine.chooseEndgameMove(legalMoves); ok {
+			output += fmt.Sprintf("; bestmove=%s", strings.ToLower(moveToString(bestMove)))
+		}
+	}
+	if info.Detail != "" {
+		output += fmt.Sprintf("; detail=%s", info.Detail)
+	}
+
+	fmt.Println(output)
+}
+
+func colorName(color Color) string {
+	if color == White {
+		return "white"
+	}
+	return "black"
+}
+
+func absInt(value int) int {
+	if value < 0 {
+		return -value
+	}
+	return value
+}
+
+func minInt(values ...int) int {
+	if len(values) == 0 {
+		return 0
+	}
+	result := values[0]
+	for i := 1; i < len(values); i++ {
+		if values[i] < result {
+			result = values[i]
+		}
+	}
+	return result
+}
+
+func manhattanDistance(a, b Square) int {
+	return absInt(a.File-b.File) + absInt(a.Rank-b.Rank)
+}
+
+func nonKingMaterialCount(counts [2][7]int, color Color) int {
+	total := 0
+	for pieceType := Pawn; pieceType <= Queen; pieceType++ {
+		total += counts[color][pieceType]
+	}
+	return total
+}
+
+func detectEndgame(gs *GameState) (EndgameInfo, bool) {
+	var counts [2][7]int
+	var kingSquares [2]Square
+	var hasKing [2]bool
+	var pawnSquares [2]Square
+	var hasPawn [2]bool
+	var rookSquares [2]Square
+	var hasRook [2]bool
+	var queenSquares [2]Square
+	var hasQueen [2]bool
+
+	for rank := 0; rank < 8; rank++ {
+		for file := 0; file < 8; file++ {
+			piece := gs.Board[rank][file]
+			if piece.Type == Empty {
+				continue
+			}
+			counts[piece.Color][piece.Type]++
+
+			square := Square{File: file, Rank: rank}
+			switch piece.Type {
+			case King:
+				kingSquares[piece.Color] = square
+				hasKing[piece.Color] = true
+			case Pawn:
+				if !hasPawn[piece.Color] {
+					pawnSquares[piece.Color] = square
+					hasPawn[piece.Color] = true
+				}
+			case Rook:
+				if !hasRook[piece.Color] {
+					rookSquares[piece.Color] = square
+					hasRook[piece.Color] = true
+				}
+			case Queen:
+				if !hasQueen[piece.Color] {
+					queenSquares[piece.Color] = square
+					hasQueen[piece.Color] = true
+				}
+			}
+		}
+	}
+
+	if !hasKing[White] || !hasKing[Black] {
+		return EndgameInfo{}, false
+	}
+
+	whiteMaterial := nonKingMaterialCount(counts, White)
+	blackMaterial := nonKingMaterialCount(counts, Black)
+
+	// KQK
+	if counts[White][Queen] == 1 && whiteMaterial == 1 && blackMaterial == 0 {
+		weakKing := kingSquares[Black]
+		strongKing := kingSquares[White]
+		edgeDistance := minInt(weakKing.File, 7-weakKing.File, weakKing.Rank, 7-weakKing.Rank)
+		kingDistance := manhattanDistance(strongKing, weakKing)
+		score := 900 + (14-kingDistance)*6 + (3-edgeDistance)*20
+		return EndgameInfo{
+			Kind:       "KQK",
+			Strong:     White,
+			Weak:       Black,
+			WhiteScore: score,
+			Detail:     fmt.Sprintf("queen=%s", queenSquares[White].ToAlgebraic()),
+		}, true
+	}
+	if counts[Black][Queen] == 1 && blackMaterial == 1 && whiteMaterial == 0 {
+		weakKing := kingSquares[White]
+		strongKing := kingSquares[Black]
+		edgeDistance := minInt(weakKing.File, 7-weakKing.File, weakKing.Rank, 7-weakKing.Rank)
+		kingDistance := manhattanDistance(strongKing, weakKing)
+		score := 900 + (14-kingDistance)*6 + (3-edgeDistance)*20
+		return EndgameInfo{
+			Kind:       "KQK",
+			Strong:     Black,
+			Weak:       White,
+			WhiteScore: -score,
+			Detail:     fmt.Sprintf("queen=%s", queenSquares[Black].ToAlgebraic()),
+		}, true
+	}
+
+	// KPK
+	if counts[White][Pawn] == 1 && whiteMaterial == 1 && blackMaterial == 0 {
+		pawn := pawnSquares[White]
+		strongKing := kingSquares[White]
+		weakKing := kingSquares[Black]
+		promotion := Square{File: pawn.File, Rank: 7}
+		pawnSteps := 7 - pawn.Rank
+		score := 120 + (6-pawnSteps)*35 + manhattanDistance(weakKing, promotion)*6 - manhattanDistance(strongKing, pawn)*8
+		if pawnSteps <= 1 {
+			score += 80
+		}
+		if score < 30 {
+			score = 30
+		}
+		return EndgameInfo{
+			Kind:       "KPK",
+			Strong:     White,
+			Weak:       Black,
+			WhiteScore: score,
+			Detail:     fmt.Sprintf("pawn=%s", pawn.ToAlgebraic()),
+		}, true
+	}
+	if counts[Black][Pawn] == 1 && blackMaterial == 1 && whiteMaterial == 0 {
+		pawn := pawnSquares[Black]
+		strongKing := kingSquares[Black]
+		weakKing := kingSquares[White]
+		promotion := Square{File: pawn.File, Rank: 0}
+		pawnSteps := pawn.Rank
+		score := 120 + (6-pawnSteps)*35 + manhattanDistance(weakKing, promotion)*6 - manhattanDistance(strongKing, pawn)*8
+		if pawnSteps <= 1 {
+			score += 80
+		}
+		if score < 30 {
+			score = 30
+		}
+		return EndgameInfo{
+			Kind:       "KPK",
+			Strong:     Black,
+			Weak:       White,
+			WhiteScore: -score,
+			Detail:     fmt.Sprintf("pawn=%s", pawn.ToAlgebraic()),
+		}, true
+	}
+
+	// KRKP
+	if counts[White][Rook] == 1 && whiteMaterial == 1 && counts[Black][Pawn] == 1 && blackMaterial == 1 {
+		strongKing := kingSquares[White]
+		weakKing := kingSquares[Black]
+		weakPawn := pawnSquares[Black]
+		pawnSteps := weakPawn.Rank
+		score := 380 - pawnSteps*25 + (manhattanDistance(weakKing, weakPawn)-manhattanDistance(strongKing, weakPawn))*12
+		if score < 50 {
+			score = 50
+		}
+		return EndgameInfo{
+			Kind:       "KRKP",
+			Strong:     White,
+			Weak:       Black,
+			WhiteScore: score,
+			Detail:     fmt.Sprintf("rook=%s,pawn=%s", rookSquares[White].ToAlgebraic(), weakPawn.ToAlgebraic()),
+		}, true
+	}
+	if counts[Black][Rook] == 1 && blackMaterial == 1 && counts[White][Pawn] == 1 && whiteMaterial == 1 {
+		strongKing := kingSquares[Black]
+		weakKing := kingSquares[White]
+		weakPawn := pawnSquares[White]
+		pawnSteps := 7 - weakPawn.Rank
+		score := 380 - pawnSteps*25 + (manhattanDistance(weakKing, weakPawn)-manhattanDistance(strongKing, weakPawn))*12
+		if score < 50 {
+			score = 50
+		}
+		return EndgameInfo{
+			Kind:       "KRKP",
+			Strong:     Black,
+			Weak:       White,
+			WhiteScore: -score,
+			Detail:     fmt.Sprintf("rook=%s,pawn=%s", rookSquares[Black].ToAlgebraic(), weakPawn.ToAlgebraic()),
+		}, true
+	}
+
+	return EndgameInfo{}, false
+}
+
+func (engine *ChessEngine) chooseEndgameMove(legalMoves []Move) (Move, EndgameInfo, bool) {
+	rootInfo, ok := detectEndgame(engine.gameState)
+	if !ok || len(legalMoves) == 0 {
+		return Move{}, EndgameInfo{}, false
+	}
+
+	rootColor := engine.gameState.ActiveColor
+	bestMove := legalMoves[0]
+	bestNotation := strings.ToLower(moveToString(bestMove))
+	bestScore := -INFINITY
+
+	for _, candidate := range legalMoves {
+		clone := engine.gameState.Clone()
+		clone.MakeMove(candidate)
+
+		score := engine.ai.evaluate(clone)
+		if endInfo, hasEndgame := detectEndgame(clone); hasEndgame {
+			score = endInfo.WhiteScore
+		}
+		if rootColor == Black {
+			score = -score
+		}
+
+		notation := strings.ToLower(moveToString(candidate))
+		if score > bestScore || (score == bestScore && notation < bestNotation) {
+			bestScore = score
+			bestMove = candidate
+			bestNotation = notation
+		}
+	}
+
+	return bestMove, rootInfo, true
+}
+
+func (engine *ChessEngine) applyEndgameAIMove(bestMove Move, info EndgameInfo) {
+	engine.gameState.MakeMove(bestMove)
+	moveStr := moveToString(bestMove)
+
+	nextLegalMoves := engine.gameState.GenerateLegalMoves()
+	if len(nextLegalMoves) == 0 {
+		if engine.gameState.IsInCheck(engine.gameState.ActiveColor) {
+			fmt.Printf("AI: %s (endgame %s, CHECKMATE)\n", moveStr, info.Kind)
+		} else {
+			fmt.Printf("AI: %s (endgame %s, STALEMATE)\n", moveStr, info.Kind)
+		}
+	} else {
+		drawReason := engine.gameState.GetDrawReason()
+		if drawReason != "" {
+			fmt.Printf("AI: %s (endgame %s, DRAW: by %s)\n", moveStr, info.Kind, drawReason)
+		} else {
+			fmt.Printf("AI: %s (endgame %s, score=%d)\n", moveStr, info.Kind, info.WhiteScore)
+		}
+	}
+
+	fmt.Print(engine.gameState.Display())
 }
 
 func (engine *ChessEngine) handlePGN(args []string) {
@@ -572,6 +1169,143 @@ func (engine *ChessEngine) handleUCI() {
 
 func (engine *ChessEngine) handleIsReady() {
 	fmt.Println("readyok")
+}
+
+func (engine *ChessEngine) handleSetOption(args []string) {
+	if len(args) < 4 || strings.ToLower(args[0]) != "name" {
+		fmt.Println("ERROR: setoption format is 'setoption name <Hash|Threads> value <n>'")
+		return
+	}
+
+	valueIndex := -1
+	for i := 1; i < len(args); i++ {
+		if strings.ToLower(args[i]) == "value" {
+			valueIndex = i
+			break
+		}
+	}
+	if valueIndex <= 1 || valueIndex+1 >= len(args) {
+		fmt.Println("ERROR: setoption requires 'value <n>'")
+		return
+	}
+
+	name := strings.ToLower(strings.TrimSpace(strings.Join(args[1:valueIndex], " ")))
+	value, err := strconv.Atoi(args[valueIndex+1])
+	if err != nil {
+		fmt.Println("ERROR: setoption value must be an integer")
+		return
+	}
+
+	switch name {
+	case "hash":
+		if value < 1 {
+			value = 1
+		}
+		if value > 1024 {
+			value = 1024
+		}
+		engine.uciHashMB = value
+		fmt.Printf("info string option Hash=%d\n", engine.uciHashMB)
+	case "threads":
+		if value < 1 {
+			value = 1
+		}
+		if value > 64 {
+			value = 64
+		}
+		engine.uciThreads = value
+		fmt.Printf("info string option Threads=%d\n", engine.uciThreads)
+	default:
+		fmt.Printf("info string unsupported option %s\n", strings.TrimSpace(strings.Join(args[1:valueIndex], " ")))
+	}
+}
+
+func (engine *ChessEngine) handleUCINewGame() {
+	engine.gameState = NewGameState()
+	engine.ai = NewAI()
+}
+
+func (engine *ChessEngine) handlePosition(args []string) {
+	if len(args) == 0 {
+		fmt.Println("ERROR: position requires 'startpos' or 'fen <...>'")
+		return
+	}
+
+	i := 0
+	switch strings.ToLower(args[0]) {
+	case "startpos":
+		engine.gameState = NewGameState()
+		engine.ai = NewAI()
+		i = 1
+	case "fen":
+		i = 1
+		fenParts := make([]string, 0, 6)
+		for i < len(args) && strings.ToLower(args[i]) != "moves" {
+			fenParts = append(fenParts, args[i])
+			i++
+		}
+		if len(fenParts) == 0 {
+			fmt.Println("ERROR: position fen requires a FEN string")
+			return
+		}
+		if err := engine.gameState.FromFEN(strings.Join(fenParts, " ")); err != nil {
+			fmt.Printf("ERROR: Invalid FEN: %s\n", err.Error())
+			return
+		}
+	default:
+		fmt.Println("ERROR: position requires 'startpos' or 'fen <...>'")
+		return
+	}
+
+	if i < len(args) && strings.ToLower(args[i]) == "moves" {
+		i++
+		for ; i < len(args); i++ {
+			if err := engine.applyMoveSilently(args[i]); err != nil {
+				fmt.Printf("ERROR: position move %s failed: %s\n", args[i], err.Error())
+				return
+			}
+		}
+	}
+}
+
+func (engine *ChessEngine) applyMoveSilently(moveStr string) error {
+	if len(moveStr) < 4 {
+		return fmt.Errorf("invalid move format")
+	}
+
+	from := AlgebraicToSquare(moveStr[0:2])
+	to := AlgebraicToSquare(moveStr[2:4])
+	if !from.IsValid() || !to.IsValid() {
+		return fmt.Errorf("invalid move format")
+	}
+
+	var promotionPiece PieceType
+	hasPromotion := false
+	if len(moveStr) == 5 {
+		hasPromotion = true
+		switch strings.ToLower(string(moveStr[4])) {
+		case "q":
+			promotionPiece = Queen
+		case "r":
+			promotionPiece = Rook
+		case "b":
+			promotionPiece = Bishop
+		case "n":
+			promotionPiece = Knight
+		default:
+			return fmt.Errorf("invalid promotion piece")
+		}
+	}
+
+	move, err := engine.gameState.IsValidMove(from, to)
+	if err != nil {
+		return err
+	}
+	if move.IsPromotion && hasPromotion {
+		move.PromoteTo = promotionPiece
+	}
+	engine.gameState.MakeMove(move)
+	return nil
 }
 
 func (engine *ChessEngine) handleNew960(args []string) {
@@ -788,13 +1522,19 @@ func (engine *ChessEngine) showHelp() {
 	fmt.Println("  undo         - Undo the last move")
 	fmt.Println("  export       - Export current position as FEN")
 	fmt.Println("  ai <depth>   - Let AI make a move (depth 1-5, default 3)")
-	fmt.Println("  go movetime <ms> - Time-managed AI move")
-	fmt.Println("  go wtime <ms> btime <ms> winc <ms> binc <ms> [movestogo <n>] - Clock-based AI move")
-	fmt.Println("  go infinite  - Run a bounded timed iterative search")
+	fmt.Println("  go movetime <ms> - Time-managed AI move with iterative deepening")
+	fmt.Println("  go wtime <ms> btime <ms> winc <ms> binc <ms> [movestogo <n>] - Clock-based timed move")
+	fmt.Println("  go depth <n> - UCI-style depth-limited search (prints info/bestmove)")
+	fmt.Println("  go infinite  - Start bounded long search mode")
 	fmt.Println("  stop         - Stop infinite search mode")
 	fmt.Println("  pgn load|show|moves - PGN command family")
+	fmt.Println("  book load|on|off|stats - Native opening book controls")
+	fmt.Println("  endgame      - Detect specialized endgame module and best move hint")
 	fmt.Println("  uci          - Enter/respond to UCI handshake")
 	fmt.Println("  isready      - UCI readiness probe")
+	fmt.Println("  setoption name <Hash|Threads> value <n> - Set UCI option")
+	fmt.Println("  ucinewgame   - Reset internal state for UCI game")
+	fmt.Println("  position startpos|fen ... [moves ...] - Load UCI position")
 	fmt.Println("  new960 [id]  - Start Chess960 game by id (0-959)")
 	fmt.Println("  position960  - Show current Chess960 metadata")
 	fmt.Println("  trace ...    - Trace controls and reports")

--- a/implementations/lua/chess.lua
+++ b/implementations/lua/chess.lua
@@ -20,15 +20,25 @@ local position_history = {}
 local irreversible_history = {}
 local pgn_path = nil
 local pgn_moves = {}
+local book_path = nil
+local book_enabled = false
+local book_entries = {}
+local book_entry_count = 0
+local book_lookups = 0
+local book_hits = 0
+local book_misses = 0
+local book_played = 0
+local uci_hash_mb = 16
+local uci_threads = 1
 local chess960_id = 0
 local trace_enabled = false
 local trace_level = "info"
 local trace_events = {}
 local trace_command_count = 0
-local transposition_table = {}
-local tt_entry_count = 0
+local tt = {}
+local search_deadline = nil
+local search_timed_out = false
 local search_stop_requested = false
-local active_search = nil
 
 local zobrist_keys = {
     pieces = {},
@@ -771,9 +781,6 @@ local function import_fen(fen_str)
     fullmove_number = tonumber(parts[6]) or 1
     
     move_history = {}
-    position_history = {}
-    irreversible_history = {}
-    zobrist_hash = compute_hash()
     return true, "OK"
 end
 
@@ -842,169 +849,112 @@ local function evaluate_position()
     return score
 end
 
--- Negamax search with iterative deepening and transposition table
-local SEARCH_INF = 2000000000
-local MATE_SCORE = 1000000
-local TT_FLAG_EXACT = "exact"
-local TT_FLAG_LOWER = "lower"
-local TT_FLAG_UPPER = "upper"
-local TT_MAX_ENTRIES = 200000
-local SEARCH_TIME_CHECK_INTERVAL = 512
-local GO_INFINITE_BUDGET_MS = 5000
-local GO_MAX_DEPTH = 64
-
-local function clone_move(move)
-    if not move then return nil end
-    if move[5] then
-        return {move[1], move[2], move[3], move[4], move[5]}
-    end
-    return {move[1], move[2], move[3], move[4]}
+-- Minimax with alpha-beta pruning
+local function move_key(move)
+    local promo = move[5] or ""
+    return string.format("%d:%d:%d:%d:%s", move[1], move[2], move[3], move[4], promo)
 end
 
-local function moves_equal(a, b)
-    if not a or not b then return false end
-    return a[1] == b[1] and a[2] == b[2] and a[3] == b[3] and a[4] == b[4] and a[5] == b[5]
-end
-
-local function move_to_string(move)
-    local move_str = indices_to_algebraic(move[1], move[2]) .. indices_to_algebraic(move[3], move[4])
-    if move[5] then
-        move_str = move_str .. move[5]
-    end
-    return move_str
-end
-
-local function clear_transposition_table()
-    transposition_table = {}
-    tt_entry_count = 0
-end
-
-local function store_tt_entry(hash_key, depth, score, flag, best_move)
-    local existing = transposition_table[hash_key]
-    if existing and existing.depth and existing.depth > depth and flag ~= TT_FLAG_EXACT then
-        return
-    end
-
-    if not existing then
-        if tt_entry_count >= TT_MAX_ENTRIES then
-            clear_transposition_table()
-        end
-        tt_entry_count = tt_entry_count + 1
-    end
-
-    transposition_table[hash_key] = {
-        depth = depth,
-        score = score,
-        flag = flag,
-        best_move = clone_move(best_move)
-    }
-end
-
-local function score_move_for_ordering(move, tt_move)
-    local score = 0
-    if tt_move and moves_equal(move, tt_move) then
-        score = score + 1000000
-    end
-
-    local target_piece = board[move[3]][move[4]]
-    if target_piece ~= "." then
-        score = score + 100000 + math.abs(PIECE_VALUES[target_piece] or 0)
-    end
-
-    if move[5] then
-        score = score + 50000
-    end
-
-    return score
-end
-
-local function order_moves(moves, tt_move)
-    table.sort(moves, function(a, b)
-        return score_move_for_ordering(a, tt_move) > score_move_for_ordering(b, tt_move)
-    end)
-end
-
-local function search_should_abort(depth)
+local function search_time_exceeded()
     if search_stop_requested then
-        if active_search then
-            active_search.aborted = true
-        end
+        search_timed_out = true
         return true
     end
-
-    if not active_search or not active_search.deadline_clock then
+    if not search_deadline then
         return false
     end
-
-    active_search.nodes = active_search.nodes + 1
-    if depth <= 1 or (active_search.nodes % SEARCH_TIME_CHECK_INTERVAL == 0) then
-        if os.clock() >= active_search.deadline_clock then
-            active_search.aborted = true
-            return true
-        end
+    if os.clock() >= search_deadline then
+        search_timed_out = true
+        return true
     end
-
     return false
 end
 
-local function negamax(depth, alpha, beta, ply)
-    if search_should_abort(depth) then
-        return nil, nil, true
+local function order_moves(moves, tt_move_key)
+    local scored = {}
+    for _, move in ipairs(moves) do
+        local score = 0
+        if tt_move_key and move_key(move) == tt_move_key then
+            score = score + 100000
+        end
+        local target = board[move[3]][move[4]]
+        if target and target ~= "." then
+            score = score + 10000 + math.abs(PIECE_VALUES[target] or 0)
+        end
+        if move[5] then
+            score = score + 9000 + math.abs(PIECE_VALUES[move[5]] or 0)
+        end
+        table.insert(scored, {move = move, score = score})
+    end
+    table.sort(scored, function(a, b) return a.score > b.score end)
+
+    local ordered = {}
+    for _, item in ipairs(scored) do
+        table.insert(ordered, item.move)
+    end
+    return ordered
+end
+
+local function negamax(depth, alpha, beta)
+    if search_time_exceeded() then
+        return 0, nil, false
     end
 
-    local hash_key = zobrist_hash
-    local alpha_orig = alpha
-    local beta_orig = beta
-    local tt_entry = transposition_table[hash_key]
+    local original_alpha = alpha
+    local key = string.format("%u", zobrist_hash)
+    local best_from_tt = nil
+    local entry = tt[key]
 
-    if tt_entry and tt_entry.depth >= depth then
-        if tt_entry.flag == TT_FLAG_EXACT then
-            return tt_entry.score, clone_move(tt_entry.best_move), false
-        elseif tt_entry.flag == TT_FLAG_LOWER then
-            alpha = math.max(alpha, tt_entry.score)
-        elseif tt_entry.flag == TT_FLAG_UPPER then
-            beta = math.min(beta, tt_entry.score)
+    if entry and entry.depth >= depth then
+        if entry.flag == "exact" then
+            return entry.score, entry.best_move_key, true
+        elseif entry.flag == "lower" then
+            alpha = math.max(alpha, entry.score)
+        elseif entry.flag == "upper" then
+            beta = math.min(beta, entry.score)
         end
-
         if alpha >= beta then
-            return tt_entry.score, clone_move(tt_entry.best_move), false
+            return entry.score, entry.best_move_key, true
         end
+        best_from_tt = entry.best_move_key
     end
 
     if depth == 0 then
-        local side_sign = white_to_move and 1 or -1
-        return side_sign * evaluate_position(), nil, false
+        local eval = evaluate_position()
+        if not white_to_move then
+            eval = -eval
+        end
+        return eval, nil, true
     end
 
     local moves = generate_legal_moves()
     if #moves == 0 then
         if is_in_check(white_to_move) then
-            return -MATE_SCORE + ply, nil, false
+            return -100000 + depth, nil, true
         end
-        return 0, nil, false
+        return 0, nil, true
     end
 
-    local tt_move = tt_entry and tt_entry.best_move or nil
-    order_moves(moves, tt_move)
+    local ordered = order_moves(moves, best_from_tt)
+    local best_score = -math.huge
+    local best_move_key = move_key(ordered[1])
 
-    local best_score = -SEARCH_INF
-    local best_move = nil
-
-    for _, move in ipairs(moves) do
-        make_move_internal(move[1], move[2], move[3], move[4], move[5])
-        local child_score, _, aborted = negamax(depth - 1, -beta, -alpha, ply + 1)
-        undo_move()
-
-        if aborted then
-            return nil, nil, true
+    for _, move in ipairs(ordered) do
+        if search_time_exceeded() then
+            return 0, nil, false
         end
+        make_move_internal(move[1], move[2], move[3], move[4], move[5])
+        local score, _, ok = negamax(depth - 1, -beta, -alpha)
+        undo_move()
+        if not ok then
+            return 0, nil, false
+        end
+        score = -score
 
-        local score = -child_score
         if score > best_score then
             best_score = score
-            best_move = clone_move(move)
+            best_move_key = move_key(move)
         end
-
         if score > alpha then
             alpha = score
         end
@@ -1013,125 +963,574 @@ local function negamax(depth, alpha, beta, ply)
         end
     end
 
-    local flag = TT_FLAG_EXACT
-    if best_score <= alpha_orig then
-        flag = TT_FLAG_UPPER
-    elseif best_score >= beta_orig then
-        flag = TT_FLAG_LOWER
+    local flag = "exact"
+    if best_score <= original_alpha then
+        flag = "upper"
+    elseif best_score >= beta then
+        flag = "lower"
     end
-    store_tt_entry(hash_key, depth, best_score, flag, best_move)
+    tt[key] = {
+        depth = depth,
+        score = best_score,
+        flag = flag,
+        best_move_key = best_move_key
+    }
 
-    return best_score, best_move, false
+    return best_score, best_move_key, true
 end
 
-local function choose_fallback_move()
-    local moves = generate_legal_moves()
-    if #moves == 0 then
-        return nil
+local function search_root(depth)
+    if search_time_exceeded() then
+        return 0, nil, false
     end
 
-    local best_move = moves[1]
-    local best_score = score_move_for_ordering(best_move, nil)
-    for i = 2, #moves do
-        local move = moves[i]
-        local score = score_move_for_ordering(move, nil)
+    local moves = generate_legal_moves()
+    if #moves == 0 then
+        return 0, nil, true
+    end
+
+    local entry = tt[string.format("%u", zobrist_hash)]
+    local ordered = order_moves(moves, entry and entry.best_move_key or nil)
+    local best_score = -math.huge
+    local best_move = ordered[1]
+    local alpha = -math.huge
+    local beta = math.huge
+
+    for _, move in ipairs(ordered) do
+        if search_time_exceeded() then
+            return 0, nil, false
+        end
+        make_move_internal(move[1], move[2], move[3], move[4], move[5])
+        local score, _, ok = negamax(depth - 1, -beta, -alpha)
+        undo_move()
+        if not ok then
+            return 0, nil, false
+        end
+        score = -score
+
         if score > best_score then
             best_score = score
             best_move = move
         end
+        if score > alpha then
+            alpha = score
+        end
     end
 
-    return clone_move(best_move)
+    return best_score, best_move, true
 end
 
-local function run_iterative_search(max_depth, time_limit_ms)
-    local start_clock = os.clock()
-    clear_transposition_table()
+local function search_best_move(max_depth, movetime_ms)
+    max_depth = tonumber(max_depth) or 3
+    if max_depth < 1 then max_depth = 1 end
+    if max_depth > 5 then max_depth = 5 end
 
-    local deadline_clock = nil
-    if time_limit_ms and time_limit_ms > 0 then
-        deadline_clock = start_clock + (time_limit_ms / 1000)
+    local legal_moves = generate_legal_moves()
+    if #legal_moves == 0 then
+        return nil, 0, 0, 0, false
     end
 
-    active_search = {
-        start_clock = start_clock,
-        deadline_clock = deadline_clock,
-        nodes = 0,
-        aborted = false
-    }
+    local start_clock = os.clock()
+    search_timed_out = false
+    search_stop_requested = false
+    search_deadline = nil
+    if movetime_ms and movetime_ms > 0 then
+        search_deadline = start_clock + (movetime_ms / 1000.0)
+    end
 
-    local best_score = nil
-    local best_move = nil
+    local best_move = legal_moves[1]
+    local best_score = evaluate_position()
+    if not white_to_move then
+        best_score = -best_score
+    end
     local completed_depth = 0
 
     for depth = 1, max_depth do
-        if search_should_abort(depth) then
+        local score, move, complete = search_root(depth)
+        if not complete then
             break
         end
-
-        local score, move, aborted = negamax(depth, -SEARCH_INF, SEARCH_INF, 0)
-        if aborted then
-            break
-        end
-
-        completed_depth = depth
-        best_score = score
-        best_move = clone_move(move)
-
-        if math.abs(score) >= MATE_SCORE - 128 then
-            break
+        if move then
+            best_move = move
+            best_score = score
+            completed_depth = depth
         end
     end
 
-    local elapsed_ms = math.floor((os.clock() - start_clock) * 1000)
-    active_search = nil
-
-    return best_score, best_move, completed_depth, elapsed_ms
-end
-
-local function perform_ai_search(max_depth, time_limit_ms, allow_fallback)
-    search_stop_requested = false
-
-    local eval, best_move, reached_depth, elapsed = run_iterative_search(max_depth, time_limit_ms)
-    if allow_fallback and not best_move then
-        best_move = choose_fallback_move()
-        if best_move then
-            eval = eval or 0
-        end
+    if completed_depth == 0 then
+        completed_depth = 1
     end
 
-    if not best_move then
-        return false, "ERROR: No legal moves"
-    end
-
-    make_move_internal(best_move[1], best_move[2], best_move[3], best_move[4], best_move[5])
-    return true, string.format(
-        "AI: %s (depth=%d, eval=%d, time=%d)",
-        move_to_string(best_move),
-        reached_depth,
-        math.floor(eval or 0),
-        elapsed
-    )
+    local elapsed = math.floor((os.clock() - start_clock) * 1000)
+    return best_move, best_score, completed_depth, elapsed, search_timed_out
 end
 
 -- AI move
-local function ai_move(depth)
-    depth = tonumber(depth) or 3
-    if depth < 1 or depth > 5 then
+local function ai_move(max_depth, movetime_ms)
+    max_depth = tonumber(max_depth) or 3
+    if max_depth < 1 or max_depth > 5 then
         return false, "ERROR: AI depth must be 1-5"
     end
 
-    return perform_ai_search(depth, nil, false)
+    local best_move, eval, depth_used, elapsed = search_best_move(max_depth, movetime_ms or 0)
+    if not best_move then
+        return false, "ERROR: No legal moves"
+    end
+    
+    local move_str = indices_to_algebraic(best_move[1], best_move[2]) .. 
+                     indices_to_algebraic(best_move[3], best_move[4])
+    if best_move[5] then
+        move_str = move_str .. best_move[5]
+    end
+    
+    make_move_internal(best_move[1], best_move[2], best_move[3], best_move[4], best_move[5])
+    
+    return true, string.format("AI: %s (depth=%d, eval=%d, time=%d)", move_str, depth_used, eval, elapsed)
 end
 
-local function ai_move_timed(time_limit_ms, max_depth)
-    local budget = tonumber(time_limit_ms)
-    if not budget or budget <= 0 then
-        return false, "ERROR: Search time must be > 0"
+local function derive_movetime_from_clock_args(tokens)
+    local values = {winc = 0, binc = 0, movestogo = 30}
+
+    local i = 1
+    while i <= #tokens do
+        local key = tokens[i]:lower()
+        local value_raw = tokens[i + 1]
+        if not value_raw then
+            return nil, string.format("go %s requires a value", key)
+        end
+        local value = tonumber(value_raw)
+        if not value then
+            return nil, string.format("go %s requires an integer value", key)
+        end
+
+        if key ~= "wtime" and key ~= "btime" and key ~= "winc" and key ~= "binc" and key ~= "movestogo" then
+            return nil, string.format("unsupported go parameter: %s", key)
+        end
+        values[key] = math.floor(value)
+        i = i + 2
     end
 
-    local depth_cap = max_depth or GO_MAX_DEPTH
-    return perform_ai_search(depth_cap, math.floor(budget), true)
+    if not values.wtime or not values.btime then
+        return nil, "go wtime/btime parameters are required"
+    end
+    if values.wtime <= 0 or values.btime <= 0 then
+        return nil, "go wtime/btime must be > 0"
+    end
+    if values.movestogo <= 0 then
+        values.movestogo = 30
+    end
+
+    local base = white_to_move and values.wtime or values.btime
+    local inc = white_to_move and values.winc or values.binc
+    local budget = math.floor(base / (values.movestogo + 1) + inc / 2)
+
+    if budget < 50 then
+        budget = 50
+    end
+    if budget >= base then
+        budget = math.floor(base / 2)
+    end
+    if budget <= 0 then
+        return nil, "unable to derive positive movetime from clocks"
+    end
+
+    return budget, nil
+end
+
+local function book_position_key_from_fen(fen)
+    local fields = {}
+    for token in tostring(fen):gmatch("%S+") do
+        table.insert(fields, token)
+    end
+    if #fields >= 4 then
+        return table.concat({fields[1], fields[2], fields[3], fields[4]}, " ")
+    end
+    return tostring(fen):gsub("^%s*(.-)%s*$", "%1")
+end
+
+local function parse_book_entries(content)
+    local parsed = {}
+    local total_entries = 0
+    local line_no = 0
+
+    for raw_line in tostring(content):gmatch("[^\r\n]+") do
+        line_no = line_no + 1
+        local line = raw_line:gsub("^%s*(.-)%s*$", "%1")
+        if line ~= "" and not line:match("^#") then
+            local left, right = line:match("^(.-)%s*%-%>%s*(.+)$")
+            if not left or not right then
+                return nil, nil, string.format("line %d: expected '<fen> -> <move> [weight]'", line_no)
+            end
+
+            local key = book_position_key_from_fen(left)
+            if key == "" then
+                return nil, nil, string.format("line %d: empty position key", line_no)
+            end
+
+            local rhs_tokens = {}
+            for token in right:gmatch("%S+") do
+                table.insert(rhs_tokens, token)
+            end
+            if #rhs_tokens == 0 then
+                return nil, nil, string.format("line %d: missing move", line_no)
+            end
+
+            local move = rhs_tokens[1]:lower()
+            if not move:match("^[a-h][1-8][a-h][1-8][qrbn]?$") then
+                return nil, nil, string.format("line %d: invalid move '%s'", line_no, move)
+            end
+
+            local weight = 1
+            if rhs_tokens[2] then
+                local parsed_weight = tonumber(rhs_tokens[2])
+                if not parsed_weight or parsed_weight % 1 ~= 0 then
+                    return nil, nil, string.format("line %d: invalid weight '%s'", line_no, rhs_tokens[2])
+                end
+                if parsed_weight <= 0 then
+                    return nil, nil, string.format("line %d: weight must be > 0", line_no)
+                end
+                weight = math.floor(parsed_weight)
+            end
+
+            if not parsed[key] then
+                parsed[key] = {}
+            end
+            table.insert(parsed[key], {move = move, weight = weight})
+            total_entries = total_entries + 1
+        end
+    end
+
+    return parsed, total_entries, nil
+end
+
+local function book_positions_count()
+    local count = 0
+    for _ in pairs(book_entries) do
+        count = count + 1
+    end
+    return count
+end
+
+local function choose_book_move()
+    book_lookups = book_lookups + 1
+    if not book_enabled or next(book_entries) == nil then
+        book_misses = book_misses + 1
+        return nil, nil
+    end
+
+    local key = book_position_key_from_fen(export_fen())
+    local entries = book_entries[key]
+    if not entries or #entries == 0 then
+        book_misses = book_misses + 1
+        return nil, nil
+    end
+
+    local legal_moves = generate_legal_moves()
+    local legal_by_notation = {}
+    for _, move in ipairs(legal_moves) do
+        local notation = indices_to_algebraic(move[1], move[2]) .. indices_to_algebraic(move[3], move[4])
+        if move[5] then
+            notation = notation .. tostring(move[5])
+        end
+        legal_by_notation[notation:lower()] = move
+    end
+
+    local weighted = {}
+    local total_weight = 0
+    for _, entry in ipairs(entries) do
+        local legal = legal_by_notation[entry.move]
+        if legal then
+            local weight = tonumber(entry.weight) or 1
+            if weight <= 0 then weight = 1 end
+            weight = math.floor(weight)
+            table.insert(weighted, {move = legal, notation = entry.move, weight = weight})
+            total_weight = total_weight + weight
+        end
+    end
+
+    if #weighted == 0 or total_weight <= 0 then
+        book_misses = book_misses + 1
+        return nil, nil
+    end
+
+    local selector = (math.abs(zobrist_hash) + book_lookups) % total_weight
+    local acc = 0
+    local chosen = weighted[1]
+    for _, item in ipairs(weighted) do
+        acc = acc + item.weight
+        if selector < acc then
+            chosen = item
+            break
+        end
+    end
+
+    book_hits = book_hits + 1
+    return chosen.move, chosen.notation
+end
+
+local function apply_book_move(best_move, move_str)
+    if not best_move then
+        return false
+    end
+
+    make_move_internal(best_move[1], best_move[2], best_move[3], best_move[4], best_move[5])
+    book_played = book_played + 1
+    print("AI: " .. move_str .. " (book)")
+    display_board()
+
+    local legal_moves = generate_legal_moves()
+    if #legal_moves == 0 then
+        if is_in_check(white_to_move) then
+            print("CHECKMATE: " .. (white_to_move and "Black" or "White") .. " wins")
+        else
+            print("STALEMATE: Draw")
+        end
+    elseif is_draw() then
+        local reason = is_draw_by_fifty_moves() and "50-move rule" or "repetition"
+        print("DRAW: by " .. reason)
+    end
+
+    return true
+end
+
+local function color_name(is_white)
+    return is_white and "white" or "black"
+end
+
+local function manhattan(a_rank, a_file, b_rank, b_file)
+    return math.abs(a_rank - b_rank) + math.abs(a_file - b_file)
+end
+
+local function non_king_material(counts)
+    return (counts.P or 0) + (counts.N or 0) + (counts.B or 0) + (counts.R or 0) + (counts.Q or 0)
+end
+
+local function detect_endgame_state()
+    local counts = {
+        white = {P = 0, N = 0, B = 0, R = 0, Q = 0, K = 0},
+        black = {P = 0, N = 0, B = 0, R = 0, Q = 0, K = 0},
+    }
+    local kings = {}
+    local pawns = {}
+    local rooks = {}
+    local queens = {}
+
+    for rank = 1, 8 do
+        for file = 1, 8 do
+            local piece = board[rank][file]
+            if piece ~= "." then
+                local upper = piece:upper()
+                local is_white = piece:match("%u") ~= nil
+                local color = is_white and "white" or "black"
+                counts[color][upper] = (counts[color][upper] or 0) + 1
+                if upper == "K" then
+                    kings[color] = {rank, file}
+                elseif upper == "P" and not pawns[color] then
+                    pawns[color] = {rank, file}
+                elseif upper == "R" and not rooks[color] then
+                    rooks[color] = {rank, file}
+                elseif upper == "Q" and not queens[color] then
+                    queens[color] = {rank, file}
+                end
+            end
+        end
+    end
+
+    if not kings.white or not kings.black then
+        return nil
+    end
+
+    local white_material = non_king_material(counts.white)
+    local black_material = non_king_material(counts.black)
+
+    -- KQK
+    if counts.white.Q == 1 and white_material == 1 and black_material == 0 then
+        local weak_king = kings.black
+        local strong_king = kings.white
+        local edge = math.min(weak_king[1] - 1, 8 - weak_king[1], weak_king[2] - 1, 8 - weak_king[2])
+        local king_distance = manhattan(strong_king[1], strong_king[2], weak_king[1], weak_king[2])
+        local score = 900 + (14 - king_distance) * 6 + (3 - edge) * 20
+        return {
+            type = "KQK",
+            strong_white = true,
+            weak_white = false,
+            score_white = score,
+            detail = "queen=" .. indices_to_algebraic(queens.white[1], queens.white[2]),
+        }
+    end
+    if counts.black.Q == 1 and black_material == 1 and white_material == 0 then
+        local weak_king = kings.white
+        local strong_king = kings.black
+        local edge = math.min(weak_king[1] - 1, 8 - weak_king[1], weak_king[2] - 1, 8 - weak_king[2])
+        local king_distance = manhattan(strong_king[1], strong_king[2], weak_king[1], weak_king[2])
+        local score = 900 + (14 - king_distance) * 6 + (3 - edge) * 20
+        return {
+            type = "KQK",
+            strong_white = false,
+            weak_white = true,
+            score_white = -score,
+            detail = "queen=" .. indices_to_algebraic(queens.black[1], queens.black[2]),
+        }
+    end
+
+    -- KPK
+    if counts.white.P == 1 and white_material == 1 and black_material == 0 then
+        local pawn = pawns.white
+        local strong_king = kings.white
+        local weak_king = kings.black
+        local promotion_rank, promotion_file = 8, pawn[2]
+        local pawn_steps = 8 - pawn[1]
+        local score = 120 + (6 - pawn_steps) * 35 +
+            manhattan(weak_king[1], weak_king[2], promotion_rank, promotion_file) * 6 -
+            manhattan(strong_king[1], strong_king[2], pawn[1], pawn[2]) * 8
+        if pawn_steps <= 1 then
+            score = score + 80
+        end
+        if score < 30 then
+            score = 30
+        end
+        return {
+            type = "KPK",
+            strong_white = true,
+            weak_white = false,
+            score_white = score,
+            detail = "pawn=" .. indices_to_algebraic(pawn[1], pawn[2]),
+        }
+    end
+    if counts.black.P == 1 and black_material == 1 and white_material == 0 then
+        local pawn = pawns.black
+        local strong_king = kings.black
+        local weak_king = kings.white
+        local promotion_rank, promotion_file = 1, pawn[2]
+        local pawn_steps = pawn[1] - 1
+        local score = 120 + (6 - pawn_steps) * 35 +
+            manhattan(weak_king[1], weak_king[2], promotion_rank, promotion_file) * 6 -
+            manhattan(strong_king[1], strong_king[2], pawn[1], pawn[2]) * 8
+        if pawn_steps <= 1 then
+            score = score + 80
+        end
+        if score < 30 then
+            score = 30
+        end
+        return {
+            type = "KPK",
+            strong_white = false,
+            weak_white = true,
+            score_white = -score,
+            detail = "pawn=" .. indices_to_algebraic(pawn[1], pawn[2]),
+        }
+    end
+
+    -- KRKP
+    if counts.white.R == 1 and white_material == 1 and counts.black.P == 1 and black_material == 1 then
+        local strong_king = kings.white
+        local weak_king = kings.black
+        local weak_pawn = pawns.black
+        local pawn_steps = weak_pawn[1] - 1
+        local score = 380 - pawn_steps * 25 +
+            (manhattan(weak_king[1], weak_king[2], weak_pawn[1], weak_pawn[2]) -
+                manhattan(strong_king[1], strong_king[2], weak_pawn[1], weak_pawn[2])) * 12
+        if score < 50 then
+            score = 50
+        end
+        return {
+            type = "KRKP",
+            strong_white = true,
+            weak_white = false,
+            score_white = score,
+            detail = "rook=" .. indices_to_algebraic(rooks.white[1], rooks.white[2]) ..
+                ",pawn=" .. indices_to_algebraic(weak_pawn[1], weak_pawn[2]),
+        }
+    end
+    if counts.black.R == 1 and black_material == 1 and counts.white.P == 1 and white_material == 1 then
+        local strong_king = kings.black
+        local weak_king = kings.white
+        local weak_pawn = pawns.white
+        local pawn_steps = 8 - weak_pawn[1]
+        local score = 380 - pawn_steps * 25 +
+            (manhattan(weak_king[1], weak_king[2], weak_pawn[1], weak_pawn[2]) -
+                manhattan(strong_king[1], strong_king[2], weak_pawn[1], weak_pawn[2])) * 12
+        if score < 50 then
+            score = 50
+        end
+        return {
+            type = "KRKP",
+            strong_white = false,
+            weak_white = true,
+            score_white = -score,
+            detail = "rook=" .. indices_to_algebraic(rooks.black[1], rooks.black[2]) ..
+                ",pawn=" .. indices_to_algebraic(weak_pawn[1], weak_pawn[2]),
+        }
+    end
+
+    return nil
+end
+
+local function choose_endgame_move()
+    local root_info = detect_endgame_state()
+    if not root_info then
+        return nil, nil, nil
+    end
+
+    local legal_moves = generate_legal_moves()
+    if #legal_moves == 0 then
+        return nil, nil, nil
+    end
+
+    local root_white = white_to_move
+    local best_move = legal_moves[1]
+    local best_move_str = indices_to_algebraic(best_move[1], best_move[2]) .. indices_to_algebraic(best_move[3], best_move[4])
+    if best_move[5] then
+        best_move_str = best_move_str .. best_move[5]
+    end
+    best_move_str = best_move_str:lower()
+    local best_score = -math.huge
+
+    for _, candidate in ipairs(legal_moves) do
+        make_move_internal(candidate[1], candidate[2], candidate[3], candidate[4], candidate[5])
+        local next_info = detect_endgame_state()
+        local score = next_info and next_info.score_white or evaluate_position()
+        if not root_white then
+            score = -score
+        end
+        local move_str = indices_to_algebraic(candidate[1], candidate[2]) .. indices_to_algebraic(candidate[3], candidate[4])
+        if candidate[5] then
+            move_str = move_str .. candidate[5]
+        end
+        move_str = move_str:lower()
+        if score > best_score or (score == best_score and move_str < best_move_str) then
+            best_score = score
+            best_move = candidate
+            best_move_str = move_str
+        end
+        undo_move()
+    end
+
+    return best_move, root_info, best_move_str
+end
+
+local function apply_endgame_move(best_move, info, move_str)
+    if not best_move then
+        return false
+    end
+
+    make_move_internal(best_move[1], best_move[2], best_move[3], best_move[4], best_move[5])
+    print(string.format("AI: %s (endgame %s, score=%d)", move_str, info.type, info.score_white))
+    display_board()
+
+    local legal_moves = generate_legal_moves()
+    if #legal_moves == 0 then
+        if is_in_check(white_to_move) then
+            print("CHECKMATE: " .. (white_to_move and "Black" or "White") .. " wins")
+        else
+            print("STALEMATE: Draw")
+        end
+    elseif is_draw() then
+        local reason = is_draw_by_fifty_moves() and "50-move rule" or "repetition"
+        print("DRAW: by " .. reason)
+    end
+
+    return true
 end
 
 local function load_pgn(path)
@@ -1333,51 +1732,147 @@ local function main()
             end
             print(string.format("  %d: %016x (current)", #position_history, zobrist_hash))
         elseif cmd == "go" then
-            local subcmd, subarg = arg:match("^(%S+)%s*(.*)$")
-            subcmd = subcmd and subcmd:lower() or ""
+            local tokens = {}
+            for token in arg:gmatch("%S+") do
+                table.insert(tokens, token)
+            end
+            local subcmd = tokens[1] and tokens[1]:lower() or ""
 
-            if subcmd == "movetime" then
-                local movetime = tonumber(subarg)
+            if subcmd == "depth" then
+                local depth = tonumber(tokens[2])
+                if not depth then
+                    print("ERROR: go depth requires an integer value")
+                else
+                    depth = math.floor(depth)
+                    if depth < 1 then depth = 1 end
+                    if depth > 5 then depth = 5 end
+                    local book_move, book_move_str = choose_book_move()
+                    if book_move and book_move_str then
+                        print("info string bookmove " .. book_move_str)
+                        print("bestmove " .. book_move_str)
+                        goto continue
+                    end
+                    local endgame_move, endgame_info, endgame_move_str = choose_endgame_move()
+                    if endgame_move and endgame_info and endgame_move_str then
+                        print(string.format("info string endgame %s score cp %d", endgame_info.type, endgame_info.score_white))
+                        print("bestmove " .. endgame_move_str)
+                        goto continue
+                    end
+                    local best_move, eval, depth_used, elapsed = search_best_move(depth, 0)
+                    if not best_move then
+                        print("bestmove 0000")
+                    else
+                        local move_str = indices_to_algebraic(best_move[1], best_move[2]) ..
+                                         indices_to_algebraic(best_move[3], best_move[4])
+                        if best_move[5] then
+                            move_str = move_str .. best_move[5]
+                        end
+                        print(string.format("info depth %d score cp %d time %d nodes 0", depth_used, eval, elapsed))
+                        print("bestmove " .. move_str)
+                    end
+                end
+            elseif subcmd == "movetime" then
+                local movetime = tonumber(tokens[2])
                 if not movetime then
                     print("ERROR: go movetime requires an integer value")
                 elseif movetime <= 0 then
                     print("ERROR: go movetime must be > 0")
                 else
-                    local depth = 5
-                    if movetime <= 200 then
-                        depth = 1
-                    elseif movetime <= 500 then
-                        depth = 2
-                    elseif movetime <= 2000 then
-                        depth = 3
-                    elseif movetime <= 5000 then
-                        depth = 4
-                    end
+                    local book_move, book_move_str = choose_book_move()
+                    if book_move and book_move_str then
+                        apply_book_move(book_move, book_move_str)
+                    else
+                        local endgame_move, endgame_info, endgame_move_str = choose_endgame_move()
+                        if endgame_move and endgame_info and endgame_move_str then
+                            apply_endgame_move(endgame_move, endgame_info, endgame_move_str)
+                        else
+                            local success, msg = ai_move(5, movetime)
+                            print(msg)
+                            if success then
+                                display_board()
 
-                    local success, msg = ai_move(depth)
-                    print(msg)
-                    if success then
-                        display_board()
-
-                        local legal_moves = generate_legal_moves()
-                        if #legal_moves == 0 then
-                            if is_in_check(white_to_move) then
-                                print("CHECKMATE: " .. (white_to_move and "Black" or "White") .. " wins")
-                            else
-                                print("STALEMATE: Draw")
+                                local legal_moves = generate_legal_moves()
+                                if #legal_moves == 0 then
+                                    if is_in_check(white_to_move) then
+                                        print("CHECKMATE: " .. (white_to_move and "Black" or "White") .. " wins")
+                                    else
+                                        print("STALEMATE: Draw")
+                                    end
+                                elseif is_draw() then
+                                    local reason = is_draw_by_fifty_moves() and "50-move rule" or "repetition"
+                                    print("DRAW: by " .. reason)
+                                end
                             end
-                        elseif is_draw() then
-                            local reason = is_draw_by_fifty_moves() and "50-move rule" or "repetition"
-                            print("DRAW: by " .. reason)
+                        end
+                    end
+                end
+            elseif subcmd == "wtime" then
+                local movetime, err = derive_movetime_from_clock_args(tokens)
+                if not movetime then
+                    print("ERROR: " .. err)
+                else
+                    local book_move, book_move_str = choose_book_move()
+                    if book_move and book_move_str then
+                        apply_book_move(book_move, book_move_str)
+                    else
+                        local endgame_move, endgame_info, endgame_move_str = choose_endgame_move()
+                        if endgame_move and endgame_info and endgame_move_str then
+                            apply_endgame_move(endgame_move, endgame_info, endgame_move_str)
+                        else
+                            local success, msg = ai_move(5, movetime)
+                            print(msg)
+                            if success then
+                                display_board()
+
+                                local legal_moves = generate_legal_moves()
+                                if #legal_moves == 0 then
+                                    if is_in_check(white_to_move) then
+                                        print("CHECKMATE: " .. (white_to_move and "Black" or "White") .. " wins")
+                                    else
+                                        print("STALEMATE: Draw")
+                                    end
+                                elseif is_draw() then
+                                    local reason = is_draw_by_fifty_moves() and "50-move rule" or "repetition"
+                                    print("DRAW: by " .. reason)
+                                end
+                            end
                         end
                     end
                 end
             elseif subcmd == "infinite" then
-                print("OK: go infinite acknowledged (use stop to terminate)")
+                print("OK: go infinite acknowledged (bounded search mode)")
+                local book_move, book_move_str = choose_book_move()
+                if book_move and book_move_str then
+                    apply_book_move(book_move, book_move_str)
+                else
+                    local endgame_move, endgame_info, endgame_move_str = choose_endgame_move()
+                    if endgame_move and endgame_info and endgame_move_str then
+                        apply_endgame_move(endgame_move, endgame_info, endgame_move_str)
+                    else
+                        local success, msg = ai_move(5, 15000)
+                        print(msg)
+                        if success then
+                            display_board()
+
+                            local legal_moves = generate_legal_moves()
+                            if #legal_moves == 0 then
+                                if is_in_check(white_to_move) then
+                                    print("CHECKMATE: " .. (white_to_move and "Black" or "White") .. " wins")
+                                else
+                                    print("STALEMATE: Draw")
+                                end
+                            elseif is_draw() then
+                                local reason = is_draw_by_fifty_moves() and "50-move rule" or "repetition"
+                                print("DRAW: by " .. reason)
+                            end
+                        end
+                    end
+                end
             else
                 print("ERROR: Unsupported go command")
             end
         elseif cmd == "stop" then
+            search_stop_requested = true
             print("OK: stop")
         elseif cmd == "pgn" then
             local subcmd, subarg = arg:match("^(%S+)%s*(.*)$")
@@ -1402,10 +1897,181 @@ local function main()
             else
                 print("ERROR: Unsupported pgn command")
             end
+        elseif cmd == "book" then
+            local subcmd, subarg = arg:match("^(%S+)%s*(.*)$")
+            subcmd = subcmd and subcmd:lower() or ""
+
+            if subcmd == "load" then
+                if not subarg or subarg == "" then
+                    print("ERROR: book load requires a file path")
+                else
+                    local file = io.open(subarg, "r")
+                    if not file then
+                        print("ERROR: book load failed: file unavailable")
+                    else
+                        local content = file:read("*a")
+                        file:close()
+                        local parsed, total_entries, err = parse_book_entries(content)
+                        if not parsed then
+                            print("ERROR: book load failed: " .. err)
+                        else
+                            book_path = subarg
+                            book_entries = parsed
+                            book_entry_count = total_entries
+                            book_enabled = true
+                            book_lookups = 0
+                            book_hits = 0
+                            book_misses = 0
+                            book_played = 0
+                            print(string.format(
+                                "BOOK: loaded path=\"%s\"; positions=%d; entries=%d; enabled=true",
+                                subarg,
+                                book_positions_count(),
+                                book_entry_count
+                            ))
+                        end
+                    end
+                end
+            elseif subcmd == "on" then
+                book_enabled = true
+                print("BOOK: enabled=true")
+            elseif subcmd == "off" then
+                book_enabled = false
+                print("BOOK: enabled=false")
+            elseif subcmd == "stats" then
+                local source = book_path or "(none)"
+                print(string.format(
+                    "BOOK: enabled=%s; path=%s; positions=%d; entries=%d; lookups=%d; hits=%d; misses=%d; played=%d",
+                    tostring(book_enabled),
+                    source,
+                    book_positions_count(),
+                    book_entry_count,
+                    book_lookups,
+                    book_hits,
+                    book_misses,
+                    book_played
+                ))
+            else
+                print("ERROR: Unsupported book command")
+            end
+        elseif cmd == "endgame" then
+            local info = detect_endgame_state()
+            if not info then
+                print(string.format("ENDGAME: type=none; active=%s; score=0", color_name(white_to_move)))
+            else
+                local best_move, _, best_move_str = choose_endgame_move()
+                local output = string.format(
+                    "ENDGAME: type=%s; strong=%s; weak=%s; score=%d",
+                    info.type,
+                    color_name(info.strong_white),
+                    color_name(info.weak_white),
+                    info.score_white
+                )
+                if best_move and best_move_str then
+                    output = output .. "; bestmove=" .. best_move_str
+                end
+                output = output .. "; detail=" .. info.detail
+                print(output)
+            end
         elseif cmd == "uci" then
             print("uciok")
         elseif cmd == "isready" then
             print("readyok")
+        elseif cmd == "setoption" then
+            local tokens = {}
+            for token in arg:gmatch("%S+") do
+                table.insert(tokens, token)
+            end
+            if #tokens < 4 or tokens[1]:lower() ~= "name" then
+                print("ERROR: setoption format is 'setoption name <Hash|Threads> value <n>'")
+            else
+                local value_idx = nil
+                for i = 2, #tokens do
+                    if tokens[i]:lower() == "value" then
+                        value_idx = i
+                        break
+                    end
+                end
+                if not value_idx or value_idx <= 2 or value_idx + 1 > #tokens then
+                    print("ERROR: setoption requires 'value <n>'")
+                else
+                    local option_name_parts = {}
+                    for i = 2, value_idx - 1 do
+                        table.insert(option_name_parts, tokens[i])
+                    end
+                    local option_name = table.concat(option_name_parts, " "):lower()
+                    local value = tonumber(tokens[value_idx + 1])
+                    if not value then
+                        print("ERROR: setoption value must be an integer")
+                    else
+                        value = math.floor(value)
+                        if option_name == "hash" then
+                            if value < 1 then value = 1 end
+                            if value > 1024 then value = 1024 end
+                            uci_hash_mb = value
+                            print(string.format("info string option Hash=%d", uci_hash_mb))
+                        elseif option_name == "threads" then
+                            if value < 1 then value = 1 end
+                            if value > 64 then value = 64 end
+                            uci_threads = value
+                            print(string.format("info string option Threads=%d", uci_threads))
+                        else
+                            print("info string unsupported option " .. table.concat(option_name_parts, " "))
+                        end
+                    end
+                end
+            end
+        elseif cmd == "ucinewgame" then
+            new_game()
+            tt = {}
+        elseif cmd == "position" then
+            local tokens = {}
+            for token in arg:gmatch("%S+") do
+                table.insert(tokens, token)
+            end
+            if #tokens == 0 then
+                print("ERROR: position requires 'startpos' or 'fen <...>'")
+            else
+                local idx = 1
+                local keyword = tokens[1]:lower()
+                if keyword == "startpos" then
+                    new_game()
+                    tt = {}
+                    idx = 2
+                elseif keyword == "fen" then
+                    idx = 2
+                    local fen_parts = {}
+                    while idx <= #tokens and tokens[idx]:lower() ~= "moves" do
+                        table.insert(fen_parts, tokens[idx])
+                        idx = idx + 1
+                    end
+                    if #fen_parts == 0 then
+                        print("ERROR: position fen requires a FEN string")
+                        goto continue
+                    end
+                    local success, msg = import_fen(table.concat(fen_parts, " "))
+                    if not success then
+                        print(msg)
+                        goto continue
+                    end
+                else
+                    print("ERROR: position requires 'startpos' or 'fen <...>'")
+                    goto continue
+                end
+
+                if idx <= #tokens and tokens[idx]:lower() == "moves" then
+                    idx = idx + 1
+                    while idx <= #tokens do
+                        local move_str = tokens[idx]
+                        local success, msg = execute_move(move_str)
+                        if not success then
+                            print("ERROR: position move " .. move_str .. " failed: " .. msg)
+                            break
+                        end
+                        idx = idx + 1
+                    end
+                end
+            end
         elseif cmd == "new960" then
             local id = tonumber(arg) or 0
             if id < 0 or id > 959 then
@@ -1484,22 +2150,32 @@ local function main()
             end
         elseif cmd == "ai" then
             local depth = tonumber(arg) or 3
-            local success, msg = ai_move(depth)
-            print(msg)
-            if success then
-                display_board()
-                
-                -- Check for game end
-                local legal_moves = generate_legal_moves()
-                if #legal_moves == 0 then
-                    if is_in_check(white_to_move) then
-                        print("CHECKMATE: " .. (white_to_move and "Black" or "White") .. " wins")
-                    else
-                        print("STALEMATE: Draw")
+            local book_move, book_move_str = choose_book_move()
+            if book_move and book_move_str then
+                apply_book_move(book_move, book_move_str)
+            else
+                local endgame_move, endgame_info, endgame_move_str = choose_endgame_move()
+                if endgame_move and endgame_info and endgame_move_str then
+                    apply_endgame_move(endgame_move, endgame_info, endgame_move_str)
+                else
+                    local success, msg = ai_move(depth)
+                    print(msg)
+                    if success then
+                        display_board()
+                        
+                        -- Check for game end
+                        local legal_moves = generate_legal_moves()
+                        if #legal_moves == 0 then
+                            if is_in_check(white_to_move) then
+                                print("CHECKMATE: " .. (white_to_move and "Black" or "White") .. " wins")
+                            else
+                                print("STALEMATE: Draw")
+                            end
+                        elseif is_draw() then
+                            local reason = is_draw_by_fifty_moves() and "50-move rule" or "repetition"
+                            print("DRAW: by " .. reason)
+                        end
                     end
-                elseif is_draw() then
-                    local reason = is_draw_by_fifty_moves() and "50-move rule" or "repetition"
-                    print("DRAW: by " .. reason)
                 end
             end
         elseif cmd == "eval" then
@@ -1521,11 +2197,18 @@ local function main()
             print("  draws            - Show draw detection status")
             print("  history          - Show position hash history")
             print("  go movetime <ms> - Time-managed AI move")
-            print("  go infinite      - Start infinite search mode (stub)")
+            print("  go wtime <ms> btime <ms> winc <ms> binc <ms> [movestogo <n>] - Clock-based timed move")
+            print("  go depth <n>     - UCI-style depth search (prints info/bestmove)")
+            print("  go infinite      - Start bounded long search mode")
             print("  stop             - Stop infinite search mode")
             print("  pgn load|show|moves - PGN command family")
+            print("  book load|on|off|stats - Native opening book controls")
+            print("  endgame          - Detect specialized endgame and best move hint")
             print("  uci              - Enter/respond to UCI handshake")
             print("  isready          - UCI readiness probe")
+            print("  setoption name <Hash|Threads> value <n> - Set UCI option")
+            print("  ucinewgame       - Reset internal state for UCI game")
+            print("  position startpos|fen ... [moves ...] - Load UCI position")
             print("  new960 [id]      - Start Chess960 game by id (0-959)")
             print("  position960      - Show current Chess960 metadata")
             print("  trace ...        - Trace controls and reports")

--- a/implementations/php/chess.php
+++ b/implementations/php/chess.php
@@ -23,8 +23,19 @@ class ChessEngine {
     private FenParser $fen_parser;
     private AI $ai;
     private Perft $perft;
+    private int $uci_hash_mb = 16;
+    private int $uci_threads = 1;
     private ?string $pgn_path = null;
     private array $pgn_moves = [];
+    private ?string $book_path = null;
+    private bool $book_enabled = false;
+    /** @var array<string,array<int,array{move:string,weight:int}>> */
+    private array $book_entries = [];
+    private int $book_entry_count = 0;
+    private int $book_lookups = 0;
+    private int $book_hits = 0;
+    private int $book_misses = 0;
+    private int $book_played = 0;
     private int $chess960_id = 0;
     private bool $trace_enabled = false;
     private string $trace_level = 'info';
@@ -129,6 +140,12 @@ class ChessEngine {
                 case 'pgn':
                     $this->handle_pgn(array_slice($parts, 1));
                     break;
+                case 'book':
+                    $this->handle_book(array_slice($parts, 1));
+                    break;
+                case 'endgame':
+                    $this->handle_endgame(array_slice($parts, 1));
+                    break;
 
                 case 'uci':
                     $this->handle_uci();
@@ -136,6 +153,18 @@ class ChessEngine {
 
                 case 'isready':
                     $this->handle_isready();
+                    break;
+
+                case 'setoption':
+                    $this->handle_setoption(array_slice($parts, 1));
+                    break;
+
+                case 'ucinewgame':
+                    $this->handle_ucinewgame();
+                    break;
+
+                case 'position':
+                    $this->handle_position(array_slice($parts, 1));
                     break;
 
                 case 'new960':
@@ -240,7 +269,7 @@ class ChessEngine {
         } else {
             require_once __DIR__ . '/lib/DrawDetection.php';
             if (DrawDetection::is_draw($this->board)) {
-                $reason = DrawDetection::is_draw_by_repetition($this->board) ? "repetition" : "50-move rule";
+                $reason = DrawDetection::is_draw_by_fifty_moves($this->board) ? "50-move rule" : "repetition";
                 echo "DRAW: by $reason\n";
             } else {
                 echo "OK: " . $move->to_string() . "\n";
@@ -270,45 +299,42 @@ class ChessEngine {
             echo "ERROR: AI depth must be 1-5\n";
             return;
         }
-        
-        $result = $this->ai->find_best_move($depth);
-        
-        if ($result === null) {
-            echo "ERROR: No legal moves available\n";
-            return;
-        }
-        
-        [$move, $eval, $time_ms] = $result;
-        $this->apply_ai_move($move, intval($eval), intval($time_ms), $depth);
+        $this->handle_ai_timed($depth, 0);
     }
 
-    private function handle_ai_move_timed(int $time_limit_ms, int $max_depth = 64): void {
-        if ($time_limit_ms <= 0) {
-            echo "ERROR: Time limit must be > 0\n";
-            return;
-        }
-
-        $result = $this->ai->find_best_move_timed($time_limit_ms, $max_depth);
-        if ($result === null) {
+    private function handle_ai_timed(int $max_depth, int $movetime_ms): void {
+        $legal_moves = $this->move_gen->generate_moves();
+        if (empty($legal_moves)) {
             echo "ERROR: No legal moves available\n";
             return;
         }
 
-        /** @var Move $move */
-        $move = $result['move'];
-        $eval = intval($result['score'] ?? 0);
-        $time_ms = intval($result['time_ms'] ?? 0);
-        $depth = max(1, intval($result['depth'] ?? 1));
-        $this->apply_ai_move($move, $eval, $time_ms, $depth);
-    }
+        $book_move = $this->choose_book_move($legal_moves);
+        if ($book_move !== null) {
+            $this->apply_book_move($book_move);
+            return;
+        }
 
-    private function apply_ai_move(Move $move, int $eval, int $time_ms, int $depth): void {
+        $endgame_choice = $this->choose_endgame_move($legal_moves);
+        if ($endgame_choice !== null) {
+            $this->apply_endgame_move($endgame_choice['move'], $endgame_choice['info']);
+            return;
+        }
+
+        [$move, $eval, $depth_used, $time_ms, ] = $this->ai->search($max_depth, $movetime_ms);
+
+        if ($move === null) {
+            echo "ERROR: No legal moves available\n";
+            return;
+        }
+
         $this->board->make_move($move);
+        echo "AI: " . $move->to_string() . " (depth=$depth_used, eval=$eval, time={$time_ms}ms)\n";
 
         // Check for game end first
         $is_checkmate = $this->move_gen->is_checkmate();
         $is_stalemate = $this->move_gen->is_stalemate();
-
+        
         if ($is_checkmate) {
             $winner = $this->board->current_player === CHESS_WHITE ? "Black" : "White";
             echo "CHECKMATE: $winner wins\n";
@@ -317,13 +343,11 @@ class ChessEngine {
         } else {
             require_once __DIR__ . '/lib/DrawDetection.php';
             if (DrawDetection::is_draw($this->board)) {
-                $reason = DrawDetection::is_draw_by_repetition($this->board) ? "repetition" : "50-move rule";
+                $reason = DrawDetection::is_draw_by_fifty_moves($this->board) ? "50-move rule" : "repetition";
                 echo "DRAW: by $reason\n";
-            } else {
-                echo "AI: " . $move->to_string() . " (depth=$depth, eval=$eval, time={$time_ms}ms)\n";
             }
         }
-
+        
         echo $this->board->display();
     }
     
@@ -381,11 +405,52 @@ class ChessEngine {
 
     private function handle_go(array $args): void {
         if (count($args) === 0) {
-            echo "ERROR: go requires subcommand (movetime|wtime|infinite)\n";
+            echo "ERROR: go requires subcommand (movetime <ms>|wtime <ms> btime <ms> winc <ms> binc <ms> [movestogo <n>]|infinite)\n";
             return;
         }
 
         $sub = strtolower($args[0]);
+        if ($sub === 'depth') {
+            if (!isset($args[1]) || !is_numeric($args[1])) {
+                echo "ERROR: go depth requires an integer value\n";
+                return;
+            }
+
+            $depth = intval($args[1]);
+            if ($depth < 1) {
+                $depth = 1;
+            } elseif ($depth > 5) {
+                $depth = 5;
+            }
+
+            $legal_moves = $this->move_gen->generate_moves();
+            $book_move = $this->choose_book_move($legal_moves);
+            if ($book_move !== null) {
+                $move_str = strtolower($book_move->to_string());
+                echo "info string bookmove {$move_str}\n";
+                echo "bestmove {$move_str}\n";
+                return;
+            }
+
+            $endgame_choice = $this->choose_endgame_move($legal_moves);
+            if ($endgame_choice !== null) {
+                $move_str = strtolower($endgame_choice['move']->to_string());
+                $info = $endgame_choice['info'];
+                echo "info string endgame {$info['type']} score cp {$info['score_white']}\n";
+                echo "bestmove {$move_str}\n";
+                return;
+            }
+
+            [$move, $eval, $depth_used, $time_ms, ] = $this->ai->search($depth, 0);
+            if ($move === null) {
+                echo "bestmove 0000\n";
+                return;
+            }
+            echo "info depth {$depth_used} score cp {$eval} time {$time_ms} nodes 0\n";
+            echo "bestmove " . $move->to_string() . "\n";
+            return;
+        }
+
         if ($sub === 'movetime') {
             if (!isset($args[1])) {
                 echo "ERROR: go movetime requires a value in milliseconds\n";
@@ -398,24 +463,23 @@ class ChessEngine {
                 return;
             }
 
-            $this->handle_ai_move_timed($movetime);
+            $this->handle_ai_timed(5, $movetime);
             return;
         }
 
-        if ($sub === 'wtime' || $sub === 'btime') {
-            $parsed = $this->parse_go_time_control($args);
-            if (is_string($parsed)) {
-                echo $parsed . "\n";
+        if ($sub === 'wtime') {
+            [$movetime, $error] = $this->derive_movetime_from_clock_args($args);
+            if ($error !== null) {
+                echo "ERROR: {$error}\n";
                 return;
             }
-
-            $movetime = $this->compute_go_movetime($parsed);
-            $this->handle_ai_move_timed($movetime);
+            $this->handle_ai_timed(5, $movetime);
             return;
         }
 
         if ($sub === 'infinite') {
-            $this->handle_ai_move_timed($this->infinite_go_budget_ms());
+            echo "OK: go infinite acknowledged (bounded search mode)\n";
+            $this->handle_ai_timed(5, 15000);
             return;
         }
 
@@ -425,6 +489,67 @@ class ChessEngine {
     private function handle_stop(): void {
         $this->ai->request_stop();
         echo "OK: stop\n";
+    }
+
+    /**
+     * @return array{0:int,1:?string}
+     */
+    private function derive_movetime_from_clock_args(array $args): array {
+        $values = [
+            'winc' => 0,
+            'binc' => 0,
+            'movestogo' => 30,
+        ];
+
+        $i = 0;
+        while ($i < count($args)) {
+            $key = strtolower(trim($args[$i]));
+            $i++;
+            if ($i >= count($args)) {
+                return [0, "go {$key} requires a value"];
+            }
+            if (!is_numeric($args[$i])) {
+                return [0, "go {$key} requires an integer value"];
+            }
+            $value = intval($args[$i]);
+            $i++;
+
+            if (!in_array($key, ['wtime', 'btime', 'winc', 'binc', 'movestogo'], true)) {
+                return [0, "unsupported go parameter: {$key}"];
+            }
+            $values[$key] = $value;
+        }
+
+        if (!isset($values['wtime']) || !isset($values['btime'])) {
+            return [0, 'go wtime/btime parameters are required'];
+        }
+        if ($values['wtime'] <= 0 || $values['btime'] <= 0) {
+            return [0, 'go wtime/btime must be > 0'];
+        }
+        if ($values['movestogo'] <= 0) {
+            $values['movestogo'] = 30;
+        }
+
+        if ($this->board->current_player === CHESS_WHITE) {
+            $base = $values['wtime'];
+            $inc = $values['winc'];
+        } else {
+            $base = $values['btime'];
+            $inc = $values['binc'];
+        }
+
+        $budget = intdiv($base, $values['movestogo'] + 1) + intdiv($inc, 2);
+        if ($budget < 50) {
+            $budget = 50;
+        }
+        if ($budget >= $base) {
+            $budget = intdiv($base, 2);
+        }
+        if ($budget <= 0) {
+            return [0, 'unable to derive positive movetime from clocks'];
+        }
+
+        return [$budget, null];
     }
 
     private function handle_pgn(array $args): void {
@@ -476,12 +601,217 @@ class ChessEngine {
         echo "ERROR: Unsupported pgn command\n";
     }
 
+    private function handle_book(array $args): void {
+        if (count($args) === 0) {
+            echo "ERROR: book requires subcommand (load|on|off|stats)\n";
+            return;
+        }
+
+        $sub = strtolower($args[0]);
+        if ($sub === 'load') {
+            if (!isset($args[1])) {
+                echo "ERROR: book load requires a file path\n";
+                return;
+            }
+            $path = implode(' ', array_slice($args, 1));
+            if (!is_readable($path)) {
+                echo "ERROR: book load failed: file not readable\n";
+                return;
+            }
+
+            $content = file_get_contents($path);
+            if ($content === false) {
+                echo "ERROR: book load failed: unable to read file\n";
+                return;
+            }
+
+            try {
+                [$entries, $total_entries] = $this->parse_book_entries($content);
+            } catch (\Exception $e) {
+                echo "ERROR: book load failed: " . $e->getMessage() . "\n";
+                return;
+            }
+
+            $this->book_path = $path;
+            $this->book_entries = $entries;
+            $this->book_entry_count = $total_entries;
+            $this->book_enabled = true;
+            $this->book_lookups = 0;
+            $this->book_hits = 0;
+            $this->book_misses = 0;
+            $this->book_played = 0;
+
+            echo 'BOOK: loaded path="' . $path . '"; positions=' . count($entries) .
+                 '; entries=' . $total_entries . '; enabled=true' . "\n";
+            return;
+        }
+
+        if ($sub === 'on') {
+            $this->book_enabled = true;
+            echo "BOOK: enabled=true\n";
+            return;
+        }
+
+        if ($sub === 'off') {
+            $this->book_enabled = false;
+            echo "BOOK: enabled=false\n";
+            return;
+        }
+
+        if ($sub === 'stats') {
+            $path = $this->book_path ?? '(none)';
+            echo "BOOK: enabled=" . ($this->book_enabled ? 'true' : 'false') .
+                 "; path={$path}; positions=" . count($this->book_entries) .
+                 "; entries={$this->book_entry_count}; lookups={$this->book_lookups}; " .
+                 "hits={$this->book_hits}; misses={$this->book_misses}; played={$this->book_played}\n";
+            return;
+        }
+
+        echo "ERROR: Unsupported book command\n";
+    }
+
+    private function handle_endgame(array $args): void {
+        $info = $this->detect_endgame_state();
+        if ($info === null) {
+            $active = $this->board->current_player === CHESS_WHITE ? 'white' : 'black';
+            echo "ENDGAME: type=none; active={$active}; score=0\n";
+            return;
+        }
+
+        $output = "ENDGAME: type={$info['type']}; strong=" . $this->color_name($info['strong']) .
+            "; weak=" . $this->color_name($info['weak']) . "; score={$info['score_white']}";
+        $legal_moves = $this->move_gen->generate_moves();
+        $choice = $this->choose_endgame_move($legal_moves);
+        if ($choice !== null) {
+            $output .= '; bestmove=' . strtolower($choice['move']->to_string());
+        }
+        $output .= '; detail=' . $info['detail'];
+        echo $output . "\n";
+    }
+
     private function handle_uci(): void {
         echo "uciok\n";
     }
 
     private function handle_isready(): void {
         echo "readyok\n";
+    }
+
+    private function handle_setoption(array $args): void {
+        if (count($args) < 4 || strtolower($args[0]) !== 'name') {
+            echo "ERROR: setoption format is 'setoption name <Hash|Threads> value <n>'\n";
+            return;
+        }
+
+        $value_idx = -1;
+        for ($i = 1; $i < count($args); $i++) {
+            if (strtolower($args[$i]) === 'value') {
+                $value_idx = $i;
+                break;
+            }
+        }
+        if ($value_idx <= 1 || $value_idx + 1 >= count($args)) {
+            echo "ERROR: setoption requires 'value <n>'\n";
+            return;
+        }
+
+        $name = strtolower(trim(implode(' ', array_slice($args, 1, $value_idx - 1))));
+        if (!is_numeric($args[$value_idx + 1])) {
+            echo "ERROR: setoption value must be an integer\n";
+            return;
+        }
+        $value = intval($args[$value_idx + 1]);
+
+        if ($name === 'hash') {
+            $this->uci_hash_mb = max(1, min(1024, $value));
+            echo "info string option Hash={$this->uci_hash_mb}\n";
+            return;
+        }
+
+        if ($name === 'threads') {
+            $this->uci_threads = max(1, min(64, $value));
+            echo "info string option Threads={$this->uci_threads}\n";
+            return;
+        }
+
+        $raw_name = trim(implode(' ', array_slice($args, 1, $value_idx - 1)));
+        echo "info string unsupported option {$raw_name}\n";
+    }
+
+    private function handle_ucinewgame(): void {
+        $this->board = new Board();
+        $this->move_gen = new MoveGenerator($this->board);
+        $this->fen_parser = new FenParser($this->board);
+        $this->ai = new AI($this->board, $this->move_gen);
+        $this->perft = new Perft($this->board, $this->move_gen);
+    }
+
+    private function handle_position(array $args): void {
+        if (count($args) === 0) {
+            echo "ERROR: position requires 'startpos' or 'fen <...>'\n";
+            return;
+        }
+
+        $idx = 0;
+        $keyword = strtolower($args[0]);
+        if ($keyword === 'startpos') {
+            $this->handle_ucinewgame();
+            $idx = 1;
+        } elseif ($keyword === 'fen') {
+            $idx = 1;
+            $fen_tokens = [];
+            while ($idx < count($args) && strtolower($args[$idx]) !== 'moves') {
+                $fen_tokens[] = $args[$idx];
+                $idx++;
+            }
+            if (empty($fen_tokens)) {
+                echo "ERROR: position fen requires a FEN string\n";
+                return;
+            }
+            if (!$this->fen_parser->load_fen(implode(' ', $fen_tokens))) {
+                echo "ERROR: Invalid FEN string\n";
+                return;
+            }
+        } else {
+            echo "ERROR: position requires 'startpos' or 'fen <...>'\n";
+            return;
+        }
+
+        if ($idx < count($args) && strtolower($args[$idx]) === 'moves') {
+            $idx++;
+            for (; $idx < count($args); $idx++) {
+                $err = $this->apply_move_silent($args[$idx]);
+                if ($err !== null) {
+                    echo "ERROR: position move {$args[$idx]} failed: {$err}\n";
+                    return;
+                }
+            }
+        }
+    }
+
+    private function apply_move_silent(string $move_str): ?string {
+        $move = $this->move_gen->parse_move($move_str);
+        if ($move === null) {
+            return 'Invalid move format';
+        }
+
+        $legal_moves = $this->move_gen->generate_moves();
+        $selected = null;
+        foreach ($legal_moves as $candidate) {
+            if ($candidate->from_row === $move->from_row &&
+                $candidate->from_col === $move->from_col &&
+                $candidate->to_row === $move->to_row &&
+                $candidate->to_col === $move->to_col) {
+                $selected = $candidate;
+                break;
+            }
+        }
+        if ($selected === null) {
+            return 'Illegal move';
+        }
+
+        $this->board->make_move($selected);
+        return null;
     }
 
     private function handle_new960(array $args): void {
@@ -628,80 +958,12 @@ class ChessEngine {
         }
     }
 
-    private function parse_go_time_control(array $args): array|string {
-        $options = [
-            'wtime' => null,
-            'btime' => null,
-            'winc' => null,
-            'binc' => null,
-            'movestogo' => null,
-        ];
-
-        $n = count($args);
-        for ($i = 0; $i < $n; $i += 2) {
-            $key = strtolower($args[$i]);
-            if (!array_key_exists($key, $options)) {
-                return "ERROR: Unsupported go parameter";
-            }
-            if (!isset($args[$i + 1])) {
-                return "ERROR: Missing value for go parameter '$key'";
-            }
-
-            $raw_value = trim($args[$i + 1]);
-            if (!preg_match('/^-?\d+$/', $raw_value)) {
-                return "ERROR: Invalid numeric value for go parameter '$key'";
-            }
-
-            $value = intval($raw_value);
-            if ($value < 0) {
-                return "ERROR: go parameter '$key' must be >= 0";
-            }
-
-            $options[$key] = $value;
-        }
-
-        foreach (['wtime', 'btime', 'winc', 'binc'] as $required) {
-            if ($options[$required] === null) {
-                return "ERROR: go wtime/btime/winc/binc are required";
-            }
-        }
-
-        if ($options['movestogo'] !== null && $options['movestogo'] <= 0) {
-            return "ERROR: go movestogo must be > 0";
-        }
-
-        return $options;
-    }
-
-    private function compute_go_movetime(array $options): int {
-        $is_white = $this->board->current_player === CHESS_WHITE;
-        $remaining = $is_white ? intval($options['wtime']) : intval($options['btime']);
-        $increment = $is_white ? intval($options['winc']) : intval($options['binc']);
-        $moves_to_go = intval($options['movestogo'] ?? 0);
-        if ($moves_to_go <= 0) {
-            $moves_to_go = 30;
-        }
-
-        if ($remaining <= 0) {
-            return 1;
-        }
-
-        $reserve = max(10, min(500, intdiv($remaining, 20)));
-        $spendable = max(1, $remaining - $reserve);
-        $base = intdiv($spendable, max(1, $moves_to_go));
-        $increment_share = intdiv($increment * 3, 4);
-        $budget = $base + $increment_share;
-
-        if ($remaining < 100) {
-            return max(1, min($remaining, 25));
-        }
-
-        return max(10, min($budget, $spendable));
-    }
-
-    private function infinite_go_budget_ms(): int {
-        // "infinite" is cooperative in this single-threaded CLI; use a long bounded search.
-        return 15000;
+    private function depth_for_movetime(int $movetime): int {
+        if ($movetime <= 200) return 1;
+        if ($movetime <= 500) return 2;
+        if ($movetime <= 2000) return 3;
+        if ($movetime <= 5000) return 4;
+        return 5;
     }
 
     private function get_repetition_count(): int {
@@ -752,6 +1014,375 @@ class ChessEngine {
         return $moves;
     }
 
+    private function book_position_key(string $fen): string {
+        $parts = preg_split('/\s+/', trim($fen)) ?: [];
+        if (count($parts) >= 4) {
+            return implode(' ', array_slice($parts, 0, 4));
+        }
+        return trim($fen);
+    }
+
+    /**
+     * @return array{0:array<string,array<int,array{move:string,weight:int}>>,1:int}
+     */
+    private function parse_book_entries(string $content): array {
+        $entries = [];
+        $total_entries = 0;
+        $lines = preg_split('/\R/', $content) ?: [];
+
+        foreach ($lines as $idx => $raw) {
+            $line_number = $idx + 1;
+            $line = trim($raw);
+            if ($line === '' || str_starts_with($line, '#')) {
+                continue;
+            }
+
+            if (strpos($line, '->') === false) {
+                throw new \RuntimeException("line {$line_number}: expected '<fen> -> <move> [weight]'");
+            }
+
+            [$left, $right] = array_map('trim', explode('->', $line, 2));
+            $key = $this->book_position_key($left);
+            if ($key === '') {
+                throw new \RuntimeException("line {$line_number}: empty position key");
+            }
+
+            $rhs_parts = preg_split('/\s+/', trim($right)) ?: [];
+            if (count($rhs_parts) === 0) {
+                throw new \RuntimeException("line {$line_number}: missing move");
+            }
+
+            $move = strtolower($rhs_parts[0]);
+            if (!preg_match('/^[a-h][1-8][a-h][1-8][qrbn]?$/', $move)) {
+                throw new \RuntimeException("line {$line_number}: invalid move '{$move}'");
+            }
+
+            $weight = 1;
+            if (isset($rhs_parts[1])) {
+                if (!is_numeric($rhs_parts[1])) {
+                    throw new \RuntimeException("line {$line_number}: invalid weight '{$rhs_parts[1]}'");
+                }
+                $weight = intval($rhs_parts[1]);
+                if ($weight <= 0) {
+                    throw new \RuntimeException("line {$line_number}: weight must be > 0");
+                }
+            }
+
+            if (!isset($entries[$key])) {
+                $entries[$key] = [];
+            }
+            $entries[$key][] = ['move' => $move, 'weight' => $weight];
+            $total_entries++;
+        }
+
+        return [$entries, $total_entries];
+    }
+
+    private function choose_book_move(array $legal_moves): ?Move {
+        $this->book_lookups++;
+        if (!$this->book_enabled || empty($this->book_entries)) {
+            $this->book_misses++;
+            return null;
+        }
+
+        $key = $this->book_position_key($this->fen_parser->export_fen());
+        $position_entries = $this->book_entries[$key] ?? [];
+        if (empty($position_entries)) {
+            $this->book_misses++;
+            return null;
+        }
+
+        $legal_by_notation = [];
+        foreach ($legal_moves as $move) {
+            $legal_by_notation[strtolower($move->to_string())] = $move;
+        }
+
+        $weighted = [];
+        $total_weight = 0;
+        foreach ($position_entries as $entry) {
+            $notation = $entry['move'];
+            if (!isset($legal_by_notation[$notation])) {
+                continue;
+            }
+            $weight = max(1, intval($entry['weight']));
+            $weighted[] = ['move' => $legal_by_notation[$notation], 'weight' => $weight];
+            $total_weight += $weight;
+        }
+
+        if (empty($weighted) || $total_weight <= 0) {
+            $this->book_misses++;
+            return null;
+        }
+
+        $seed = abs(intval($this->board->zobrist_hash)) + $this->book_lookups;
+        $selector = $seed % $total_weight;
+        $acc = 0;
+        $chosen = $weighted[0]['move'];
+        foreach ($weighted as $entry) {
+            $acc += $entry['weight'];
+            if ($selector < $acc) {
+                $chosen = $entry['move'];
+                break;
+            }
+        }
+
+        $this->book_hits++;
+        return $chosen;
+    }
+
+    private function apply_book_move(Move $move): void {
+        $this->board->make_move($move);
+        $this->book_played++;
+        $move_str = strtolower($move->to_string());
+
+        $is_checkmate = $this->move_gen->is_checkmate();
+        $is_stalemate = $this->move_gen->is_stalemate();
+
+        if ($is_checkmate) {
+            $winner = $this->board->current_player === CHESS_WHITE ? "Black" : "White";
+            echo "AI: {$move_str} (book, CHECKMATE: {$winner} wins)\n";
+        } elseif ($is_stalemate) {
+            echo "AI: {$move_str} (book, STALEMATE)\n";
+        } else {
+            require_once __DIR__ . '/lib/DrawDetection.php';
+            if (DrawDetection::is_draw($this->board)) {
+                $reason = DrawDetection::is_draw_by_fifty_moves($this->board) ? "50-move rule" : "repetition";
+                echo "AI: {$move_str} (book, DRAW: by {$reason})\n";
+            } else {
+                echo "AI: {$move_str} (book)\n";
+            }
+        }
+
+        echo $this->board->display();
+    }
+
+    private function color_name(int $color): string {
+        return $color === CHESS_WHITE ? 'white' : 'black';
+    }
+
+    private function square_to_algebraic(array $sq): string {
+        return chr(ord('a') + $sq[1]) . (8 - $sq[0]);
+    }
+
+    private function manhattan(array $a, array $b): int {
+        return abs($a[0] - $b[0]) + abs($a[1] - $b[1]);
+    }
+
+    private function non_king_material(array $counts, int $color): int {
+        return ($counts[$color][CHESS_PAWN] ?? 0) +
+            ($counts[$color][CHESS_KNIGHT] ?? 0) +
+            ($counts[$color][CHESS_BISHOP] ?? 0) +
+            ($counts[$color][CHESS_ROOK] ?? 0) +
+            ($counts[$color][CHESS_QUEEN] ?? 0);
+    }
+
+    private function detect_endgame_state(): ?array {
+        $piece_keys = [CHESS_EMPTY, CHESS_PAWN, CHESS_KNIGHT, CHESS_BISHOP, CHESS_ROOK, CHESS_QUEEN, CHESS_KING];
+        $counts = [
+            CHESS_WHITE => array_fill_keys($piece_keys, 0),
+            CHESS_BLACK => array_fill_keys($piece_keys, 0),
+        ];
+        $kings = [];
+        $pawns = [];
+        $rooks = [];
+        $queens = [];
+
+        for ($row = 0; $row < 8; $row++) {
+            for ($col = 0; $col < 8; $col++) {
+                [$piece, $color] = $this->board->get_piece($row, $col);
+                if ($piece === CHESS_EMPTY) {
+                    continue;
+                }
+                $counts[$color][$piece]++;
+                if ($piece === CHESS_KING) {
+                    $kings[$color] = [$row, $col];
+                } elseif ($piece === CHESS_PAWN && !isset($pawns[$color])) {
+                    $pawns[$color] = [$row, $col];
+                } elseif ($piece === CHESS_ROOK && !isset($rooks[$color])) {
+                    $rooks[$color] = [$row, $col];
+                } elseif ($piece === CHESS_QUEEN && !isset($queens[$color])) {
+                    $queens[$color] = [$row, $col];
+                }
+            }
+        }
+
+        if (!isset($kings[CHESS_WHITE]) || !isset($kings[CHESS_BLACK])) {
+            return null;
+        }
+
+        $white_material = $this->non_king_material($counts, CHESS_WHITE);
+        $black_material = $this->non_king_material($counts, CHESS_BLACK);
+
+        // KQK
+        if (($counts[CHESS_WHITE][CHESS_QUEEN] ?? 0) === 1 && $white_material === 1 && $black_material === 0) {
+            $weak_king = $kings[CHESS_BLACK];
+            $strong_king = $kings[CHESS_WHITE];
+            $edge = min($weak_king[0], 7 - $weak_king[0], $weak_king[1], 7 - $weak_king[1]);
+            $king_distance = $this->manhattan($strong_king, $weak_king);
+            $score = 900 + (14 - $king_distance) * 6 + (3 - $edge) * 20;
+            return [
+                'type' => 'KQK',
+                'strong' => CHESS_WHITE,
+                'weak' => CHESS_BLACK,
+                'score_white' => $score,
+                'detail' => 'queen=' . $this->square_to_algebraic($queens[CHESS_WHITE]),
+            ];
+        }
+        if (($counts[CHESS_BLACK][CHESS_QUEEN] ?? 0) === 1 && $black_material === 1 && $white_material === 0) {
+            $weak_king = $kings[CHESS_WHITE];
+            $strong_king = $kings[CHESS_BLACK];
+            $edge = min($weak_king[0], 7 - $weak_king[0], $weak_king[1], 7 - $weak_king[1]);
+            $king_distance = $this->manhattan($strong_king, $weak_king);
+            $score = 900 + (14 - $king_distance) * 6 + (3 - $edge) * 20;
+            return [
+                'type' => 'KQK',
+                'strong' => CHESS_BLACK,
+                'weak' => CHESS_WHITE,
+                'score_white' => -$score,
+                'detail' => 'queen=' . $this->square_to_algebraic($queens[CHESS_BLACK]),
+            ];
+        }
+
+        // KPK
+        if (($counts[CHESS_WHITE][CHESS_PAWN] ?? 0) === 1 && $white_material === 1 && $black_material === 0) {
+            $pawn = $pawns[CHESS_WHITE];
+            $strong_king = $kings[CHESS_WHITE];
+            $weak_king = $kings[CHESS_BLACK];
+            $promotion = [0, $pawn[1]];
+            $pawn_steps = $pawn[0];
+            $score = 120 + (6 - $pawn_steps) * 35 + $this->manhattan($weak_king, $promotion) * 6 - $this->manhattan($strong_king, $pawn) * 8;
+            if ($pawn_steps <= 1) {
+                $score += 80;
+            }
+            if ($score < 30) {
+                $score = 30;
+            }
+            return [
+                'type' => 'KPK',
+                'strong' => CHESS_WHITE,
+                'weak' => CHESS_BLACK,
+                'score_white' => $score,
+                'detail' => 'pawn=' . $this->square_to_algebraic($pawn),
+            ];
+        }
+        if (($counts[CHESS_BLACK][CHESS_PAWN] ?? 0) === 1 && $black_material === 1 && $white_material === 0) {
+            $pawn = $pawns[CHESS_BLACK];
+            $strong_king = $kings[CHESS_BLACK];
+            $weak_king = $kings[CHESS_WHITE];
+            $promotion = [7, $pawn[1]];
+            $pawn_steps = 7 - $pawn[0];
+            $score = 120 + (6 - $pawn_steps) * 35 + $this->manhattan($weak_king, $promotion) * 6 - $this->manhattan($strong_king, $pawn) * 8;
+            if ($pawn_steps <= 1) {
+                $score += 80;
+            }
+            if ($score < 30) {
+                $score = 30;
+            }
+            return [
+                'type' => 'KPK',
+                'strong' => CHESS_BLACK,
+                'weak' => CHESS_WHITE,
+                'score_white' => -$score,
+                'detail' => 'pawn=' . $this->square_to_algebraic($pawn),
+            ];
+        }
+
+        // KRKP
+        if (($counts[CHESS_WHITE][CHESS_ROOK] ?? 0) === 1 && $white_material === 1 &&
+            ($counts[CHESS_BLACK][CHESS_PAWN] ?? 0) === 1 && $black_material === 1) {
+            $strong_king = $kings[CHESS_WHITE];
+            $weak_king = $kings[CHESS_BLACK];
+            $weak_pawn = $pawns[CHESS_BLACK];
+            $pawn_steps = 7 - $weak_pawn[0];
+            $score = 380 - $pawn_steps * 25 + ($this->manhattan($weak_king, $weak_pawn) - $this->manhattan($strong_king, $weak_pawn)) * 12;
+            if ($score < 50) {
+                $score = 50;
+            }
+            return [
+                'type' => 'KRKP',
+                'strong' => CHESS_WHITE,
+                'weak' => CHESS_BLACK,
+                'score_white' => $score,
+                'detail' => 'rook=' . $this->square_to_algebraic($rooks[CHESS_WHITE]) . ',pawn=' . $this->square_to_algebraic($weak_pawn),
+            ];
+        }
+        if (($counts[CHESS_BLACK][CHESS_ROOK] ?? 0) === 1 && $black_material === 1 &&
+            ($counts[CHESS_WHITE][CHESS_PAWN] ?? 0) === 1 && $white_material === 1) {
+            $strong_king = $kings[CHESS_BLACK];
+            $weak_king = $kings[CHESS_WHITE];
+            $weak_pawn = $pawns[CHESS_WHITE];
+            $pawn_steps = $weak_pawn[0];
+            $score = 380 - $pawn_steps * 25 + ($this->manhattan($weak_king, $weak_pawn) - $this->manhattan($strong_king, $weak_pawn)) * 12;
+            if ($score < 50) {
+                $score = 50;
+            }
+            return [
+                'type' => 'KRKP',
+                'strong' => CHESS_BLACK,
+                'weak' => CHESS_WHITE,
+                'score_white' => -$score,
+                'detail' => 'rook=' . $this->square_to_algebraic($rooks[CHESS_BLACK]) . ',pawn=' . $this->square_to_algebraic($weak_pawn),
+            ];
+        }
+
+        return null;
+    }
+
+    private function choose_endgame_move(array $legal_moves): ?array {
+        $root_info = $this->detect_endgame_state();
+        if ($root_info === null || count($legal_moves) === 0) {
+            return null;
+        }
+
+        $root_color = $this->board->current_player;
+        $best_move = $legal_moves[0];
+        $best_notation = strtolower($best_move->to_string());
+        $best_score = -PHP_INT_MAX;
+
+        foreach ($legal_moves as $candidate) {
+            $this->board->make_move($candidate);
+            $next_info = $this->detect_endgame_state();
+            $score = $next_info !== null ? intval($next_info['score_white']) : $this->ai->evaluate();
+            if ($root_color === CHESS_BLACK) {
+                $score = -$score;
+            }
+            $notation = strtolower($candidate->to_string());
+            if ($score > $best_score || ($score === $best_score && $notation < $best_notation)) {
+                $best_score = $score;
+                $best_move = $candidate;
+                $best_notation = $notation;
+            }
+            $this->board->undo_move();
+        }
+
+        return ['move' => $best_move, 'info' => $root_info];
+    }
+
+    private function apply_endgame_move(Move $move, array $info): void {
+        $this->board->make_move($move);
+        $move_str = strtolower($move->to_string());
+        echo "AI: {$move_str} (endgame {$info['type']}, score={$info['score_white']})\n";
+
+        // Check for game end first
+        $is_checkmate = $this->move_gen->is_checkmate();
+        $is_stalemate = $this->move_gen->is_stalemate();
+        
+        if ($is_checkmate) {
+            $winner = $this->board->current_player === CHESS_WHITE ? "Black" : "White";
+            echo "CHECKMATE: $winner wins\n";
+        } elseif ($is_stalemate) {
+            echo "STALEMATE: Draw\n";
+        } else {
+            require_once __DIR__ . '/lib/DrawDetection.php';
+            if (DrawDetection::is_draw($this->board)) {
+                $reason = DrawDetection::is_draw_by_fifty_moves($this->board) ? "50-move rule" : "repetition";
+                echo "DRAW: by $reason\n";
+            }
+        }
+        
+        echo $this->board->display();
+    }
+
     private function handle_status(): void {
         $is_checkmate = $this->move_gen->is_checkmate();
         $is_stalemate = $this->move_gen->is_stalemate();
@@ -764,7 +1395,7 @@ class ChessEngine {
         } else {
             require_once __DIR__ . '/lib/DrawDetection.php';
             if (DrawDetection::is_draw($this->board)) {
-                $reason = DrawDetection::is_draw_by_repetition($this->board) ? "repetition" : "50-move rule";
+                $reason = DrawDetection::is_draw_by_fifty_moves($this->board) ? "50-move rule" : "repetition";
                 echo "DRAW: by $reason\n";
             } else {
                 echo "OK: ongoing\n";
@@ -800,12 +1431,18 @@ Available commands:
   draws                       - Show draw detection status
   history                     - Show position hash history
   go movetime <ms>            - Time-managed AI move
-  go wtime <ms> btime <ms> winc <ms> binc <ms> [movestogo <n>] - Clock-managed AI move
-  go infinite                 - Long bounded iterative search
-  stop                        - Cooperative stop request (backward-compatible)
+  go wtime <ms> btime <ms> winc <ms> binc <ms> [movestogo <n>] - Clock-based timed move
+  go depth <n>                - UCI-style depth search (prints info/bestmove)
+  go infinite                 - Start bounded long search mode
+  stop                        - Stop infinite search mode
   pgn load|show|moves         - PGN command family
+  book load|on|off|stats      - Native opening book controls
+  endgame                     - Detect specialized endgame and best move hint
   uci                         - Enter/respond to UCI handshake
   isready                     - UCI readiness probe
+  setoption name <Hash|Threads> value <n> - Set UCI option
+  ucinewgame                  - Reset internal state for UCI game
+  position startpos|fen ... [moves ...] - Load UCI position
   new960 [id]                 - Start Chess960 game by id (0-959)
   position960                 - Show current Chess960 metadata
   trace on|off|level|report   - Trace controls and summary

--- a/implementations/php/lib/AI.php
+++ b/implementations/php/lib/AI.php
@@ -7,362 +7,277 @@ require_once __DIR__ . '/Board.php';
 require_once __DIR__ . '/MoveGenerator.php';
 
 /**
- * AI with minimax and alpha-beta pruning
+ * AI with iterative deepening + negamax alpha-beta + transposition table.
  */
 class AI {
-    private const TT_FLAG_EXACT = 0;
-    private const TT_FLAG_LOWER = 1;
-    private const TT_FLAG_UPPER = 2;
-    private const SCORE_INF = 1000000000;
-    private const SCORE_MATE = 1000000;
+    private const MATE_VALUE = 100000;
+    private const INFINITY_SCORE = 1000000000;
 
     private Board $board;
     private MoveGenerator $move_gen;
     private array $tt = [];
-    private int $tt_max_entries = 200000;
-    private ?float $search_deadline = null;
+    private ?float $deadline = null;
+    private bool $timed_out = false;
     private bool $stop_requested = false;
-    private int $node_count = 0;
-    
+
     public function __construct(Board $board, MoveGenerator $move_gen) {
         $this->board = $board;
         $this->move_gen = $move_gen;
-    }
-    
-    public function find_best_move(int $depth): ?array {
-        $result = $this->search_with_iterative_deepening($depth, null);
-        if ($result === null) {
-            return null;
-        }
-
-        return [$result['move'], $result['score'], $result['time_ms']];
-    }
-
-    public function find_best_move_timed(int $time_limit_ms, int $max_depth = 64): ?array {
-        $max_depth = max(1, $max_depth);
-        $time_limit_ms = max(1, $time_limit_ms);
-        return $this->search_with_iterative_deepening($max_depth, $time_limit_ms);
     }
 
     public function request_stop(): void {
         $this->stop_requested = true;
     }
 
-    public function clear_stop_request(): void {
-        $this->stop_requested = false;
+    /**
+     * Backward-compatible API used by `ai <depth>`.
+     *
+     * @return array{0:Move,1:int,2:int}|null
+     */
+    public function find_best_move(int $depth): ?array {
+        [$move, $score, , $time_ms, ] = $this->search($depth, 0);
+        if ($move === null) {
+            return null;
+        }
+        return [$move, $score, $time_ms];
     }
 
-    private function search_with_iterative_deepening(int $max_depth, ?int $time_limit_ms): ?array {
-        $start_time = microtime(true);
-        $this->clear_stop_request();
-        $this->search_deadline = $time_limit_ms !== null ? ($start_time + ($time_limit_ms / 1000.0)) : null;
-        $this->node_count = 0;
-
-        $root_moves = $this->move_gen->generate_moves();
-        if (empty($root_moves)) {
-            $this->search_deadline = null;
-            return null;
-        }
-
-        $best_move = null;
-        $best_score = -self::SCORE_INF;
-        $best_depth = 0;
-
-        $tt_entry = $this->tt_lookup($this->board->zobrist_hash);
-        $root_hint = $tt_entry['best'] ?? null;
-        $ordered_root = $this->order_moves($root_moves, $root_hint);
-
-        for ($depth = 1; $depth <= $max_depth; $depth++) {
-            if ($this->should_stop_search()) {
-                break;
-            }
-
-            $iteration = $this->search_root($depth, $ordered_root);
-            if ($iteration === null) {
-                break;
-            }
-
-            $best_move = $iteration['move'];
-            $best_score = $iteration['score'];
-            $best_depth = $depth;
-            $ordered_root = $this->order_moves($root_moves, $iteration['best_sig']);
-        }
-
-        if ($best_move === null) {
-            $best_move = $ordered_root[0] ?? null;
-            if ($best_move === null) {
-                $this->search_deadline = null;
-                return null;
-            }
-            $best_score = 0;
-        }
-
-        $elapsed_ms = (int) round((microtime(true) - $start_time) * 1000);
-        $timed_out = $time_limit_ms !== null && $this->search_deadline !== null && microtime(true) >= $this->search_deadline;
-        $this->search_deadline = null;
-
-        return [
-            'move' => $best_move,
-            'score' => $best_score,
-            'time_ms' => $elapsed_ms,
-            'depth' => $best_depth,
-            'timed_out' => $timed_out,
-            'nodes' => $this->node_count,
-        ];
-    }
-
-    private function search_root(int $depth, array $moves): ?array {
-        $alpha = -self::SCORE_INF;
-        $beta = self::SCORE_INF;
-        $best_score = -self::SCORE_INF;
-        $best_move = null;
-        $best_sig = null;
-
-        foreach ($moves as $move) {
-            if ($this->should_stop_search()) {
-                return null;
-            }
-
-            $this->board->make_move($move);
-            $child_score = $this->negamax($depth - 1, -$beta, -$alpha, 1);
-            $this->board->undo_move();
-
-            if ($child_score === null) {
-                return null;
-            }
-
-            $score = -$child_score;
-            if ($score > $best_score) {
-                $best_score = $score;
-                $best_move = $move;
-                $best_sig = $this->move_signature($move);
-            }
-
-            if ($score > $alpha) {
-                $alpha = $score;
-            }
-            if ($alpha >= $beta) {
-                break;
-            }
-        }
-
-        if ($best_move === null) {
-            return null;
-        }
-
-        $this->tt_store(
-            $this->board->zobrist_hash,
-            $depth,
-            $best_score,
-            self::TT_FLAG_EXACT,
-            $best_sig
-        );
-
-        return ['move' => $best_move, 'score' => $best_score, 'best_sig' => $best_sig];
-    }
-
-    private function negamax(int $depth, int $alpha, int $beta, int $ply): ?int {
-        $this->node_count++;
-        if (($this->node_count & 2047) === 0 && $this->should_stop_search()) {
-            return null;
-        }
-
-        if ($this->should_stop_search()) {
-            return null;
-        }
-
-        if ($depth === 0) {
-            return $this->evaluate();
-        }
-
-        if ($this->move_gen->is_checkmate()) {
-            return -self::SCORE_MATE + $ply;
-        }
-
-        if ($this->move_gen->is_stalemate()) {
-            return 0;
-        }
-
-        $alpha_original = $alpha;
-        $beta_original = $beta;
-        $hash = $this->board->zobrist_hash;
-        $tt_entry = $this->tt_lookup($hash);
-        $best_hint = null;
-
-        if ($tt_entry !== null) {
-            $best_hint = $tt_entry['best'] ?? null;
-            if ($tt_entry['depth'] >= $depth) {
-                if ($tt_entry['flag'] === self::TT_FLAG_EXACT) {
-                    return $tt_entry['score'];
-                }
-
-                if ($tt_entry['flag'] === self::TT_FLAG_LOWER) {
-                    $alpha = max($alpha, $tt_entry['score']);
-                } elseif ($tt_entry['flag'] === self::TT_FLAG_UPPER) {
-                    $beta = min($beta, $tt_entry['score']);
-                }
-
-                if ($alpha >= $beta) {
-                    return $tt_entry['score'];
-                }
-            }
+    /**
+     * @return array{0:?Move,1:int,2:int,3:int,4:bool}
+     */
+    public function search(int $max_depth, int $movetime_ms = 0): array {
+        if ($max_depth < 1) {
+            $max_depth = 1;
+        } elseif ($max_depth > 5) {
+            $max_depth = 5;
         }
 
         $moves = $this->move_gen->generate_moves();
         if (empty($moves)) {
-            if ($this->move_gen->is_in_check()) {
-                return -self::SCORE_MATE + $ply;
-            }
-            return 0;
+            return [null, 0, 0, 0, false];
         }
 
-        $moves = $this->order_moves($moves, $best_hint);
-        $best_score = -self::SCORE_INF;
-        $best_sig = null;
+        $this->timed_out = false;
+        $this->stop_requested = false;
+        $start = microtime(true);
+        $this->deadline = $movetime_ms > 0 ? ($start + ($movetime_ms / 1000.0)) : null;
 
-        foreach ($moves as $move) {
+        $best_move = $moves[0];
+        $best_score = $this->evaluate();
+        $completed_depth = 0;
+
+        for ($depth = 1; $depth <= $max_depth; $depth++) {
+            [$score, $move, $complete] = $this->search_root($depth);
+            if (!$complete) {
+                break;
+            }
+            if ($move !== null) {
+                $best_move = $move;
+                $best_score = $score;
+                $completed_depth = $depth;
+            }
+        }
+
+        if ($completed_depth === 0) {
+            $completed_depth = 1;
+        }
+
+        $elapsed_ms = (int) round((microtime(true) - $start) * 1000);
+        return [$best_move, $best_score, $completed_depth, $elapsed_ms, $this->timed_out];
+    }
+
+    /**
+     * @return array{0:int,1:?Move,2:bool}
+     */
+    private function search_root(int $depth): array {
+        if ($this->time_exceeded()) {
+            return [0, null, false];
+        }
+
+        $moves = $this->move_gen->generate_moves();
+        if (empty($moves)) {
+            return [0, null, true];
+        }
+
+        $entry = $this->tt[(string) $this->board->zobrist_hash] ?? null;
+        $tt_move = $entry['best_move'] ?? null;
+        $ordered = $this->order_moves($moves, $tt_move);
+
+        $alpha = -self::INFINITY_SCORE;
+        $beta = self::INFINITY_SCORE;
+        $best_score = -self::INFINITY_SCORE;
+        $best_move = $ordered[0] ?? null;
+
+        foreach ($ordered as $move) {
+            if ($this->time_exceeded()) {
+                return [0, null, false];
+            }
             $this->board->make_move($move);
-            $child_score = $this->negamax($depth - 1, -$beta, -$alpha, $ply + 1);
+            [$score, , $ok] = $this->negamax($depth - 1, -$beta, -$alpha);
             $this->board->undo_move();
 
-            if ($child_score === null) {
-                return null;
+            if (!$ok) {
+                return [0, null, false];
             }
 
-            $score = -$child_score;
+            $score = -$score;
             if ($score > $best_score) {
                 $best_score = $score;
-                $best_sig = $this->move_signature($move);
+                $best_move = $move;
             }
-
             if ($score > $alpha) {
                 $alpha = $score;
             }
+        }
 
+        return [$best_score, $best_move, true];
+    }
+
+    /**
+     * @return array{0:int,1:?Move,2:bool}
+     */
+    private function negamax(int $depth, int $alpha, int $beta): array {
+        if ($this->time_exceeded()) {
+            return [0, null, false];
+        }
+
+        $original_alpha = $alpha;
+        $key = (string) $this->board->zobrist_hash;
+        $best_from_tt = null;
+        $entry = $this->tt[$key] ?? null;
+        if ($entry !== null && $entry['depth'] >= $depth) {
+            if ($entry['flag'] === 'exact') {
+                return [$entry['score'], $entry['best_move'], true];
+            }
+            if ($entry['flag'] === 'lower') {
+                $alpha = max($alpha, $entry['score']);
+            } elseif ($entry['flag'] === 'upper') {
+                $beta = min($beta, $entry['score']);
+            }
+            if ($alpha >= $beta) {
+                return [$entry['score'], $entry['best_move'], true];
+            }
+            $best_from_tt = $entry['best_move'];
+        }
+
+        if ($depth === 0) {
+            return [$this->evaluate(), null, true];
+        }
+
+        if ($this->move_gen->is_checkmate()) {
+            return [-self::MATE_VALUE + $depth, null, true];
+        }
+        if ($this->move_gen->is_stalemate()) {
+            return [0, null, true];
+        }
+
+        $moves = $this->move_gen->generate_moves();
+        if (empty($moves)) {
+            return [0, null, true];
+        }
+
+        $ordered = $this->order_moves($moves, $best_from_tt);
+        $best_score = -self::INFINITY_SCORE;
+        $best_move = $ordered[0] ?? null;
+
+        foreach ($ordered as $move) {
+            if ($this->time_exceeded()) {
+                return [0, null, false];
+            }
+            $this->board->make_move($move);
+            [$score, , $ok] = $this->negamax($depth - 1, -$beta, -$alpha);
+            $this->board->undo_move();
+
+            if (!$ok) {
+                return [0, null, false];
+            }
+            $score = -$score;
+
+            if ($score > $best_score) {
+                $best_score = $score;
+                $best_move = $move;
+            }
+            if ($score > $alpha) {
+                $alpha = $score;
+            }
             if ($alpha >= $beta) {
                 break;
             }
         }
 
-        $flag = self::TT_FLAG_EXACT;
-        if ($best_score <= $alpha_original) {
-            $flag = self::TT_FLAG_UPPER;
-        } elseif ($best_score >= $beta_original) {
-            $flag = self::TT_FLAG_LOWER;
-        }
-
-        $this->tt_store($hash, $depth, $best_score, $flag, $best_sig);
-        return $best_score;
-    }
-
-    private function should_stop_search(): bool {
-        if ($this->stop_requested) {
-            return true;
-        }
-        if ($this->search_deadline === null) {
-            return false;
-        }
-        return microtime(true) >= $this->search_deadline;
-    }
-
-    private function tt_lookup(int $hash): ?array {
-        $key = $this->tt_key($hash);
-        return $this->tt[$key] ?? null;
-    }
-
-    private function tt_store(int $hash, int $depth, int $score, int $flag, ?array $best_sig): void {
-        $key = $this->tt_key($hash);
-        $existing = $this->tt[$key] ?? null;
-        if ($existing !== null && $existing['depth'] > $depth) {
-            return;
-        }
-
-        if (count($this->tt) >= $this->tt_max_entries) {
-            // Simple bounded table policy to keep memory use deterministic.
-            $this->tt = [];
+        $flag = 'exact';
+        if ($best_score <= $original_alpha) {
+            $flag = 'upper';
+        } elseif ($best_score >= $beta) {
+            $flag = 'lower';
         }
 
         $this->tt[$key] = [
             'depth' => $depth,
-            'score' => $score,
+            'score' => $best_score,
             'flag' => $flag,
-            'best' => $best_sig,
+            'best_move' => $best_move,
         ];
+
+        return [$best_score, $best_move, true];
     }
 
-    private function tt_key(int $hash): string {
-        return (string) sprintf('%u', $hash);
-    }
-
-    private function order_moves(array $moves, ?array $tt_best_sig): array {
-        $scored = [];
-        foreach ($moves as $idx => $move) {
-            $score = $this->move_order_score($move);
-            if ($tt_best_sig !== null && $this->move_matches_signature($move, $tt_best_sig)) {
-                $score += 1000000;
-            }
-            $scored[] = ['idx' => $idx, 'score' => $score, 'move' => $move];
-        }
-
-        usort($scored, function(array $a, array $b): int {
-            if ($a['score'] === $b['score']) {
-                return $a['idx'] <=> $b['idx'];
-            }
-            return $b['score'] <=> $a['score'];
+    /**
+     * @param Move[] $moves
+     * @return Move[]
+     */
+    private function order_moves(array $moves, ?Move $tt_move = null): array {
+        usort($moves, function (Move $a, Move $b) use ($tt_move): int {
+            return $this->move_ordering_score($b, $tt_move) <=> $this->move_ordering_score($a, $tt_move);
         });
-
-        $ordered = [];
-        foreach ($scored as $entry) {
-            $ordered[] = $entry['move'];
-        }
-        return $ordered;
+        return $moves;
     }
 
-    private function move_order_score(Move $move): int {
+    private function move_ordering_score(Move $move, ?Move $tt_move): int {
         $score = 0;
-
-        [$moving_piece, $_] = $this->board->get_piece($move->from_row, $move->from_col);
-        [$target_piece, $_target_color] = $this->board->get_piece($move->to_row, $move->to_col);
-
-        if ($move->is_en_passant) {
-            $score += 5000;
-        } elseif ($target_piece !== CHESS_EMPTY) {
-            $score += 5000 + CHESS_PIECE_VALUES[$target_piece] - intdiv(CHESS_PIECE_VALUES[$moving_piece], 10);
+        if ($tt_move !== null && $this->same_move($move, $tt_move)) {
+            $score += 100000;
         }
 
+        [$target_piece, ] = $this->board->get_piece($move->to_row, $move->to_col);
+        if ($target_piece !== CHESS_EMPTY) {
+            $score += 10000 + CHESS_PIECE_VALUES[$target_piece];
+        }
         if ($move->promotion !== null) {
             $score += 9000 + CHESS_PIECE_VALUES[$move->promotion];
         }
-
         if ($move->is_castling) {
-            $score += 50;
+            $score += 100;
         }
-
         return $score;
     }
 
-    private function move_signature(Move $move): array {
-        return [
-            'from_row' => $move->from_row,
-            'from_col' => $move->from_col,
-            'to_row' => $move->to_row,
-            'to_col' => $move->to_col,
-            'promotion' => $move->promotion,
-            'is_castling' => $move->is_castling,
-            'is_en_passant' => $move->is_en_passant,
-        ];
+    private function same_move(?Move $a, ?Move $b): bool {
+        if ($a === null || $b === null) {
+            return false;
+        }
+        return $a->from_row === $b->from_row &&
+            $a->from_col === $b->from_col &&
+            $a->to_row === $b->to_row &&
+            $a->to_col === $b->to_col &&
+            $a->promotion === $b->promotion;
     }
 
-    private function move_matches_signature(Move $move, array $sig): bool {
-        return $move->from_row === $sig['from_row']
-            && $move->from_col === $sig['from_col']
-            && $move->to_row === $sig['to_row']
-            && $move->to_col === $sig['to_col']
-            && $move->promotion === $sig['promotion']
-            && $move->is_castling === $sig['is_castling']
-            && $move->is_en_passant === $sig['is_en_passant'];
+    private function time_exceeded(): bool {
+        if ($this->stop_requested) {
+            $this->timed_out = true;
+            return true;
+        }
+        if ($this->deadline === null) {
+            return false;
+        }
+        if (microtime(true) >= $this->deadline) {
+            $this->timed_out = true;
+            return true;
+        }
+        return false;
     }
-
+    
     public function evaluate(): int {
         $score = 0;
         

--- a/implementations/python/chess.py
+++ b/implementations/python/chess.py
@@ -8,7 +8,7 @@ import sys
 import re
 import json
 import time
-from typing import Optional, Dict
+from typing import Optional
 from lib.board import Board
 from lib.move_generator import MoveGenerator
 from lib.fen_parser import FenParser
@@ -19,8 +19,6 @@ from lib.types import Move, Color, PieceType
 
 class ChessEngine:
     """Main chess engine class that handles user commands and game flow."""
-    GO_MAX_DEPTH = 5
-    GO_INFINITE_MOVETIME_MS = 10000
     
     def __init__(self):
         self.board = Board()
@@ -32,6 +30,16 @@ class ChessEngine:
         self._go_infinite = False
         self._pgn_path: Optional[str] = None
         self._pgn_moves = []
+        self._book_path: Optional[str] = None
+        self._book_enabled = False
+        self._book_entries = {}
+        self._book_entry_count = 0
+        self._book_lookups = 0
+        self._book_hits = 0
+        self._book_misses = 0
+        self._book_played = 0
+        self._uci_hash_mb = 16
+        self._uci_threads = 1
         self._chess960_id = 0
         self._trace_enabled = False
         self._trace_level = 'info'
@@ -106,10 +114,20 @@ class ChessEngine:
                 self.handle_stop()
             elif cmd == 'pgn':
                 self.handle_pgn(parts[1:])
+            elif cmd == 'book':
+                self.handle_book(parts[1:])
+            elif cmd == 'endgame':
+                self.handle_endgame(parts[1:])
             elif cmd == 'uci':
                 self.handle_uci()
             elif cmd == 'isready':
                 self.handle_isready()
+            elif cmd == 'setoption':
+                self.handle_setoption(parts[1:])
+            elif cmd == 'ucinewgame':
+                self.handle_ucinewgame()
+            elif cmd == 'position':
+                self.handle_position(parts[1:])
             elif cmd == 'new960':
                 self.handle_new960(parts[1:])
             elif cmd == 'position960':
@@ -228,33 +246,26 @@ class ChessEngine:
         if not (1 <= depth <= 5):
             print('ERROR: AI depth must be 1-5')
             return
-        
-        start_time = time.time()
-        
-        best_move, eval_score = self.ai.get_best_move(depth)
-        
-        end_time = time.time()
-        elapsed_ms = int((end_time - start_time) * 1000)
-        self._apply_ai_move(best_move, eval_score, depth, elapsed_ms)
+        self.handle_ai_timed(depth, 0)
 
-    def handle_ai_timed_move(self, movetime_ms: int, max_depth: int = GO_MAX_DEPTH):
-        """Handle time-managed AI move."""
-        if movetime_ms <= 0:
-            print('ERROR: movetime must be > 0')
+    def handle_ai_timed(self, max_depth: int, movetime_ms: int):
+        """Handle time-managed AI search."""
+        legal_moves = self.move_generator.generate_legal_moves()
+        if not legal_moves:
+            print('ERROR: No legal moves available')
             return
 
-        bounded_depth = max(1, min(max_depth, self.GO_MAX_DEPTH))
-        start_time = time.time()
-        best_move, eval_score, completed_depth = self.ai.get_best_move_timed(
-            movetime_ms,
-            max_depth=bounded_depth
-        )
-        elapsed_ms = int((time.time() - start_time) * 1000)
-        reported_depth = completed_depth if completed_depth > 0 else 1
-        self._apply_ai_move(best_move, eval_score, reported_depth, elapsed_ms)
+        book_move = self._choose_book_move(legal_moves)
+        if book_move is not None:
+            self._apply_book_move(book_move)
+            return
 
-    def _apply_ai_move(self, best_move: Optional[Move], eval_score: int, depth: int, elapsed_ms: int):
-        """Apply a computed AI move and print standard outputs."""
+        endgame_choice = self._choose_endgame_move(legal_moves)
+        if endgame_choice is not None:
+            self._apply_endgame_move(endgame_choice[0], endgame_choice[1])
+            return
+
+        best_move, eval_score, depth_used, elapsed_ms, _ = self.ai.search(max_depth, movetime_ms)
         if not best_move:
             print('ERROR: No legal moves available')
             return
@@ -263,11 +274,10 @@ class ChessEngine:
         self.board.make_move(best_move)
 
         move_str = best_move.to_algebraic()
-        print(f'AI: {move_str} (depth={depth}, eval={eval_score}, time={elapsed_ms}ms)')
+        print(f'AI: {move_str} (depth={depth_used}, eval={eval_score}, time={elapsed_ms}ms)')
 
         print(self.board.display())
 
-        # Check for game end
         game_status = self.board.get_game_status()
         if game_status == 'checkmate':
             winner = 'Black' if self.board.to_move == Color.WHITE else 'White'
@@ -342,6 +352,45 @@ class ChessEngine:
             return
 
         subcommand = args[0].lower()
+        if subcommand == 'depth':
+            if len(args) < 2:
+                print('ERROR: go depth requires a value')
+                return
+            try:
+                depth = int(args[1])
+            except ValueError:
+                print('ERROR: go depth requires an integer value')
+                return
+
+            if depth < 1:
+                depth = 1
+            if depth > 5:
+                depth = 5
+
+            legal_moves = self.move_generator.generate_legal_moves()
+            book_move = self._choose_book_move(legal_moves)
+            if book_move is not None:
+                move_str = book_move.to_algebraic()
+                print(f'info string bookmove {move_str}')
+                print(f'bestmove {move_str}')
+                return
+
+            endgame_choice = self._choose_endgame_move(legal_moves)
+            if endgame_choice is not None:
+                move, info = endgame_choice
+                move_str = move.to_algebraic()
+                print(f'info string endgame {info["type"]} score cp {info["score_white"]}')
+                print(f'bestmove {move_str}')
+                return
+
+            best_move, eval_score, depth_used, elapsed_ms, _ = self.ai.search(depth, 0)
+            if not best_move:
+                print('bestmove 0000')
+                return
+            print(f'info depth {depth_used} score cp {eval_score} time {elapsed_ms} nodes 0')
+            print(f'bestmove {best_move.to_algebraic()}')
+            return
+
         if subcommand == 'movetime':
             if len(args) < 2:
                 print('ERROR: go movetime requires a value in milliseconds')
@@ -356,24 +405,21 @@ class ChessEngine:
                 print('ERROR: go movetime must be > 0')
                 return
 
-            self.handle_ai_timed_move(movetime_ms, max_depth=self.GO_MAX_DEPTH)
+            self.handle_ai_timed(5, movetime_ms)
+            return
+
+        if subcommand == 'wtime':
+            movetime_ms, error = self._derive_movetime_from_clock_args(args)
+            if error is not None:
+                print(f'ERROR: {error}')
+                return
+            self.handle_ai_timed(5, movetime_ms)
             return
 
         if subcommand == 'infinite':
             self._go_infinite = True
-            try:
-                # Wave-1 cooperative behavior: bounded long search instead of pure ack-only stub.
-                self.handle_ai_timed_move(self.GO_INFINITE_MOVETIME_MS, max_depth=self.GO_MAX_DEPTH)
-            finally:
-                self._go_infinite = False
-            return
-
-        if subcommand in ('wtime', 'btime', 'winc', 'binc', 'movestogo'):
-            controls = self._parse_go_time_controls(args)
-            if controls is None:
-                return
-            movetime_ms = self._compute_go_movetime(controls)
-            self.handle_ai_timed_move(movetime_ms, max_depth=self.GO_MAX_DEPTH)
+            print('OK: go infinite acknowledged (bounded search mode)')
+            self.handle_ai_timed(5, 15000)
             return
 
         print('ERROR: Unsupported go command')
@@ -381,76 +427,50 @@ class ChessEngine:
     def handle_stop(self):
         """Handle stop command."""
         self._go_infinite = False
+        self.ai.request_stop()
         print('OK: stop')
 
-    def _parse_go_time_controls(self, args) -> Optional[Dict[str, int]]:
-        """Parse key-value go time controls."""
-        allowed = {'wtime', 'btime', 'winc', 'binc', 'movestogo'}
-        parsed: Dict[str, int] = {}
-        idx = 0
-
-        while idx < len(args):
-            key = args[idx].lower()
-            if key not in allowed:
-                print(f'ERROR: Unsupported go parameter: {key}')
-                return None
-
-            if idx + 1 >= len(args):
-                print(f'ERROR: go {key} requires an integer value')
-                return None
-
-            if key in parsed:
-                print(f'ERROR: Duplicate go parameter: {key}')
-                return None
-
+    def _derive_movetime_from_clock_args(self, args):
+        """Derive think time from go wtime/btime/winc/binc controls."""
+        values = {'winc': 0, 'binc': 0, 'movestogo': 30}
+        i = 0
+        while i < len(args):
+            key = args[i].lower()
+            i += 1
+            if i >= len(args):
+                return 0, f'go {key} requires a value'
             try:
-                value = int(args[idx + 1])
+                value = int(args[i])
             except ValueError:
-                print(f'ERROR: go {key} requires an integer value')
-                return None
+                return 0, f'go {key} requires an integer value'
+            i += 1
 
-            if key == 'movestogo':
-                if value <= 0:
-                    print('ERROR: go movestogo must be > 0')
-                    return None
-            elif value < 0:
-                print(f'ERROR: go {key} must be >= 0')
-                return None
+            if key not in ('wtime', 'btime', 'winc', 'binc', 'movestogo'):
+                return 0, f'unsupported go parameter: {key}'
+            values[key] = value
 
-            parsed[key] = value
-            idx += 2
+        if 'wtime' not in values or 'btime' not in values:
+            return 0, 'go wtime/btime parameters are required'
+        if values['wtime'] <= 0 or values['btime'] <= 0:
+            return 0, 'go wtime/btime must be > 0'
+        if values['movestogo'] <= 0:
+            values['movestogo'] = 30
 
-        required = ('wtime', 'btime', 'winc', 'binc')
-        missing = [field for field in required if field not in parsed]
-        if missing:
-            print(f"ERROR: go time controls missing required fields: {' '.join(missing)}")
-            return None
-
-        return parsed
-
-    def _compute_go_movetime(self, controls: Dict[str, int]) -> int:
-        """Compute a practical per-move time budget from clock controls."""
         if self.board.to_move == Color.WHITE:
-            remaining_ms = controls['wtime']
-            increment_ms = controls['winc']
+            base = values['wtime']
+            inc = values['winc']
         else:
-            remaining_ms = controls['btime']
-            increment_ms = controls['binc']
+            base = values['btime']
+            inc = values['binc']
 
-        moves_to_go = controls.get('movestogo', 30)
-
-        if remaining_ms <= 0:
-            return max(25, min(1000, increment_ms))
-
-        reserve_ms = max(50, remaining_ms // 20)
-        usable_ms = max(1, remaining_ms - reserve_ms)
-        budget_ms = usable_ms // max(1, moves_to_go)
-        budget_ms += increment_ms // 2
-        budget_ms = max(25, budget_ms)
-        budget_ms = min(budget_ms, usable_ms)
-
-        # Keep command responsive even with very large remaining clocks.
-        return min(budget_ms, 30000)
+        budget = base // (values['movestogo'] + 1) + inc // 2
+        if budget < 50:
+            budget = 50
+        if budget >= base:
+            budget = base // 2
+        if budget <= 0:
+            return 0, 'unable to derive positive movetime from clocks'
+        return budget, None
 
     def handle_pgn(self, args):
         """Handle pgn command family."""
@@ -490,6 +510,81 @@ class ChessEngine:
 
         print('ERROR: Unsupported pgn command')
 
+    def handle_book(self, args):
+        """Handle book command family."""
+        if not args:
+            print('ERROR: book requires subcommand (load|on|off|stats)')
+            return
+
+        subcommand = args[0].lower()
+        if subcommand == 'load':
+            if len(args) < 2:
+                print('ERROR: book load requires a file path')
+                return
+            path = ' '.join(args[1:])
+            try:
+                with open(path, 'r', encoding='utf-8') as handle:
+                    content = handle.read()
+                entries, total_entries = self._parse_book_entries(content)
+            except Exception as exc:
+                print(f'ERROR: book load failed: {exc}')
+                return
+
+            self._book_path = path
+            self._book_entries = entries
+            self._book_entry_count = total_entries
+            self._book_enabled = True
+            self._book_lookups = 0
+            self._book_hits = 0
+            self._book_misses = 0
+            self._book_played = 0
+            print(
+                f'BOOK: loaded path="{path}"; positions={len(entries)}; '
+                f'entries={total_entries}; enabled=true'
+            )
+            return
+
+        if subcommand == 'on':
+            self._book_enabled = True
+            print('BOOK: enabled=true')
+            return
+
+        if subcommand == 'off':
+            self._book_enabled = False
+            print('BOOK: enabled=false')
+            return
+
+        if subcommand == 'stats':
+            path = self._book_path if self._book_path else '(none)'
+            print(
+                f'BOOK: enabled={str(self._book_enabled).lower()}; '
+                f'path={path}; positions={len(self._book_entries)}; '
+                f'entries={self._book_entry_count}; lookups={self._book_lookups}; '
+                f'hits={self._book_hits}; misses={self._book_misses}; played={self._book_played}'
+            )
+            return
+
+        print('ERROR: Unsupported book command')
+
+    def handle_endgame(self, _args):
+        """Report specialized endgame detection and best move hint."""
+        info = self._detect_endgame_state()
+        if info is None:
+            active = 'white' if self.board.to_move == Color.WHITE else 'black'
+            print(f'ENDGAME: type=none; active={active}; score=0')
+            return
+
+        output = (
+            f'ENDGAME: type={info["type"]}; strong={self._color_name(info["strong"])}; '
+            f'weak={self._color_name(info["weak"])}; score={info["score_white"]}'
+        )
+        legal_moves = self.move_generator.generate_legal_moves()
+        choice = self._choose_endgame_move(legal_moves)
+        if choice is not None:
+            output += f'; bestmove={choice[0].to_algebraic().lower()}'
+        output += f'; detail={info["detail"]}'
+        print(output)
+
     def handle_uci(self):
         """Handle uci command."""
         print('uciok')
@@ -497,6 +592,118 @@ class ChessEngine:
     def handle_isready(self):
         """Handle isready command."""
         print('readyok')
+
+    def handle_setoption(self, args):
+        """Handle UCI setoption command."""
+        if len(args) < 4 or args[0].lower() != 'name':
+            print("ERROR: setoption format is 'setoption name <Hash|Threads> value <n>'")
+            return
+
+        try:
+            value_idx = next(i for i, token in enumerate(args) if token.lower() == 'value')
+        except StopIteration:
+            print("ERROR: setoption requires 'value <n>'")
+            return
+
+        if value_idx <= 0 or value_idx + 1 >= len(args):
+            print("ERROR: setoption requires 'value <n>'")
+            return
+
+        name = ' '.join(args[1:value_idx]).strip().lower()
+        try:
+            value = int(args[value_idx + 1])
+        except ValueError:
+            print('ERROR: setoption value must be an integer')
+            return
+
+        if name == 'hash':
+            self._uci_hash_mb = max(1, min(1024, value))
+            print(f'info string option Hash={self._uci_hash_mb}')
+            return
+
+        if name == 'threads':
+            self._uci_threads = max(1, min(64, value))
+            print(f'info string option Threads={self._uci_threads}')
+            return
+
+        print(f'info string unsupported option {" ".join(args[1:value_idx]).strip()}')
+
+    def handle_ucinewgame(self):
+        """Handle UCI ucinewgame command."""
+        self.board = Board()
+        self.move_generator = MoveGenerator(self.board)
+        self.fen_parser = FenParser(self.board)
+        self.ai = AI(self.board, self.move_generator)
+        self.perft = Perft(self.board, self.move_generator)
+        self.move_history = []
+
+    def handle_position(self, args):
+        """Handle UCI position command: startpos|fen ... [moves ...]."""
+        if not args:
+            print("ERROR: position requires 'startpos' or 'fen <...>'")
+            return
+
+        idx = 0
+        keyword = args[0].lower()
+        if keyword == 'startpos':
+            self.handle_ucinewgame()
+            idx = 1
+        elif keyword == 'fen':
+            idx = 1
+            fen_tokens = []
+            while idx < len(args) and args[idx].lower() != 'moves':
+                fen_tokens.append(args[idx])
+                idx += 1
+            if not fen_tokens:
+                print('ERROR: position fen requires a FEN string')
+                return
+            try:
+                self.fen_parser.parse(' '.join(fen_tokens))
+                self.move_history = []
+            except Exception as exc:
+                print(f'ERROR: Invalid FEN string: {exc}')
+                return
+        else:
+            print("ERROR: position requires 'startpos' or 'fen <...>'")
+            return
+
+        if idx < len(args) and args[idx].lower() == 'moves':
+            idx += 1
+            for move_str in args[idx:]:
+                error = self._apply_move_silent(move_str)
+                if error is not None:
+                    print(f'ERROR: position move {move_str} failed: {error}')
+                    return
+
+    def _apply_move_silent(self, move_str: str) -> Optional[str]:
+        """Apply one coordinate move without emitting CLI output."""
+        move = Move.from_algebraic(move_str)
+        if not move:
+            return 'Invalid move format'
+
+        moving_piece = self.board.get_piece(move.from_row, move.from_col)
+        if moving_piece and moving_piece.type == PieceType.PAWN and move.promotion is None:
+            if (moving_piece.color == Color.WHITE and move.to_row == 7) or \
+               (moving_piece.color == Color.BLACK and move.to_row == 0):
+                move.promotion = PieceType.QUEEN
+
+        legal_moves = self.move_generator.generate_legal_moves()
+        legal_move = None
+        for candidate in legal_moves:
+            if (candidate.from_row == move.from_row and
+                candidate.from_col == move.from_col and
+                candidate.to_row == move.to_row and
+                candidate.to_col == move.to_col and
+                candidate.promotion == move.promotion):
+                legal_move = candidate
+                break
+
+        if not legal_move:
+            return 'Illegal move'
+
+        self.move_history.append(legal_move)
+        self.board.make_move(legal_move)
+        return None
 
     def handle_new960(self, args):
         """Handle new960 command."""
@@ -626,6 +833,18 @@ class ChessEngine:
         if len(self._trace_events) > 256:
             self._trace_events = self._trace_events[-256:]
 
+    def depth_for_movetime(self, movetime_ms: int) -> int:
+        """Convert movetime budget to a practical search depth."""
+        if movetime_ms <= 200:
+            return 1
+        if movetime_ms <= 500:
+            return 2
+        if movetime_ms <= 2000:
+            return 3
+        if movetime_ms <= 5000:
+            return 4
+        return 5
+
     def get_repetition_count(self) -> int:
         """Count current position repetitions since last irreversible move."""
         current_hash = self.board.zobrist_hash
@@ -661,6 +880,318 @@ class ChessEngine:
                 continue
             moves.append(token)
         return moves
+
+    def _book_position_key(self, fen: str) -> str:
+        parts = fen.strip().split()
+        if len(parts) >= 4:
+            return ' '.join(parts[:4])
+        return fen.strip()
+
+    def _parse_book_entries(self, content: str):
+        entries = {}
+        total_entries = 0
+        move_pattern = re.compile(r'^[a-h][1-8][a-h][1-8][qrbn]?$')
+
+        for idx, raw in enumerate(content.splitlines(), start=1):
+            line = raw.strip()
+            if not line or line.startswith('#'):
+                continue
+            if '->' not in line:
+                raise ValueError(f"line {idx}: expected '<fen> -> <move> [weight]'")
+
+            left, right = line.split('->', 1)
+            key = self._book_position_key(left)
+            if not key:
+                raise ValueError(f'line {idx}: empty position key')
+
+            rhs_parts = right.strip().split()
+            if not rhs_parts:
+                raise ValueError(f'line {idx}: missing move')
+
+            move = rhs_parts[0].lower()
+            if not move_pattern.match(move):
+                raise ValueError(f'line {idx}: invalid move "{move}"')
+
+            weight = 1
+            if len(rhs_parts) > 1:
+                try:
+                    weight = int(rhs_parts[1])
+                except ValueError as exc:
+                    raise ValueError(f'line {idx}: invalid weight "{rhs_parts[1]}"') from exc
+                if weight <= 0:
+                    raise ValueError(f'line {idx}: weight must be > 0')
+
+            entries.setdefault(key, []).append((move, weight))
+            total_entries += 1
+
+        return entries, total_entries
+
+    def _choose_book_move(self, legal_moves):
+        self._book_lookups += 1
+        if not self._book_enabled or not self._book_entries:
+            self._book_misses += 1
+            return None
+
+        key = self._book_position_key(self.fen_parser.export())
+        candidates = self._book_entries.get(key, [])
+        if not candidates:
+            self._book_misses += 1
+            return None
+
+        legal_by_notation = {
+            move.to_algebraic().lower(): move
+            for move in legal_moves
+        }
+
+        weighted = []
+        total_weight = 0
+        for notation, weight in candidates:
+            move = legal_by_notation.get(notation)
+            if move is None:
+                continue
+            norm_weight = weight if weight > 0 else 1
+            weighted.append((move, norm_weight))
+            total_weight += norm_weight
+
+        if not weighted or total_weight <= 0:
+            self._book_misses += 1
+            return None
+
+        selector = (int(self.board.zobrist_hash) + self._book_lookups) % total_weight
+        acc = 0
+        chosen = weighted[0][0]
+        for move, weight in weighted:
+            acc += weight
+            if selector < acc:
+                chosen = move
+                break
+
+        self._book_hits += 1
+        return chosen
+
+    def _apply_book_move(self, move: Move):
+        self.move_history.append(move)
+        self.board.make_move(move)
+        self._book_played += 1
+        move_str = move.to_algebraic()
+
+        game_status = self.board.get_game_status()
+        if game_status == 'checkmate':
+            winner = 'Black' if self.board.to_move == Color.WHITE else 'White'
+            print(f'AI: {move_str} (book, CHECKMATE: {winner} wins)')
+        elif game_status == 'stalemate':
+            print(f'AI: {move_str} (book, STALEMATE)')
+        else:
+            from lib.draw_detection import is_draw
+            if is_draw(self.board):
+                from lib.draw_detection import is_draw_by_repetition
+                reason = 'repetition' if is_draw_by_repetition(self.board) else '50-move rule'
+                print(f'AI: {move_str} (book, DRAW: by {reason})')
+            else:
+                print(f'AI: {move_str} (book)')
+
+        print(self.board.display())
+
+    def _color_name(self, color: Color) -> str:
+        return 'white' if color == Color.WHITE else 'black'
+
+    def _manhattan(self, a, b) -> int:
+        return abs(a[0] - b[0]) + abs(a[1] - b[1])
+
+    def _non_king_material(self, counts, color: Color) -> int:
+        return (
+            counts[color][PieceType.PAWN] +
+            counts[color][PieceType.KNIGHT] +
+            counts[color][PieceType.BISHOP] +
+            counts[color][PieceType.ROOK] +
+            counts[color][PieceType.QUEEN]
+        )
+
+    def _detect_endgame_state(self):
+        counts = {
+            Color.WHITE: {pt: 0 for pt in PieceType},
+            Color.BLACK: {pt: 0 for pt in PieceType},
+        }
+        kings = {}
+        pawns = {}
+        rooks = {}
+        queens = {}
+
+        for row in range(8):
+            for col in range(8):
+                piece = self.board.get_piece(row, col)
+                if not piece:
+                    continue
+                counts[piece.color][piece.type] += 1
+                if piece.type == PieceType.KING:
+                    kings[piece.color] = (row, col)
+                elif piece.type == PieceType.PAWN and piece.color not in pawns:
+                    pawns[piece.color] = (row, col)
+                elif piece.type == PieceType.ROOK and piece.color not in rooks:
+                    rooks[piece.color] = (row, col)
+                elif piece.type == PieceType.QUEEN and piece.color not in queens:
+                    queens[piece.color] = (row, col)
+
+        if Color.WHITE not in kings or Color.BLACK not in kings:
+            return None
+
+        white_material = self._non_king_material(counts, Color.WHITE)
+        black_material = self._non_king_material(counts, Color.BLACK)
+
+        # KQK
+        if counts[Color.WHITE][PieceType.QUEEN] == 1 and white_material == 1 and black_material == 0:
+            weak_king = kings[Color.BLACK]
+            strong_king = kings[Color.WHITE]
+            edge_distance = min(weak_king[0], 7 - weak_king[0], weak_king[1], 7 - weak_king[1])
+            king_distance = self._manhattan(strong_king, weak_king)
+            score = 900 + (14 - king_distance) * 6 + (3 - edge_distance) * 20
+            return {
+                'type': 'KQK',
+                'strong': Color.WHITE,
+                'weak': Color.BLACK,
+                'score_white': score,
+                'detail': f'queen={chr(ord("a") + queens[Color.WHITE][1])}{queens[Color.WHITE][0] + 1}',
+            }
+        if counts[Color.BLACK][PieceType.QUEEN] == 1 and black_material == 1 and white_material == 0:
+            weak_king = kings[Color.WHITE]
+            strong_king = kings[Color.BLACK]
+            edge_distance = min(weak_king[0], 7 - weak_king[0], weak_king[1], 7 - weak_king[1])
+            king_distance = self._manhattan(strong_king, weak_king)
+            score = 900 + (14 - king_distance) * 6 + (3 - edge_distance) * 20
+            return {
+                'type': 'KQK',
+                'strong': Color.BLACK,
+                'weak': Color.WHITE,
+                'score_white': -score,
+                'detail': f'queen={chr(ord("a") + queens[Color.BLACK][1])}{queens[Color.BLACK][0] + 1}',
+            }
+
+        # KPK
+        if counts[Color.WHITE][PieceType.PAWN] == 1 and white_material == 1 and black_material == 0:
+            pawn = pawns[Color.WHITE]
+            strong_king = kings[Color.WHITE]
+            weak_king = kings[Color.BLACK]
+            promotion = (7, pawn[1])
+            pawn_steps = 7 - pawn[0]
+            score = 120 + (6 - pawn_steps) * 35 + self._manhattan(weak_king, promotion) * 6 - self._manhattan(strong_king, pawn) * 8
+            if pawn_steps <= 1:
+                score += 80
+            if score < 30:
+                score = 30
+            return {
+                'type': 'KPK',
+                'strong': Color.WHITE,
+                'weak': Color.BLACK,
+                'score_white': score,
+                'detail': f'pawn={chr(ord("a") + pawn[1])}{pawn[0] + 1}',
+            }
+        if counts[Color.BLACK][PieceType.PAWN] == 1 and black_material == 1 and white_material == 0:
+            pawn = pawns[Color.BLACK]
+            strong_king = kings[Color.BLACK]
+            weak_king = kings[Color.WHITE]
+            promotion = (0, pawn[1])
+            pawn_steps = pawn[0]
+            score = 120 + (6 - pawn_steps) * 35 + self._manhattan(weak_king, promotion) * 6 - self._manhattan(strong_king, pawn) * 8
+            if pawn_steps <= 1:
+                score += 80
+            if score < 30:
+                score = 30
+            return {
+                'type': 'KPK',
+                'strong': Color.BLACK,
+                'weak': Color.WHITE,
+                'score_white': -score,
+                'detail': f'pawn={chr(ord("a") + pawn[1])}{pawn[0] + 1}',
+            }
+
+        # KRKP
+        if counts[Color.WHITE][PieceType.ROOK] == 1 and white_material == 1 and counts[Color.BLACK][PieceType.PAWN] == 1 and black_material == 1:
+            strong_king = kings[Color.WHITE]
+            weak_king = kings[Color.BLACK]
+            weak_pawn = pawns[Color.BLACK]
+            pawn_steps = weak_pawn[0]
+            score = 380 - pawn_steps * 25 + (self._manhattan(weak_king, weak_pawn) - self._manhattan(strong_king, weak_pawn)) * 12
+            if score < 50:
+                score = 50
+            return {
+                'type': 'KRKP',
+                'strong': Color.WHITE,
+                'weak': Color.BLACK,
+                'score_white': score,
+                'detail': (
+                    f'rook={chr(ord("a") + rooks[Color.WHITE][1])}{rooks[Color.WHITE][0] + 1},'
+                    f'pawn={chr(ord("a") + weak_pawn[1])}{weak_pawn[0] + 1}'
+                ),
+            }
+        if counts[Color.BLACK][PieceType.ROOK] == 1 and black_material == 1 and counts[Color.WHITE][PieceType.PAWN] == 1 and white_material == 1:
+            strong_king = kings[Color.BLACK]
+            weak_king = kings[Color.WHITE]
+            weak_pawn = pawns[Color.WHITE]
+            pawn_steps = 7 - weak_pawn[0]
+            score = 380 - pawn_steps * 25 + (self._manhattan(weak_king, weak_pawn) - self._manhattan(strong_king, weak_pawn)) * 12
+            if score < 50:
+                score = 50
+            return {
+                'type': 'KRKP',
+                'strong': Color.BLACK,
+                'weak': Color.WHITE,
+                'score_white': -score,
+                'detail': (
+                    f'rook={chr(ord("a") + rooks[Color.BLACK][1])}{rooks[Color.BLACK][0] + 1},'
+                    f'pawn={chr(ord("a") + weak_pawn[1])}{weak_pawn[0] + 1}'
+                ),
+            }
+
+        return None
+
+    def _choose_endgame_move(self, legal_moves):
+        root_info = self._detect_endgame_state()
+        if root_info is None or not legal_moves:
+            return None
+
+        root_color = self.board.to_move
+        best_move = legal_moves[0]
+        best_notation = best_move.to_algebraic().lower()
+        best_score = -10**9
+
+        for move in legal_moves:
+            self.board.make_move(move)
+            next_info = self._detect_endgame_state()
+            if next_info is not None:
+                score = next_info['score_white']
+            else:
+                score = self.ai.evaluate_position()
+            if root_color == Color.BLACK:
+                score = -score
+            notation = move.to_algebraic().lower()
+            if score > best_score or (score == best_score and notation < best_notation):
+                best_score = score
+                best_move = move
+                best_notation = notation
+            self.board.undo_move(move)
+
+        return best_move, root_info
+
+    def _apply_endgame_move(self, move: Move, info):
+        self.move_history.append(move)
+        self.board.make_move(move)
+        move_str = move.to_algebraic()
+        print(f'AI: {move_str} (endgame {info["type"]}, score={info["score_white"]})')
+
+        print(self.board.display())
+
+        game_status = self.board.get_game_status()
+        if game_status == 'checkmate':
+            winner = 'Black' if self.board.to_move == Color.WHITE else 'White'
+            print(f'CHECKMATE: {winner} wins')
+        elif game_status == 'stalemate':
+            print('STALEMATE: Draw')
+        else:
+            from lib.draw_detection import is_draw
+            if is_draw(self.board):
+                from lib.draw_detection import is_draw_by_repetition
+                reason = 'repetition' if is_draw_by_repetition(self.board) else '50-move rule'
+                print(f'DRAW: by {reason}')
     
     def handle_status(self):
         """Handle status command."""
@@ -710,12 +1241,18 @@ Available commands:
   draws                      - Show draw detection status
   history                    - Show position hash history
   go movetime <ms>           - Time-managed AI move
-  go wtime <ms> btime <ms> winc <ms> binc <ms> [movestogo <n>] - Clock-managed AI move
-  go infinite                - Run bounded long iterative search
-  stop                       - Cooperative stop signal
+  go wtime <ms> btime <ms> winc <ms> binc <ms> [movestogo <n>] - Clock-based timed move
+  go depth <n>               - UCI-style depth search (prints info/bestmove)
+  go infinite                - Start bounded long search mode
+  stop                       - Stop infinite search mode
   pgn load|show|moves        - PGN command family
+  book load|on|off|stats     - Native opening book controls
+  endgame                    - Detect specialized endgame and best move hint
   uci                        - Enter/respond to UCI handshake
   isready                    - UCI readiness probe
+  setoption name <Hash|Threads> value <n> - Set UCI option
+  ucinewgame                 - Reset internal state for UCI game
+  position startpos|fen ... [moves ...] - Load UCI position
   new960 [id]                - Start Chess960 game by id (0-959)
   position960                - Show current Chess960 metadata
   perft <depth>              - Performance test (move count)

--- a/implementations/python/lib/ai.py
+++ b/implementations/python/lib/ai.py
@@ -1,37 +1,27 @@
-"""
-AI engine using iterative deepening negamax with alpha-beta pruning.
-"""
+"""AI engine using iterative deepening + negamax + alpha-beta + TT."""
 
-import time
 from dataclasses import dataclass
-from typing import Dict, Optional, Tuple, List
+import time
+from typing import Dict, Tuple, Optional, List
 from lib.types import Move, Piece, PieceType, Color
 from lib.board import Board
 from lib.move_generator import MoveGenerator
 
-
-class SearchTimeout(Exception):
-    """Raised when search reaches its deadline."""
+MATE_VALUE = 100000
+INFINITY = 10**9
 
 
 @dataclass
 class TTEntry:
-    """Transposition table entry."""
     depth: int
     score: int
-    flag: str
-    best_move: Optional[Tuple[int, int, int, int, Optional[PieceType], bool, bool]]
+    flag: str  # exact | lower | upper
+    best_move: Optional[Move]
 
 
 class AI:
-    """Chess AI with iterative deepening, TT-backed negamax and alpha-beta pruning."""
-
-    TT_EXACT = "exact"
-    TT_LOWERBOUND = "lowerbound"
-    TT_UPPERBOUND = "upperbound"
-    MATE_SCORE = 100000
-    TT_MAX_SIZE = 250000
-
+    """Chess AI using minimax with alpha-beta pruning."""
+    
     # Piece values for evaluation
     PIECE_VALUES = {
         PieceType.PAWN: 100,
@@ -41,7 +31,7 @@ class AI:
         PieceType.QUEEN: 900,
         PieceType.KING: 20000
     }
-
+    
     # Position bonus tables
     PAWN_TABLE = [
         [0,  0,  0,  0,  0,  0,  0,  0],
@@ -53,7 +43,7 @@ class AI:
         [5, 10, 10,-20,-20, 10, 10,  5],
         [0,  0,  0,  0,  0,  0,  0,  0]
     ]
-
+    
     KNIGHT_TABLE = [
         [-50,-40,-30,-30,-30,-30,-40,-50],
         [-40,-20,  0,  0,  0,  0,-20,-40],
@@ -64,7 +54,7 @@ class AI:
         [-40,-20,  0,  5,  5,  0,-20,-40],
         [-50,-40,-30,-30,-30,-30,-40,-50]
     ]
-
+    
     BISHOP_TABLE = [
         [-20,-10,-10,-10,-10,-10,-10,-20],
         [-10,  0,  0,  0,  0,  0,  0,-10],
@@ -75,7 +65,7 @@ class AI:
         [-10,  5,  0,  0,  0,  0,  5,-10],
         [-20,-10,-10,-10,-10,-10,-10,-20]
     ]
-
+    
     ROOK_TABLE = [
         [0,  0,  0,  0,  0,  0,  0,  0],
         [5, 10, 10, 10, 10, 10, 10,  5],
@@ -86,7 +76,7 @@ class AI:
         [-5,  0,  0,  0,  0,  0,  0, -5],
         [0,  0,  0,  5,  5,  0,  0,  0]
     ]
-
+    
     QUEEN_TABLE = [
         [-20,-10,-10, -5, -5,-10,-10,-20],
         [-10,  0,  0,  0,  0,  0,  0,-10],
@@ -97,7 +87,7 @@ class AI:
         [-10,  0,  5,  0,  0,  0,  0,-10],
         [-20,-10,-10, -5, -5,-10,-10,-20]
     ]
-
+    
     KING_TABLE = [
         [-30,-40,-40,-50,-50,-40,-40,-30],
         [-30,-40,-40,-50,-50,-40,-40,-30],
@@ -108,254 +98,190 @@ class AI:
         [20, 20,  0,  0,  0,  0, 20, 20],
         [20, 30, 10,  0,  0, 10, 30, 20]
     ]
-
+    
     def __init__(self, board: Board, move_generator: MoveGenerator):
         self.board = board
         self.move_generator = move_generator
-        self.transposition_table: Dict[int, TTEntry] = {}
+        self._tt: Dict[int, TTEntry] = {}
         self._deadline: Optional[float] = None
-
+        self._timed_out = False
+        self._stop_requested = False
+    
     def get_best_move(self, depth: int) -> Tuple[Optional[Move], int]:
-        """Get best move for fixed depth (backward-compatible API)."""
-        best_move, score, _ = self.search(max_depth=depth)
-        return best_move, score
-
-    def get_best_move_timed(self, movetime_ms: int, max_depth: int = 5) -> Tuple[Optional[Move], int, int]:
-        """Get best move using iterative deepening bounded by movetime."""
-        return self.search(max_depth=max_depth, time_limit_ms=movetime_ms)
-
-    def search(self, max_depth: int, time_limit_ms: Optional[int] = None) -> Tuple[Optional[Move], int, int]:
-        """
-        Iterative deepening search.
-
-        Returns (best_move, eval_score, completed_depth). If timeout happens during a
-        deeper iteration, result from the last fully completed depth is returned.
-        """
-        if max_depth < 1:
-            max_depth = 1
-
-        legal_moves = self.move_generator.generate_legal_moves()
-        if not legal_moves:
-            return None, 0, 0
-
-        fallback_move = self._order_moves(legal_moves)[0]
-        fallback_score = self._evaluate_for_side_to_move()
-
-        if time_limit_ms is not None and time_limit_ms <= 0:
-            time_limit_ms = 1
-
-        self._deadline = None
-        if time_limit_ms is not None:
-            self._deadline = time.monotonic() + (time_limit_ms / 1000.0)
-
-        best_move = fallback_move
-        best_score = fallback_score
-        completed_depth = 0
-
-        try:
-            for depth in range(1, max_depth + 1):
-                self._check_timeout()
-                iter_move, iter_score = self._search_root(depth)
-                if iter_move is None:
-                    break
-                best_move = iter_move
-                best_score = iter_score
-                completed_depth = depth
-        except SearchTimeout:
-            # Keep last completed iteration result.
-            pass
-        finally:
-            self._deadline = None
-
-        return best_move, best_score, completed_depth
-
-    def _search_root(self, depth: int) -> Tuple[Optional[Move], int]:
-        """Search root node at a fixed depth."""
-        self._check_timeout()
-
-        alpha = -self.MATE_SCORE
-        beta = self.MATE_SCORE
-        best_score = -self.MATE_SCORE
-        best_move: Optional[Move] = None
-
-        node_hash = self.board.zobrist_hash
-        tt_entry = self.transposition_table.get(node_hash)
-        tt_move_key = tt_entry.best_move if tt_entry else None
-
-        legal_moves = self.move_generator.generate_legal_moves()
-        if not legal_moves:
-            if self.board.is_in_check(self.board.to_move):
-                return None, -self.MATE_SCORE
-            return None, 0
-
-        ordered_moves = self._order_moves(legal_moves, tt_move_key)
-        alpha_original = alpha
-        beta_original = beta
-
-        for move in ordered_moves:
-            self._check_timeout()
-            self.board.make_move(move)
-            score = -self._negamax(depth - 1, -beta, -alpha, 1)
-            self.board.undo_move(move)
-
-            if score > best_score:
-                best_score = score
-                best_move = move
-
-            if score > alpha:
-                alpha = score
-
-            if alpha >= beta:
-                break
-
-        if best_move is not None:
-            flag = self.TT_EXACT
-            if best_score <= alpha_original:
-                flag = self.TT_UPPERBOUND
-            elif best_score >= beta_original:
-                flag = self.TT_LOWERBOUND
-            self._store_tt(node_hash, depth, best_score, flag, best_move)
-
+        """Backward-compatible API used by `ai <depth>` command."""
+        best_move, best_score, _, _, _ = self.search(depth, 0)
         return best_move, best_score
 
-    def _negamax(self, depth: int, alpha: int, beta: int, ply: int) -> int:
-        """Negamax with alpha-beta pruning and TT lookup/store."""
-        self._check_timeout()
-        alpha_original = alpha
-        beta_original = beta
+    def request_stop(self) -> None:
+        """Cooperative stop flag for ongoing search."""
+        self._stop_requested = True
 
-        node_hash = self.board.zobrist_hash
-        tt_entry = self.transposition_table.get(node_hash)
-        tt_move_key = None
-        if tt_entry:
-            tt_move_key = tt_entry.best_move
-            if tt_entry.depth >= depth:
-                if tt_entry.flag == self.TT_EXACT:
-                    return tt_entry.score
-                if tt_entry.flag == self.TT_LOWERBOUND:
-                    alpha = max(alpha, tt_entry.score)
-                elif tt_entry.flag == self.TT_UPPERBOUND:
-                    beta = min(beta, tt_entry.score)
-                if alpha >= beta:
-                    return tt_entry.score
-
-        if depth == 0:
-            return self._evaluate_for_side_to_move()
+    def search(self, max_depth: int, movetime_ms: int) -> Tuple[Optional[Move], int, int, int, bool]:
+        """Return (best_move, score, depth_reached, elapsed_ms, timed_out)."""
+        if max_depth < 1:
+            max_depth = 1
+        if max_depth > 5:
+            max_depth = 5
 
         legal_moves = self.move_generator.generate_legal_moves()
         if not legal_moves:
-            if self.board.is_in_check(self.board.to_move):
-                # Prefer faster mates and slower losses.
-                return -self.MATE_SCORE + ply
-            return 0
+            return None, 0, 0, 0, False
 
-        best_score = -self.MATE_SCORE
-        best_move: Optional[Move] = None
+        self._timed_out = False
+        self._stop_requested = False
+        start = time.monotonic()
+        self._deadline = start + (movetime_ms / 1000.0) if movetime_ms > 0 else None
 
-        for move in self._order_moves(legal_moves, tt_move_key):
-            self._check_timeout()
+        best_move = legal_moves[0]
+        best_score = self.evaluate_position()
+        completed_depth = 0
+
+        for depth in range(1, max_depth + 1):
+            score, move, complete = self._search_root(depth)
+            if not complete:
+                break
+            if move is not None:
+                best_move = move
+                best_score = score
+                completed_depth = depth
+
+        if completed_depth == 0:
+            completed_depth = 1
+
+        elapsed_ms = int((time.monotonic() - start) * 1000)
+        return best_move, int(best_score), completed_depth, elapsed_ms, self._timed_out
+
+    def _search_root(self, depth: int) -> Tuple[int, Optional[Move], bool]:
+        if self._time_exceeded():
+            return 0, None, False
+
+        moves = self.move_generator.generate_legal_moves()
+        if not moves:
+            return 0, None, True
+
+        entry = self._tt.get(self.board.zobrist_hash)
+        ordered_moves = self._order_moves(moves, entry.best_move if entry else None)
+
+        alpha = -INFINITY
+        beta = INFINITY
+        best_score = -INFINITY
+        best_move: Optional[Move] = ordered_moves[0]
+
+        for move in ordered_moves:
+            if self._time_exceeded():
+                return 0, None, False
             self.board.make_move(move)
-            score = -self._negamax(depth - 1, -beta, -alpha, ply + 1)
+            score, _, ok = self._negamax(depth - 1, -beta, -alpha)
             self.board.undo_move(move)
+            if not ok:
+                return 0, None, False
+            score = -score
 
             if score > best_score:
                 best_score = score
                 best_move = move
-
             if score > alpha:
                 alpha = score
 
+        return int(best_score), best_move, True
+
+    def _negamax(self, depth: int, alpha: int, beta: int) -> Tuple[int, Optional[Move], bool]:
+        if self._time_exceeded():
+            return 0, None, False
+
+        original_alpha = alpha
+        key = self.board.zobrist_hash
+        best_from_tt: Optional[Move] = None
+
+        entry = self._tt.get(key)
+        if entry and entry.depth >= depth:
+            if entry.flag == 'exact':
+                return entry.score, entry.best_move, True
+            if entry.flag == 'lower':
+                alpha = max(alpha, entry.score)
+            elif entry.flag == 'upper':
+                beta = min(beta, entry.score)
+            if alpha >= beta:
+                return entry.score, entry.best_move, True
+            best_from_tt = entry.best_move
+
+        if depth == 0:
+            return int(self.evaluate_position()), None, True
+
+        moves = self.move_generator.generate_legal_moves()
+        if not moves:
+            if self.board.is_in_check(self.board.to_move):
+                return -MATE_VALUE + depth, None, True
+            return 0, None, True
+
+        ordered = self._order_moves(moves, best_from_tt)
+        best_score = -INFINITY
+        best_move: Optional[Move] = ordered[0]
+
+        for move in ordered:
+            if self._time_exceeded():
+                return 0, None, False
+            self.board.make_move(move)
+            score, _, ok = self._negamax(depth - 1, -beta, -alpha)
+            self.board.undo_move(move)
+            if not ok:
+                return 0, None, False
+            score = -score
+
+            if score > best_score:
+                best_score = score
+                best_move = move
+            if score > alpha:
+                alpha = score
             if alpha >= beta:
                 break
 
-        flag = self.TT_EXACT
-        if best_score <= alpha_original:
-            flag = self.TT_UPPERBOUND
-        elif best_score >= beta_original:
-            flag = self.TT_LOWERBOUND
+        flag = 'exact'
+        if best_score <= original_alpha:
+            flag = 'upper'
+        elif best_score >= beta:
+            flag = 'lower'
+        self._tt[key] = TTEntry(depth=depth, score=int(best_score), flag=flag, best_move=best_move)
 
-        self._store_tt(node_hash, depth, best_score, flag, best_move)
-        return best_score
+        return int(best_score), best_move, True
 
-    def _store_tt(self, node_hash: int, depth: int, score: int, flag: str, best_move: Optional[Move]) -> None:
-        """Store TT entry with shallow size control."""
-        if len(self.transposition_table) >= self.TT_MAX_SIZE:
-            self.transposition_table.clear()
-        self.transposition_table[node_hash] = TTEntry(
-            depth=depth,
-            score=score,
-            flag=flag,
-            best_move=self._move_to_key(best_move) if best_move else None
-        )
-
-    def _evaluate_for_side_to_move(self) -> int:
-        """Return static eval from side-to-move perspective."""
-        score = self.evaluate_position()
-        return score if self.board.to_move == Color.WHITE else -score
-
-    def _check_timeout(self) -> None:
-        """Raise SearchTimeout when deadline is reached."""
-        if self._deadline is not None and time.monotonic() >= self._deadline:
-            raise SearchTimeout()
-
-    def _move_to_key(
-        self,
-        move: Optional[Move]
-    ) -> Optional[Tuple[int, int, int, int, Optional[PieceType], bool, bool]]:
-        """Serialize move identity for TT storage."""
-        if move is None:
-            return None
-        return (
-            move.from_row,
-            move.from_col,
-            move.to_row,
-            move.to_col,
-            move.promotion,
-            move.is_castling,
-            move.is_en_passant,
-        )
-
-    def _move_matches_key(
-        self,
-        move: Move,
-        move_key: Optional[Tuple[int, int, int, int, Optional[PieceType], bool, bool]]
-    ) -> bool:
-        """Compare a move against TT move identity."""
-        if move_key is None:
-            return False
-        return self._move_to_key(move) == move_key
-
-    def _order_moves(
-        self,
-        moves: List[Move],
-        tt_move_key: Optional[Tuple[int, int, int, int, Optional[PieceType], bool, bool]] = None
-    ) -> List[Move]:
-        """Order moves for better pruning and deterministic choices."""
-        def move_score(move: Move) -> int:
+    def _order_moves(self, moves: List[Move], tt_move: Optional[Move] = None) -> List[Move]:
+        """Order moves for better alpha-beta pruning."""
+        def move_score(move):
             score = 0
 
-            # Prioritize captures.
+            if tt_move and move == tt_move:
+                score += 100000
+            
+            # Prioritize captures
             target_piece = self.board.get_piece(move.to_row, move.to_col)
             if target_piece:
                 score += self.PIECE_VALUES[target_piece.type]
-            elif move.is_en_passant:
-                score += self.PIECE_VALUES[PieceType.PAWN]
-
-            # Prioritize promotions.
+            
+            # Prioritize promotions
             if move.promotion:
                 score += self.PIECE_VALUES[move.promotion]
-
-            # Prioritize center moves.
+            
+            # Prioritize center moves
+            center_bonus = 0
             if 3 <= move.to_row <= 4 and 3 <= move.to_col <= 4:
-                score += 10
-
+                center_bonus = 10
+            score += center_bonus
+            
             return score
+        
+        return sorted(moves, key=move_score, reverse=True)
 
-        def move_key(move: Move):
-            tt_priority = 0 if self._move_matches_key(move, tt_move_key) else 1
-            return (tt_priority, -move_score(move), move.to_algebraic())
-
-        return sorted(moves, key=move_key)
+    def _time_exceeded(self) -> bool:
+        if self._stop_requested:
+            self._timed_out = True
+            return True
+        if self._deadline is None:
+            return False
+        if time.monotonic() >= self._deadline:
+            self._timed_out = True
+            return True
+        return False
     
     def evaluate_position(self) -> int:
         """Evaluate the current position."""

--- a/test/suites/v2_full.json
+++ b/test/suites/v2_full.json
@@ -98,6 +98,33 @@
         }
       ]
     },
+    "functional_book": {
+      "description": "Native opening book contract",
+      "required": true,
+      "tests": [
+        {
+          "id": "book_load_stats",
+          "name": "Book Load Stats",
+          "commands": [
+            {"fixture_file": "test/fixtures/book/commands_load_stats.txt"}
+          ],
+          "expected_patterns": ["BOOK: loaded", "BOOK: enabled=true", "entries=2"],
+          "timeout": 8000
+        },
+        {
+          "id": "book_ai_move",
+          "name": "Book AI Move",
+          "commands": [
+            {"cmd": "new"},
+            {"cmd": "book load /repo/test/fixtures/book/opening.book"},
+            {"cmd": "ai 3"},
+            {"cmd": "book stats"}
+          ],
+          "expected_patterns": ["AI:", "(book)", "BOOK: enabled=true", "hits=1"],
+          "timeout": 8000
+        }
+      ]
+    },
     "functional_uci": {
       "description": "UCI handshake surface with transcript fixtures",
       "required": true,

--- a/test/suites/v3_book.json
+++ b/test/suites/v3_book.json
@@ -1,0 +1,57 @@
+{
+  "version": "3.0",
+  "track": "v3-book",
+  "description": "Native opening book track (load, toggle, move selection)",
+  "test_categories": {
+    "book_load": {
+      "description": "Book load and stats command contract",
+      "required": true,
+      "tests": [
+        {
+          "id": "book_load_stats",
+          "name": "Book Load Stats",
+          "commands": [
+            {"fixture_file": "test/fixtures/book/commands_load_stats.txt"}
+          ],
+          "expected_patterns": ["BOOK: loaded", "BOOK: enabled=true", "entries=2"],
+          "timeout": 8000
+        }
+      ]
+    },
+    "book_toggle": {
+      "description": "Book on/off toggles remain observable",
+      "required": true,
+      "tests": [
+        {
+          "id": "book_toggle_on_off",
+          "name": "Book Toggle On Off",
+          "commands": [
+            {"cmd": "new"},
+            {"cmd": "book load /repo/test/fixtures/book/opening.book"},
+            {"fixture_file": "test/fixtures/book/commands_toggle.txt"}
+          ],
+          "expected_patterns": ["BOOK: enabled=false", "BOOK: enabled=true"],
+          "timeout": 8000
+        }
+      ]
+    },
+    "book_play": {
+      "description": "Book move is actually played before search",
+      "required": true,
+      "tests": [
+        {
+          "id": "book_ai_move",
+          "name": "Book AI Move",
+          "commands": [
+            {"cmd": "new"},
+            {"cmd": "book load /repo/test/fixtures/book/opening.book"},
+            {"cmd": "ai 3"},
+            {"cmd": "book stats"}
+          ],
+          "expected_patterns": ["AI:", "(book)", "hits=1", "played=1"],
+          "timeout": 8000
+        }
+      ]
+    }
+  }
+}

--- a/test/test_harness.py
+++ b/test/test_harness.py
@@ -31,6 +31,7 @@ TRACK_TO_SUITE = {
     "v2-functional": "test/suites/v2_functional.json",
     "v2-system": "test/suites/v2_system.json",
     "v2-full": "test/suites/v2_full.json",
+    "v3-book": "test/suites/v3_book.json",
 }
 
 class ChessEngineTester:


### PR DESCRIPTION
## Summary
Rebased Wave 1 core-v2 engine changes onto latest `main` and kept only net-new changes.

Scope includes:
- core5 search/time-management flow updates
- opening-book command/fixture integration
- v2 harness additions (`v3_book` suite + harness hook)
- updated engine behavior in: `dart`, `go`, `lua`, `php`, `python`

## Validation
### GitHub checks
- Test Chess Engines workflow: all jobs passed on updated branch.

### Local strict Docker gates (on rebased branch)
Executed for each of `dart`, `go`, `lua`, `php`, `python`:
- `make image DIR=<impl>`
- `make build DIR=<impl>`
- `make analyze DIR=<impl>`
- `make test DIR=<impl>`
- `make test-chess-engine DIR=<impl> TRACK=v1`
- `make test-chess-engine DIR=<impl> TRACK=v2-full`

All passed.

## Related Issues
Fixes #81
Relates to #84