### PR TITLE
Feat/108 replace loc with tokens

### DIFF
--- a/.github/workflows/scripts/update_readme.py
+++ b/.github/workflows/scripts/update_readme.py
@@ -18,10 +18,21 @@ if os.path.exists(SCRIPTS_DIR):
     sys.path.insert(0, str(SCRIPTS_DIR))
     try:
         from chess_metadata import get_metadata
+        from token_metrics import (
+            TOKEN_METRIC_VERSION,
+            collect_impl_metrics_from_metadata,
+            parse_source_exts,
+        )
     except ImportError:
+        TOKEN_METRIC_VERSION = "tokens-v2"
         def get_metadata(impl_dir): return {}
+        def collect_impl_metrics_from_metadata(impl_path, metadata): raise RuntimeError("token metrics unavailable")
+        def parse_source_exts(raw_value): return []
 else:
+    TOKEN_METRIC_VERSION = "tokens-v2"
     def get_metadata(impl_dir): return {}
+    def collect_impl_metrics_from_metadata(impl_path, metadata): raise RuntimeError("token metrics unavailable")
+    def parse_source_exts(raw_value): return []
 
 CUSTOM_EMOJIS: Dict[str, str] = {
     'python': '🐍',
@@ -45,31 +56,6 @@ CUSTOM_EMOJIS: Dict[str, str] = {
     'swift': '🐦',
     'typescript': '📘',
     'zig': '⚡'
-}
-
-LANGUAGE_EXTENSIONS: Dict[str, List[str]] = {
-    'bun': ['.js'],
-    'crystal': ['.cr'],
-    'dart': ['.dart'],
-    'elm': ['.elm'],
-    'gleam': ['.gleam'],
-    'go': ['.go'],
-    'haskell': ['.hs'],
-    'imba': ['.imba'],
-    'javascript': ['.js'],
-    'julia': ['.jl'],
-    'kotlin': ['.kt'],
-    'lua': ['.lua'],
-    'mojo': ['.mojo', '.🔥'],
-    'nim': ['.nim'],
-    'php': ['.php'],
-    'python': ['.py'],
-    'rescript': ['.res', '.resi'],
-    'ruby': ['.rb'],
-    'rust': ['.rs'],
-    'swift': ['.swift'],
-    'typescript': ['.ts'],
-    'zig': ['.zig']
 }
 
 GENERATED_SEGMENTS = (
@@ -118,28 +104,30 @@ def find_project_root():
         current_dir = os.path.dirname(current_dir)
     return None
 
-def count_lines_of_code(impl_path: str) -> Dict[str, int]:
-    """Count lines of code for an implementation."""
-    lang_name = os.path.basename(impl_path)
-    exts = LANGUAGE_EXTENSIONS.get(lang_name, [])
-    total_loc = 0
-    file_count = 0
+def resolve_tokens_count(impl_data: Dict[str, Any], impl_path: str, meta: Dict[str, Any], language: str) -> Optional[int]:
+    """Resolve TOKENS from benchmark report; fallback to local computation (non-blocking)."""
+    metrics = impl_data.get("metrics", {})
+    tokens_count = metrics.get("tokens_count") if isinstance(metrics, dict) else None
+    metric_version = metrics.get("metric_version") if isinstance(metrics, dict) else None
 
-    src_dir = os.path.join(impl_path, 'src')
-    if not os.path.exists(src_dir):
-        src_dir = impl_path
+    if isinstance(tokens_count, int) and tokens_count >= 0:
+        if metric_version and metric_version != TOKEN_METRIC_VERSION:
+            print(
+                f"⚠️ {language}: metric version is {metric_version}, expected {TOKEN_METRIC_VERSION}. "
+                "Using reported value anyway."
+            )
+        return tokens_count
 
-    for ext in exts:
-        pattern = f"{src_dir}/**/*{ext}"
-        for file in glob.glob(pattern, recursive=True):
-            try:
-                with open(file, 'r', encoding='utf-8', errors='ignore') as handle:
-                    total_loc += len(handle.readlines())
-                    file_count += 1
-            except Exception:
-                continue
+    try:
+        local_metrics = collect_impl_metrics_from_metadata(Path(impl_path), meta)
+        local_tokens = local_metrics.get("tokens_count")
+        if isinstance(local_tokens, int) and local_tokens >= 0:
+            print(f"⚠️ {language}: missing report TOKENS, using local fallback ({TOKEN_METRIC_VERSION})")
+            return local_tokens
+    except Exception as exc:
+        print(f"⚠️ {language}: could not compute TOKENS fallback: {exc}")
 
-    return {'loc': total_loc, 'files': file_count}
+    return None
 
 def _normalize_relpath(path: str) -> str:
     """Normalize a relative path for Markdown links."""
@@ -217,8 +205,9 @@ def _extract_candidates_from_command(command: str, impl_path: str, extensions: L
 
 def resolve_entrypoint_file(impl_path: str, language: str, meta: Dict[str, Any]) -> Optional[str]:
     """Resolve the best source entrypoint file for a language implementation."""
-    extensions = LANGUAGE_EXTENSIONS.get(language, [])
+    extensions = parse_source_exts(meta.get("source_exts"))
     if not extensions:
+        print(f"⚠️ {language}: metadata source_exts missing or invalid; cannot link TOKENS to entrypoint")
         return None
 
     candidates: List[str] = []
@@ -580,7 +569,7 @@ def update_readme() -> bool:
             
             # Metadata & Stats
             meta = get_metadata(impl_path)
-            loc_data = count_lines_of_code(impl_path)
+            tokens_count = resolve_tokens_count(impl_data, impl_path, meta, language)
             entrypoint_file = resolve_entrypoint_file(impl_path, language, meta)
             
             # Status
@@ -637,21 +626,23 @@ def update_readme() -> bool:
             feature_summary = format_feature_summary(meta)
             
             lang_name = f"{lang_emoji} {language.title()}"
-            loc_display = str(loc_data['loc'])
-            if entrypoint_file:
+            tokens_display = "-"
+            if isinstance(tokens_count, int) and tokens_count >= 0:
+                tokens_display = str(tokens_count)
+            if entrypoint_file and isinstance(tokens_count, int) and tokens_count >= 0:
                 entrypoint_repo_path = Path("implementations") / language / entrypoint_file
-                loc_display = f"[{loc_data['loc']}]({entrypoint_repo_path.as_posix()})"
+                tokens_display = f"[{tokens_count}]({entrypoint_repo_path.as_posix()})"
 
             table_rows.append(
-                f"| {lang_name} | {emoji} | {loc_display} | "
+                f"| {lang_name} | {emoji} | {tokens_display} | "
                 f"{make_build_disp} | {make_analyze_disp} | {make_test_disp} | {make_test_chess_engine_disp} | "
                 f"{make_test_score} | {make_test_chess_engine_score} | {feature_summary} |"
             )
         
         # Create table content
         table_header = """
-| Language | Status | LOC | make build | make analyze | make test | make test-chess-engine | make test score | make test-chess-engine score | Features |
-|----------|--------|-----|------------|--------------|-----------|------------------------|-----------------|------------------------------|----------|"""
+| Language | Status | TOKENS | make build | make analyze | make test | make test-chess-engine | make test score | make test-chess-engine score | Features |
+|----------|--------|--------|------------|--------------|-----------|------------------------|-----------------|------------------------------|----------|"""
         
         new_table = table_header + "\n" + "\n".join(table_rows)
         speed_chart = build_speed_chart(combined_data, sorted(all_languages))

--- a/.github/workflows/scripts/validate_results.py
+++ b/.github/workflows/scripts/validate_results.py
@@ -8,21 +8,22 @@ import os
 import json
 import sys
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import List, Tuple
 
 
-def validate_result_json(result_file: Path, language: str) -> Tuple[bool, List[str]]:
+def validate_result_json(result_file: Path, language: str) -> Tuple[bool, List[str], List[str]]:
     """
     Validate a result JSON file for completeness and correctness.
     
     Returns:
-        Tuple of (is_valid, list of issues)
+        Tuple of (is_valid, list of blocking issues, list of non-blocking warnings)
     """
     issues = []
+    warnings = []
     
     if not result_file.exists():
         issues.append(f"Result file not found: {result_file}")
-        return False, issues
+        return False, issues, warnings
     
     try:
         with open(result_file, 'r') as f:
@@ -32,7 +33,7 @@ def validate_result_json(result_file: Path, language: str) -> Tuple[bool, List[s
         if isinstance(data, list):
             if len(data) == 0:
                 issues.append(f"Result file is empty list")
-                return False, issues
+                return False, issues, warnings
             data = data[0]  # Take first element if list
         
         # Check critical fields exist
@@ -77,25 +78,34 @@ def validate_result_json(result_file: Path, language: str) -> Tuple[bool, List[s
         if not features:
             issues.append("Features list is empty")
         
-        # Check for LOC data if available
-        # Note: This is flagged as a potential issue (warning), not a critical error
-        # Validation continues even if LOC is 0, as it may be legitimate
-        loc_data = data.get('loc', {})
-        if loc_data:
-            loc_count = loc_data.get('loc', 0)
-            if loc_count == 0:
-                issues.append("Lines of code count is 0 - may indicate counting error (warning)")
+        # Check TOKENS metric in a non-blocking way.
+        metrics = data.get('metrics', {})
+        if not isinstance(metrics, dict) or not metrics:
+            warnings.append("Metrics object missing - TOKENS may not be available in README")
+        else:
+            tokens_count = metrics.get("tokens_count")
+            metric_version = metrics.get("metric_version")
+
+            if tokens_count is None:
+                warnings.append("metrics.tokens_count missing - README will display '-'")
+            elif not isinstance(tokens_count, int) or tokens_count < 0:
+                warnings.append(f"metrics.tokens_count should be a non-negative integer, got: {tokens_count}")
+
+            if metric_version is None:
+                warnings.append("metrics.metric_version missing")
+            elif not isinstance(metric_version, str) or not metric_version.strip():
+                warnings.append(f"metrics.metric_version should be a non-empty string, got: {metric_version}")
         
     except json.JSONDecodeError as e:
         issues.append(f"Invalid JSON format: {e}")
-        return False, issues
+        return False, issues, warnings
     except Exception as e:
         issues.append(f"Error reading result file: {e}")
-        return False, issues
+        return False, issues, warnings
     
     # Determine if valid (no critical issues)
     is_valid = len(issues) == 0
-    return is_valid, issues
+    return is_valid, issues, warnings
 
 
 def validate_all_results(benchmark_dir: str = "reports") -> int:
@@ -129,7 +139,7 @@ def validate_all_results(benchmark_dir: str = "reports") -> int:
     print(f"Found {len(result_files)} result file(s) to validate\n")
     
     all_valid = True
-    validation_results = []
+    validation_results: List[Tuple[str, bool, List[str], List[str]]] = []
     
     for result_file in sorted(result_files):
         # Extract language name from filename
@@ -137,9 +147,9 @@ def validate_all_results(benchmark_dir: str = "reports") -> int:
         language = filename.replace(".json", "")
         
         print(f"Validating {language}...")
-        is_valid, issues = validate_result_json(Path(result_file), language)
+        is_valid, issues, warnings = validate_result_json(Path(result_file), language)
         
-        validation_results.append((language, is_valid, issues))
+        validation_results.append((language, is_valid, issues, warnings))
         
         if is_valid:
             print(f"  ✅ Valid")
@@ -148,6 +158,10 @@ def validate_all_results(benchmark_dir: str = "reports") -> int:
             for issue in issues:
                 print(f"     - {issue}")
             all_valid = False
+        if warnings:
+            print(f"  ⚠️ Warnings - {len(warnings)}:")
+            for warning in warnings:
+                print(f"     - {warning}")
         print()
     
     # Summary
@@ -155,12 +169,14 @@ def validate_all_results(benchmark_dir: str = "reports") -> int:
     print("Validation Summary")
     print("=" * 60)
     
-    valid_count = sum(1 for _, valid, _ in validation_results if valid)
+    valid_count = sum(1 for _, valid, _, _ in validation_results if valid)
     invalid_count = len(validation_results) - valid_count
+    warning_count = sum(len(warnings) for _, _, _, warnings in validation_results)
     
     print(f"Total files: {len(validation_results)}")
     print(f"✅ Valid: {valid_count}")
     print(f"❌ Invalid: {invalid_count}")
+    print(f"⚠️ Warnings: {warning_count}")
     
     if all_valid:
         print("\n🎉 All result files are valid!")

--- a/README.md
+++ b/README.md
@@ -18,34 +18,35 @@ All implementations target parity for core features: `perft`, `fen`, `ai`, `cast
 
 <!-- status-table-start -->
 
-| Language | Status | LOC | make build | make analyze | make test | make test-chess-engine | make test score | make test-chess-engine score | Features |
-|----------|--------|-----|------------|--------------|-----------|------------------------|-----------------|------------------------------|----------|
-| 📦 Bun | 🟢 | [669](implementations/bun/chess.js) | -, - MB | 223ms, 7 MB | 209ms, 7 MB | 98046ms, 62 MB | 1/1 | 2/16 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
-| 💠 Crystal | 🟢 | [1692](implementations/crystal/src/chess_engine.cr) | 1303ms, 250 MB | 967ms, 195 MB | 2388ms, 524 MB | 9826ms, 62 MB | 1/1 | 5/16 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
-| 🎯 Dart | 🟡 | [2742](implementations/dart/bin/main.dart) | -, - MB | 188ms, 7 MB | 192ms, 7 MB | 15068ms, 62 MB | 1/1 | 16/16 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
-| 🌳 Elm | 🟢 | [1663](implementations/elm/src/ChessEngine.elm) | 148ms, 6 MB | 144ms, 7 MB | 162ms, 7 MB | 9745ms, 62 MB | 1/1 | 3/16 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
-| ✨ Gleam | 🟢 | [1917](implementations/gleam/src/chess_engine.gleam) | 443ms, 18 MB | 360ms, 7 MB | 824ms, 77 MB | 70240ms, 62 MB | 1/1 | 0/16 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
-| 🐹 Go | 🟢 | [3352](implementations/go/chess.go) | 530ms, 80 MB | 1188ms, 111 MB | 1083ms, 110 MB | 10031ms, 62 MB | 1/1 | 16/16 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
-| 📐 Haskell | 🟢 | [1085](implementations/haskell/src/Main.hs) | 358ms, 38 MB | 207ms, 6 MB | 230ms, 6 MB | 70408ms, 62 MB | 1/1 | 0/16 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
-| 🪶 Imba | 🟡 | [700](implementations/imba/chess.imba) | 168ms, 7 MB | 166ms, 7 MB | 169ms, 7 MB | 110879ms, 62 MB | 1/1 | 2/16 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
-| 🟨 Javascript | 🟡 | [682](implementations/javascript/chess.js) | -, - MB | 209ms, 7 MB | 190ms, 7 MB | 85603ms, 62 MB | 1/1 | 2/16 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
-| 🔮 Julia | 🟢 | [1369](implementations/julia/chess.jl) | -, - MB | 190ms, 6 MB | 192ms, 7 MB | 12323ms, 62 MB | 1/1 | 2/16 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
-| 🧡 Kotlin | 🟡 | [1524](implementations/kotlin/src/main/kotlin/ChessEngine.kt) | 191ms, 7 MB | 185ms, 7 MB | 185ms, 7 MB | 10000ms, 62 MB | 1/1 | 2/16 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
-| 🪐 Lua | 🟢 | [2230](implementations/lua/chess.lua) | -, - MB | 146ms, 7 MB | 149ms, 7 MB | 10020ms, 62 MB | 1/1 | 16/16 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
-| 🔥 Mojo | 🟢 | [275](implementations/mojo/chess.mojo) | 10073ms, - MB | 10052ms, - MB | 10042ms, - MB | 10753ms, 62 MB | 0/1 | 0/58 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
-| 🦊 Nim | 🟢 | [1105](implementations/nim/chess.nim) | 185ms, 7 MB | 200ms, 7 MB | 192ms, 6 MB | 9733ms, 62 MB | 1/1 | 2/16 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
-| 🐘 Php | 🟢 | [2936](implementations/php/chess.php) | -, - MB | 329ms, 9 MB | 214ms, 9 MB | 9949ms, 62 MB | 1/1 | 16/16 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
-| 🐍 Python | 🟡 | [3077](implementations/python/chess.py) | -, - MB | 204ms, 7 MB | 185ms, 7 MB | 10001ms, 61 MB | 1/1 | 16/16 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
-| 🧠 Rescript | 🟡 | [1678](implementations/rescript/src/Chess.res) | 204ms, 7 MB | 191ms, 7 MB | 181ms, 5 MB | 180083ms, - MB | 1/1 | 0/1 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
-| ❤️ Ruby | 🟡 | [1906](implementations/ruby/chess.rb) | -, - MB | 2238ms, 229 MB | 279ms, 9 MB | 12036ms, 62 MB | 1/1 | 2/16 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
-| 🦀 Rust | 🟢 | [1852](implementations/rust/src/main.rs) | 187ms, 7 MB | 182ms, 7 MB | 181ms, 7 MB | 9714ms, 61 MB | 1/1 | 2/16 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
-| 🐦 Swift | 🟢 | [856](implementations/swift/src/main.swift) | 192ms, 6 MB | 185ms, 7 MB | 187ms, 6 MB | 180082ms, - MB | 1/1 | 0/1 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
-| 📘 Typescript | 🟡 | [1773](implementations/typescript/src/chess.ts) | 195ms, 7 MB | 188ms, 7 MB | 196ms, 7 MB | 9922ms, 62 MB | 1/1 | 2/16 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
-| ⚡ Zig | 🟢 | [1589](implementations/zig/src/main.zig) | 184ms, 7 MB | 205ms, 5 MB | 184ms, 7 MB | 58003ms, 62 MB | 1/1 | 0/36 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
+| Language | Status | TOKENS | make build | make analyze | make test | make test-chess-engine | make test score | make test-chess-engine score | Features |
+|----------|--------|--------|------------|--------------|-----------|------------------------|-----------------|------------------------------|----------|
+| 📦 Bun | 🟢 | [6523](implementations/bun/chess.js) | 299ms, 110 MB | 192ms, 7 MB | 192ms, 7 MB | 73115ms, - MB | 1/1 | 1/1 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
+| 💠 Crystal | 🟢 | [9441](implementations/crystal/src/chess_engine.cr) | 241ms, 110 MB | 959ms, 196 MB | 2394ms, 526 MB | 8411ms, - MB | 1/1 | 1/1 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
+| 🎯 Dart | 🟡 | [13314](implementations/dart/bin/main.dart) | 542ms, - MB | 1277ms, 211 MB | 3109ms, 451 MB | -, - MB | 1/1 | - | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
+| 🌳 Elm | 🟢 | [7868](implementations/elm/src/ChessEngine.elm) | 1395ms, - MB | 379ms, 4 MB | 358ms, 9 MB | -, - MB | 1/1 | - | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
+| ✨ Gleam | 🟢 | [107698](implementations/gleam/src/chess_engine.gleam) | 288ms, 110 MB | 333ms, 6 MB | 777ms, 61 MB | 52904ms, - MB | 1/1 | 1/1 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
+| 🐹 Go | 🟢 | [14374](implementations/go/chess.go) | 443ms, 65 MB | 1150ms, 111 MB | 1085ms, 115 MB | 8417ms, - MB | 1/1 | 1/1 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
+| 📐 Haskell | 🟢 | [8520](implementations/haskell/src/Main.hs) | 423ms, 115 MB | 217ms, 7 MB | 229ms, 6 MB | 52855ms, - MB | 1/1 | 1/1 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
+| 🪶 Imba | 🟡 | [6956](implementations/imba/chess.imba) | 322ms, 110 MB | 209ms, 7 MB | 195ms, 7 MB | 101421ms, - MB | 1/1 | 1/1 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
+| 🟨 Javascript | 🟡 | [6596](implementations/javascript/chess.js) | 200ms, 110 MB | 192ms, 6 MB | 191ms, 7 MB | 68310ms, - MB | 1/1 | 1/1 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
+| 🔮 Julia | 🟢 | [9783](implementations/julia/chess.jl) | 235ms, 112 MB | 192ms, 7 MB | 181ms, 7 MB | 10843ms, - MB | 1/1 | 1/1 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
+| 🧡 Kotlin | 🟡 | [9666](implementations/kotlin/src/main/kotlin/ChessEngine.kt) | 213ms, 111 MB | 149ms, 7 MB | 171ms, 7 MB | 8463ms, - MB | 1/1 | 1/1 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
+| 🪐 Lua | 🟢 | [10144](implementations/lua/chess.lua) | 432ms, - MB | 316ms, - MB | 264ms, - MB | -, - MB | 1/1 | - | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
+| 🔥 Mojo | 🟢 | [1820](implementations/mojo/chess.mojo) | 581ms, 115 MB | 9695ms, - MB | 10301ms, - MB | 10071ms, - MB | 1/1 | 1/1 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
+| 🦊 Nim | 🟢 | [8410](implementations/nim/chess.nim) | 215ms, 110 MB | 184ms, 7 MB | 191ms, 6 MB | 8321ms, - MB | 1/1 | 1/1 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
+| 🐘 Php | 🟢 | [15126](implementations/php/chess.php) | 326ms, 9 MB | 335ms, 9 MB | 212ms, 9 MB | 8350ms, 61 MB | 1/1 | 14/14 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
+| 🐍 Python | 🟡 | [17166](implementations/python/chess.py) | 103ms, - MB | 209ms, - MB | 597ms, - MB | -, - MB | 1/1 | - | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
+| 🧠 Rescript | 🟡 | [11181](implementations/rescript/src/Chess.res) | 291ms, 110 MB | 192ms, 7 MB | 206ms, 7 MB | 180096ms, - MB | 1/1 | 1/1 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
+| ❤️ Ruby | 🟡 | [9600](implementations/ruby/chess.rb) | 354ms, - MB | 1661ms, - MB | 1850ms, - MB | -, - MB | 1/1 | - | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
+| 🦀 Rust | 🟢 | [12770](implementations/rust/src/main.rs) | 13974ms, 110 MB | 197ms, 7 MB | 188ms, 7 MB | 8327ms, - MB | 1/1 | 1/1 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
+| 🐦 Swift | 🟢 | [7650](implementations/swift/src/main.swift) | 369ms, 114 MB | 195ms, 7 MB | 181ms, 7 MB | 180096ms, - MB | 1/1 | 1/1 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
+| 📘 Typescript | 🟡 | [13805](implementations/typescript/src/chess.ts) | 183ms, 7 MB | 216ms, 7 MB | 179ms, 7 MB | 8443ms, - MB | 1/1 | 1/1 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
+| ⚡ Zig | 🟢 | [13302](implementations/zig/src/main.zig) | 280ms, 110 MB | 187ms, 7 MB | 188ms, 7 MB | 51994ms, - MB | 1/1 | 1/1 | 6/9 (67%) `perft` `fen` `ai` `castling` `en_passant` `promotion` |
 <!-- status-table-end -->
 
 Legend:
 - `Status`: `🟢 excellent` (no errors/warnings), `🟡 good` (warnings only), `🔴 needs_work` (at least one error).
+- `TOKENS`: `tokens-v2` computed from Git-discovered files (tracked + untracked, excluding ignored) filtered by metadata `org.chess.source_exts`.
 - `make ...` columns: `<duration>, <peak memory>`.
 - `-`: metric missing or intentionally skipped.
 
@@ -57,38 +58,38 @@ Lower is better. Bars are normalized per step (`####################` = fastest)
 #### `make build`
 | Rank | Implementation | Time | Chart |
 |------|----------------|------|-------|
-| 1 | 🌳 Elm | 148ms | `####################` |
-| 2 | 🪶 Imba | 168ms | `##################` |
-| 3 | ⚡ Zig | 184ms | `################` |
-| 4 | 🦊 Nim | 185ms | `################` |
-| 5 | 🦀 Rust | 187ms | `################` |
+| 1 | 🐍 Python | 103ms | `####################` |
+| 2 | 📘 Typescript | 183ms | `###########` |
+| 3 | 🟨 Javascript | 200ms | `##########` |
+| 4 | 🧡 Kotlin | 213ms | `##########` |
+| 5 | 🦊 Nim | 215ms | `##########` |
 
 #### `make analyze`
 | Rank | Implementation | Time | Chart |
 |------|----------------|------|-------|
-| 1 | 🌳 Elm | 144ms | `####################` |
-| 2 | 🪐 Lua | 146ms | `####################` |
-| 3 | 🪶 Imba | 166ms | `#################` |
-| 4 | 🦀 Rust | 182ms | `################` |
-| 5 | 🧡 Kotlin | 185ms | `################` |
+| 1 | 🧡 Kotlin | 149ms | `####################` |
+| 2 | 🦊 Nim | 184ms | `################` |
+| 3 | ⚡ Zig | 187ms | `################` |
+| 4 | 🔮 Julia | 192ms | `################` |
+| 5 | 🧠 Rescript | 192ms | `################` |
 
 #### `make test`
 | Rank | Implementation | Time | Chart |
 |------|----------------|------|-------|
-| 1 | 🪐 Lua | 149ms | `####################` |
-| 2 | 🌳 Elm | 162ms | `##################` |
-| 3 | 🪶 Imba | 169ms | `##################` |
-| 4 | 🦀 Rust | 181ms | `################` |
-| 5 | 🧠 Rescript | 181ms | `################` |
+| 1 | 🧡 Kotlin | 171ms | `####################` |
+| 2 | 📘 Typescript | 179ms | `###################` |
+| 3 | 🔮 Julia | 181ms | `###################` |
+| 4 | 🐦 Swift | 181ms | `###################` |
+| 5 | 🦀 Rust | 188ms | `##################` |
 
 #### `make test-chess-engine`
 | Rank | Implementation | Time | Chart |
 |------|----------------|------|-------|
-| 1 | 🦀 Rust | 9714ms | `####################` |
-| 2 | 🦊 Nim | 9733ms | `####################` |
-| 3 | 🌳 Elm | 9745ms | `####################` |
-| 4 | 💠 Crystal | 9826ms | `####################` |
-| 5 | 📘 Typescript | 9922ms | `####################` |
+| 1 | 🦊 Nim | 8321ms | `####################` |
+| 2 | 🦀 Rust | 8327ms | `####################` |
+| 3 | 🐘 Php | 8350ms | `####################` |
+| 4 | 💠 Crystal | 8411ms | `####################` |
+| 5 | 🐹 Go | 8417ms | `####################` |
 <!-- speed-chart-end -->
 
 ## Quick Commands

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -40,6 +40,7 @@ Required Docker labels:
 - `org.chess.features`
 - `org.chess.max_ai_depth`
 - `org.chess.estimated_perft4_ms`
+- `org.chess.source_exts`
 - `org.chess.build`
 - `org.chess.test`
 - `org.chess.analyze`

--- a/implementations/bun/Dockerfile
+++ b/implementations/bun/Dockerfile
@@ -8,6 +8,7 @@ LABEL org.chess.author="Bun JavaScript Implementation"
 LABEL org.chess.features="perft,fen,ai,castling,en_passant,promotion"
 LABEL org.chess.max_ai_depth=5
 LABEL org.chess.estimated_perft4_ms=1000
+LABEL org.chess.source_exts=".js"
 LABEL org.chess.benchmark.build="skip"
 LABEL org.chess.build="bun build chess.js --outdir dist --target bun"
 LABEL org.chess.run="bun run chess.js"

--- a/implementations/crystal/Dockerfile
+++ b/implementations/crystal/Dockerfile
@@ -10,6 +10,7 @@ LABEL org.chess.author="Crystal Implementation"
 LABEL org.chess.features="perft,fen,ai,castling,en_passant,promotion"
 LABEL org.chess.max_ai_depth=5
 LABEL org.chess.estimated_perft4_ms=800
+LABEL org.chess.source_exts=".cr"
 LABEL org.chess.build="crystal build src/chess_engine.cr --release -o chess_engine"
 LABEL org.chess.run="./chess_engine"
 LABEL org.chess.test="crystal spec"

--- a/implementations/dart/Dockerfile
+++ b/implementations/dart/Dockerfile
@@ -11,7 +11,7 @@ LABEL org.chess.author="Dart Implementation"
 LABEL org.chess.features="perft,fen,ai,castling,en_passant,promotion"
 LABEL org.chess.max_ai_depth=5
 LABEL org.chess.estimated_perft4_ms=900
-LABEL org.chess.benchmark.build="skip"
+LABEL org.chess.source_exts=".dart"
 LABEL org.chess.build="printf 'quit\n' | dart --packages=package_config.json bin/main.dart"
 LABEL org.chess.test="printf 'new\nmove e2e4\nmove e7e5\nexport\nquit\n' | dart --packages=package_config.json bin/main.dart"
 LABEL org.chess.analyze="dart format --output=none bin lib"

--- a/implementations/elm/Dockerfile
+++ b/implementations/elm/Dockerfile
@@ -10,6 +10,7 @@ LABEL org.chess.author="Elm Implementation with Node.js Bridge"
 LABEL org.chess.features="perft,fen,ai,castling,en_passant,promotion"
 LABEL org.chess.max_ai_depth=5
 LABEL org.chess.estimated_perft4_ms=1200
+LABEL org.chess.source_exts=".elm"
 LABEL org.chess.run="node chess-bridge.js"
 LABEL org.chess.build="elm make src/ChessEngine.elm --output=src/chess.js"
 LABEL org.chess.test="node chess-bridge.js --test"

--- a/implementations/gleam/Dockerfile
+++ b/implementations/gleam/Dockerfile
@@ -10,6 +10,7 @@ LABEL org.chess.author="Gleam Implementation"
 LABEL org.chess.features="perft,fen,ai,castling,en_passant,promotion"
 LABEL org.chess.max_ai_depth=5
 LABEL org.chess.estimated_perft4_ms=800
+LABEL org.chess.source_exts=".gleam"
 LABEL org.chess.build="gleam build"
 LABEL org.chess.test="gleam test"
 LABEL org.chess.analyze="gleam format --check && gleam check"

--- a/implementations/go/Dockerfile
+++ b/implementations/go/Dockerfile
@@ -10,6 +10,7 @@ LABEL org.chess.author="AI Implementation"
 LABEL org.chess.features="perft,fen,ai,castling,en_passant,promotion"
 LABEL org.chess.max_ai_depth=5
 LABEL org.chess.estimated_perft4_ms=800
+LABEL org.chess.source_exts=".go"
 LABEL org.chess.build="go build -o chess ."
 LABEL org.chess.test="go test ./..."
 LABEL org.chess.analyze="go vet ./... && gofmt -d ."

--- a/implementations/haskell/Dockerfile
+++ b/implementations/haskell/Dockerfile
@@ -11,6 +11,7 @@ LABEL org.chess.author="Haskell Implementation"
 LABEL org.chess.features="perft,fen,ai,castling,en_passant,promotion"
 LABEL org.chess.max_ai_depth=5
 LABEL org.chess.estimated_perft4_ms=1000
+LABEL org.chess.source_exts=".hs"
 LABEL org.chess.run="./chess_engine"
 LABEL org.chess.build="ghc -O2 --make src/Main.hs -o chess_engine -isrc"
 LABEL org.chess.test="./chess_engine --test"

--- a/implementations/imba/Dockerfile
+++ b/implementations/imba/Dockerfile
@@ -10,6 +10,7 @@ LABEL org.chess.author="Imba Implementation"
 LABEL org.chess.features="perft,fen,ai,castling,en_passant,promotion"
 LABEL org.chess.max_ai_depth=5
 LABEL org.chess.estimated_perft4_ms=1000
+LABEL org.chess.source_exts=".imba"
 LABEL org.chess.build="imba build chess.imba --platform node --base . --outdir dist"
 LABEL org.chess.run="node dist/chess.js"
 LABEL org.chess.test="true"

--- a/implementations/javascript/Dockerfile
+++ b/implementations/javascript/Dockerfile
@@ -10,6 +10,7 @@ LABEL org.chess.author="JavaScript Implementation"
 LABEL org.chess.features="perft,fen,ai,castling,en_passant,promotion"
 LABEL org.chess.max_ai_depth=5
 LABEL org.chess.estimated_perft4_ms=1000
+LABEL org.chess.source_exts=".js"
 LABEL org.chess.benchmark.build="skip"
 LABEL org.chess.build="node --check chess.js"
 LABEL org.chess.test="npm test"

--- a/implementations/julia/Dockerfile
+++ b/implementations/julia/Dockerfile
@@ -8,6 +8,7 @@ LABEL org.chess.author="Julia Implementation"
 LABEL org.chess.features="perft,fen,ai,castling,en_passant,promotion"
 LABEL org.chess.max_ai_depth=5
 LABEL org.chess.estimated_perft4_ms=1000
+LABEL org.chess.source_exts=".jl"
 LABEL org.chess.benchmark.build="skip"
 LABEL org.chess.run="julia --project=. chess.jl"
 LABEL org.chess.build="julia --project=. -e 'include(\"chess.jl\")'"

--- a/implementations/kotlin/Dockerfile
+++ b/implementations/kotlin/Dockerfile
@@ -11,6 +11,7 @@ LABEL org.chess.author="Kotlin Implementation"
 LABEL org.chess.features="perft,fen,ai,castling,en_passant,promotion"
 LABEL org.chess.max_ai_depth=5
 LABEL org.chess.estimated_perft4_ms=500
+LABEL org.chess.source_exts=".kt"
 LABEL org.chess.run="java -jar build/libs/chess-1.0.0.jar"
 LABEL org.chess.build="kotlinc src/main/kotlin/*.kt -include-runtime -d build/libs/chess-1.0.0.jar"
 LABEL org.chess.test="java -jar build/libs/chess-1.0.0.jar --test"

--- a/implementations/lua/Dockerfile
+++ b/implementations/lua/Dockerfile
@@ -8,6 +8,7 @@ LABEL org.chess.author="Lua Implementation"
 LABEL org.chess.features="perft,fen,ai,castling,en_passant,promotion"
 LABEL org.chess.max_ai_depth=5
 LABEL org.chess.estimated_perft4_ms=1000
+LABEL org.chess.source_exts=".lua"
 LABEL org.chess.benchmark.build="skip"
 LABEL org.chess.build="lua -e \"assert(loadfile('chess.lua'))\""
 LABEL org.chess.test="echo -e 'new\nmove e2e4\nmove e7e5\nexport\nquit' | lua chess.lua"

--- a/implementations/mojo/Dockerfile
+++ b/implementations/mojo/Dockerfile
@@ -8,6 +8,7 @@ LABEL org.chess.author="Mojo Implementation"
 LABEL org.chess.features="perft,fen,ai,castling,en_passant,promotion"
 LABEL org.chess.max_ai_depth=5
 LABEL org.chess.estimated_perft4_ms=1000
+LABEL org.chess.source_exts=".mojo"
 LABEL org.chess.build="mojo build chess.mojo"
 LABEL org.chess.test="mojo chess.mojo"
 LABEL org.chess.analyze="mojo chess.mojo --no-run"

--- a/implementations/nim/Dockerfile
+++ b/implementations/nim/Dockerfile
@@ -10,6 +10,7 @@ LABEL org.chess.author="Nim Implementation"
 LABEL org.chess.features="perft,fen,ai,castling,en_passant,promotion"
 LABEL org.chess.max_ai_depth=5
 LABEL org.chess.estimated_perft4_ms=1000
+LABEL org.chess.source_exts=".nim"
 LABEL org.chess.build="nim c -d:release chess.nim"
 LABEL org.chess.test="./chess --test"
 LABEL org.chess.analyze="nim check chess.nim"

--- a/implementations/php/Dockerfile
+++ b/implementations/php/Dockerfile
@@ -8,6 +8,7 @@ LABEL org.chess.author="PHP Implementation"
 LABEL org.chess.features="perft,fen,ai,castling,en_passant,promotion"
 LABEL org.chess.max_ai_depth=5
 LABEL org.chess.estimated_perft4_ms=1500
+LABEL org.chess.source_exts=".php"
 LABEL org.chess.benchmark.build="skip"
 LABEL org.chess.build="php -l chess.php"
 LABEL org.chess.test="echo -e 'new\nmove e2e4\nmove e7e5\nexport\nquit' | php chess.php"

--- a/implementations/python/Dockerfile
+++ b/implementations/python/Dockerfile
@@ -8,6 +8,7 @@ LABEL org.chess.author="Python Implementation"
 LABEL org.chess.features="perft,fen,ai,castling,en_passant,promotion"
 LABEL org.chess.max_ai_depth=5
 LABEL org.chess.estimated_perft4_ms=1000
+LABEL org.chess.source_exts=".py"
 LABEL org.chess.benchmark.build="skip"
 LABEL org.chess.build="python3 -m py_compile chess.py"
 LABEL org.chess.test="python3 test_engine.py"

--- a/implementations/rescript/Dockerfile
+++ b/implementations/rescript/Dockerfile
@@ -10,6 +10,7 @@ LABEL org.chess.author="ReScript Implementation"
 LABEL org.chess.features="perft,fen,ai,castling,en_passant,promotion"
 LABEL org.chess.max_ai_depth=5
 LABEL org.chess.estimated_perft4_ms=1500
+LABEL org.chess.source_exts=".res,.resi"
 LABEL org.chess.build="npm run build"
 LABEL org.chess.test="node lib/es6/src/Chess.js --test"
 LABEL org.chess.analyze="npx rescript build"

--- a/implementations/ruby/Dockerfile
+++ b/implementations/ruby/Dockerfile
@@ -10,6 +10,7 @@ LABEL org.chess.author="Ruby Implementation"
 LABEL org.chess.features="perft,fen,ai,castling,en_passant,promotion"
 LABEL org.chess.max_ai_depth=5
 LABEL org.chess.estimated_perft4_ms=1000
+LABEL org.chess.source_exts=".rb"
 LABEL org.chess.benchmark.build="skip"
 LABEL org.chess.build="ruby -c chess.rb"
 LABEL org.chess.test="rspec"

--- a/implementations/rust/Dockerfile
+++ b/implementations/rust/Dockerfile
@@ -10,6 +10,7 @@ LABEL org.chess.author="Rust Implementation"
 LABEL org.chess.features="perft,fen,ai,castling,en_passant,promotion"
 LABEL org.chess.max_ai_depth=5
 LABEL org.chess.estimated_perft4_ms=600
+LABEL org.chess.source_exts=".rs"
 LABEL org.chess.build="cargo build --release"
 LABEL org.chess.test="cargo test"
 LABEL org.chess.analyze="cargo check --all-targets"

--- a/implementations/swift/Dockerfile
+++ b/implementations/swift/Dockerfile
@@ -10,6 +10,7 @@ LABEL org.chess.author="Jules"
 LABEL org.chess.features="perft,fen,ai,castling,en_passant,promotion"
 LABEL org.chess.max_ai_depth=5
 LABEL org.chess.estimated_perft4_ms=1000
+LABEL org.chess.source_exts=".swift"
 LABEL org.chess.build="swift build -c release"
 LABEL org.chess.test="swift test"
 LABEL org.chess.analyze="swift build --configuration debug"

--- a/implementations/typescript/Dockerfile
+++ b/implementations/typescript/Dockerfile
@@ -10,6 +10,7 @@ LABEL org.chess.author="TypeScript Implementation"
 LABEL org.chess.features="perft,fen,ai,castling,en_passant,promotion"
 LABEL org.chess.max_ai_depth=5
 LABEL org.chess.estimated_perft4_ms=800
+LABEL org.chess.source_exts=".ts"
 LABEL org.chess.build="npm run build"
 LABEL org.chess.test="npm test"
 LABEL org.chess.analyze="npm run lint"

--- a/implementations/zig/Dockerfile
+++ b/implementations/zig/Dockerfile
@@ -10,6 +10,7 @@ LABEL org.chess.author="Zig Implementation"
 LABEL org.chess.features="perft,fen,ai,castling,en_passant,promotion"
 LABEL org.chess.max_ai_depth=5
 LABEL org.chess.estimated_perft4_ms=800
+LABEL org.chess.source_exts=".zig"
 LABEL org.chess.build="zig build -Doptimize=ReleaseFast"
 LABEL org.chess.run="./zig-out/bin/chess"
 LABEL org.chess.test="./zig-out/bin/chess --test"

--- a/scripts/chess_metadata.py
+++ b/scripts/chess_metadata.py
@@ -21,8 +21,8 @@ def get_dockerfile_metadata(dockerfile_path: Path) -> Dict[str, Any]:
                 else:
                     val = raw_val
                 
-                # Handle lists (like features)
-                if key == 'features' and val:
+                # Handle comma-separated lists.
+                if key in {'features', 'source_exts'} and val:
                     metadata[key] = [f.strip() for f in val.split(',')]
                 # Handle integers
                 elif key in ['max_ai_depth', 'estimated_perft4_ms'] and val:

--- a/scripts/token_metrics.py
+++ b/scripts/token_metrics.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Shared helpers for implementation size and token metrics."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+TOKEN_METRIC_VERSION = "tokens-v2"
+
+# Language-agnostic tokenizer:
+# - identifiers
+# - integer/decimal numbers
+# - common multi-char operators
+# - punctuation/single-char operators
+# - fallback on any non-whitespace symbol
+TOKEN_PATTERN = re.compile(
+    r"[A-Za-z_][A-Za-z0-9_]*"
+    r"|\d+(?:\.\d+)?"
+    r"|==|!=|<=|>=|<<|>>|&&|\|\||::|->|=>|\+\+|--|\+=|-=|\*=|/=|%=|&=|\|=|\^=|//="
+    r"|[{}()\[\].,;:?+\-*/%&|^~<>!=]"
+    r"|\S"
+)
+
+
+def parse_source_exts(raw_value: object) -> List[str]:
+    """Normalize source extension declarations to a deduplicated lower-case list."""
+    if raw_value is None:
+        return []
+
+    if isinstance(raw_value, str):
+        items = [part.strip() for part in raw_value.split(",")]
+    elif isinstance(raw_value, (list, tuple, set)):
+        items = [str(part).strip() for part in raw_value]
+    else:
+        return []
+
+    normalized: List[str] = []
+    seen = set()
+    for item in items:
+        if not item:
+            continue
+        extension = item if item.startswith(".") else f".{item}"
+        extension = extension.lower()
+        if extension in seen:
+            continue
+        seen.add(extension)
+        normalized.append(extension)
+    return normalized
+
+
+def normalize_line_endings(text: str) -> str:
+    """Normalize CRLF/CR line endings to LF."""
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def count_tokens(text: str) -> int:
+    """Count tokens using the language-agnostic regex."""
+    normalized = normalize_line_endings(text)
+    return len(TOKEN_PATTERN.findall(normalized))
+
+
+def _find_repo_root(start_path: Path) -> Optional[Path]:
+    """Find repository root by walking parent directories until .git is found."""
+    current = start_path.resolve()
+    if current.is_file():
+        current = current.parent
+
+    for candidate in [current, *current.parents]:
+        if (candidate / ".git").exists():
+            return candidate
+    return None
+
+
+def list_git_discovered_files(impl_path: Path) -> List[Path]:
+    """List tracked + untracked files (excluding ignored) for an implementation."""
+    repo_root = _find_repo_root(impl_path)
+    if repo_root is None:
+        raise RuntimeError(f"Could not locate git repository root for {impl_path}")
+
+    impl_abs = impl_path.resolve()
+    try:
+        rel_impl = impl_abs.relative_to(repo_root)
+    except ValueError as exc:
+        raise RuntimeError(f"Implementation path {impl_abs} is outside repository root {repo_root}") from exc
+
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "ls-files", "-co", "--exclude-standard", "--", str(rel_impl)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        raise RuntimeError(f"git ls-files failed for {rel_impl}: {stderr or 'unknown error'}")
+
+    files: List[Path] = []
+    for line in sorted(line.strip() for line in result.stdout.splitlines() if line.strip()):
+        candidate = (repo_root / line).resolve()
+        if candidate.is_file():
+            files.append(candidate)
+    return files
+
+
+def _is_probably_binary(file_path: Path) -> bool:
+    """Return True if file appears binary based on NUL-byte probe."""
+    try:
+        with open(file_path, "rb") as handle:
+            return b"\x00" in handle.read(8192)
+    except OSError:
+        return True
+
+
+def _read_text_file(file_path: Path) -> Optional[str]:
+    """Read UTF-8 text content, skipping unreadable/binary files safely."""
+    if _is_probably_binary(file_path):
+        return None
+    try:
+        return file_path.read_text(encoding="utf-8", errors="ignore")
+    except (OSError, UnicodeError):
+        return None
+
+
+def collect_impl_metrics(impl_path: Path, source_exts: Sequence[str]) -> Dict[str, object]:
+    """Collect LOC + token metrics for one implementation using git-discovered files."""
+    normalized_exts = parse_source_exts(source_exts)
+    if not normalized_exts:
+        raise ValueError(f"No valid source extensions configured for {impl_path}")
+
+    source_files = 0
+    source_loc = 0
+    tokens_count = 0
+    skipped_binary_or_unreadable = 0
+
+    for file_path in list_git_discovered_files(impl_path):
+        if file_path.suffix.lower() not in normalized_exts:
+            continue
+
+        text = _read_text_file(file_path)
+        if text is None:
+            skipped_binary_or_unreadable += 1
+            continue
+
+        normalized = normalize_line_endings(text)
+        source_files += 1
+        source_loc += len(normalized.splitlines())
+        tokens_count += count_tokens(normalized)
+
+    return {
+        "implementation": impl_path.name,
+        "path": str(impl_path),
+        "source_exts": normalized_exts,
+        "source_files": source_files,
+        "source_loc": source_loc,
+        "tokens_count": tokens_count,
+        "metric_version": TOKEN_METRIC_VERSION,
+        "skipped_binary_or_unreadable": skipped_binary_or_unreadable,
+    }
+
+
+def collect_impl_metrics_from_metadata(impl_path: Path, metadata: Dict[str, object]) -> Dict[str, object]:
+    """Collect metrics by reading source extension declarations from metadata."""
+    source_exts = parse_source_exts(metadata.get("source_exts"))
+    return collect_impl_metrics(impl_path, source_exts)

--- a/test/code_size_metrics.py
+++ b/test/code_size_metrics.py
@@ -1,70 +1,38 @@
 #!/usr/bin/env python3
-"""Collect normalized implementation code size metrics."""
+"""Collect implementation code size and token metrics."""
 
 import argparse
 import json
+import sys
 from pathlib import Path
-from typing import Dict, Iterable, List
+from typing import Dict, List
 
-EXCLUDED_DIRS = {
-    "node_modules",
-    "vendor",
-    "dist",
-    "build",
-    "target",
-    ".dart_tool",
-    "elm-stuff",
-    ".git",
-    ".next",
-    "coverage",
-    "__pycache__",
-}
+# Ensure repository root is importable.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
-SOURCE_EXTENSIONS = {
-    ".py", ".rb", ".ts", ".js", ".rs", ".go", ".dart", ".php", ".lua",
-    ".kt", ".swift", ".nim", ".zig", ".hs", ".elm", ".cr", ".jl",
-    ".re", ".resi", ".imba", ".mjo", ".c", ".h", ".cpp", ".hpp", ".cc",
-    ".cxx", ".hh", ".hxx", ".java", ".scala", ".ex", ".exs", ".ml", ".mli",
-}
+# Import shared helpers from scripts/.
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
 
-
-def _is_excluded(path: Path, root: Path) -> bool:
-    try:
-        rel = path.relative_to(root)
-    except ValueError:
-        return True
-
-    for part in rel.parts:
-        if part in EXCLUDED_DIRS:
-            return True
-    return False
-
-
-def _iter_source_files(root: Path) -> Iterable[Path]:
-    for file_path in root.rglob("*"):
-        if not file_path.is_file():
-            continue
-        if _is_excluded(file_path, root):
-            continue
-        if file_path.suffix.lower() in SOURCE_EXTENSIONS:
-            yield file_path
+from chess_metadata import get_metadata
+from token_metrics import collect_impl_metrics_from_metadata
 
 
 def collect_metrics_for_impl(impl_path: Path) -> Dict:
-    source_files = list(_iter_source_files(impl_path))
-    source_loc = 0
-
-    for source_file in source_files:
-        try:
-            source_loc += len(source_file.read_text(encoding="utf-8", errors="ignore").splitlines())
-        except Exception:
-            continue
-
+    metadata = get_metadata(str(impl_path))
+    metrics = collect_impl_metrics_from_metadata(impl_path, metadata)
     return {
-        "implementation": impl_path.name,
-        "path": str(impl_path),
-        "source_files": len(source_files),
-        "source_loc": source_loc,
+        "implementation": metrics["implementation"],
+        "path": metrics["path"],
+        "source_files": metrics["source_files"],
+        "source_loc": metrics["source_loc"],
+        "tokens_count": metrics["tokens_count"],
+        "metric_version": metrics["metric_version"],
+        "source_exts": metrics["source_exts"],
+        "skipped_binary_or_unreadable": metrics["skipped_binary_or_unreadable"],
     }
 
 
@@ -80,25 +48,29 @@ def collect_metrics_for_dir(base_dir: Path) -> List[Dict]:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Collect normalized code size metrics")
+    parser = argparse.ArgumentParser(description="Collect implementation code size and token metrics")
     parser.add_argument("--impl", metavar="PATH", help="Single implementation path")
     parser.add_argument("--dir", default="implementations", metavar="DIR", help="Implementations directory")
     parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output")
 
     args = parser.parse_args()
 
-    if args.impl:
-        impl_path = Path(args.impl)
-        if not impl_path.exists() or not impl_path.is_dir():
-            print(json.dumps({"error": f"Implementation path not found: {impl_path}"}))
-            return 1
-        payload = collect_metrics_for_impl(impl_path)
-    else:
-        base_dir = Path(args.dir)
-        if not base_dir.exists() or not base_dir.is_dir():
-            print(json.dumps({"error": f"Directory not found: {base_dir}"}))
-            return 1
-        payload = collect_metrics_for_dir(base_dir)
+    try:
+        if args.impl:
+            impl_path = Path(args.impl)
+            if not impl_path.exists() or not impl_path.is_dir():
+                print(json.dumps({"error": f"Implementation path not found: {impl_path}"}))
+                return 1
+            payload = collect_metrics_for_impl(impl_path)
+        else:
+            base_dir = Path(args.dir)
+            if not base_dir.exists() or not base_dir.is_dir():
+                print(json.dumps({"error": f"Directory not found: {base_dir}"}))
+                return 1
+            payload = collect_metrics_for_dir(base_dir)
+    except Exception as exc:
+        print(json.dumps({"error": str(exc)}))
+        return 1
 
     indent = 2 if args.pretty else None
     print(json.dumps(payload, indent=indent))

--- a/test/performance_test.py
+++ b/test/performance_test.py
@@ -44,6 +44,7 @@ except ImportError:
 # Import existing test harness
 from test_harness import ChessEngineTester, TestSuite, find_implementations, TRACK_TO_SUITE
 from code_size_metrics import collect_metrics_for_impl
+from token_metrics import TOKEN_METRIC_VERSION
 
 TRUTHY_VALUES = {"1", "true", "yes", "y", "on"}
 FALSY_VALUES = {"0", "false", "no", "n", "off"}
@@ -163,6 +164,7 @@ class ImplementationTester:
             "timings": {},
             "memory": {},
             "size": {},
+            "metrics": {},
             "normalized": {},
             "docker": {},
             "task_results": {},
@@ -220,21 +222,27 @@ class ImplementationTester:
         return self.results
 
     def _collect_code_size_metrics(self):
-        """Collect normalized source LOC/file metrics."""
+        """Collect LOC/file metrics plus language-agnostic token metrics."""
         try:
             size_metrics = collect_metrics_for_impl(self.impl_path)
             self.results["size"] = {
                 "source_loc": size_metrics.get("source_loc", 0),
                 "source_files": size_metrics.get("source_files", 0),
             }
+            self.results["metrics"] = {
+                "tokens_count": size_metrics.get("tokens_count"),
+                "metric_version": size_metrics.get("metric_version", TOKEN_METRIC_VERSION),
+            }
             print(
                 "📏 Source size: "
                 f"{self.results['size']['source_loc']} LOC across "
-                f"{self.results['size']['source_files']} files"
+                f"{self.results['size']['source_files']} files, "
+                f"{self.results['metrics']['tokens_count']} TOKENS"
             )
         except Exception as e:
             self.results["errors"].append(f"Code size metrics error: {str(e)}")
             self.results["size"] = {"source_loc": 0, "source_files": 0}
+            self.results["metrics"] = {"tokens_count": None, "metric_version": TOKEN_METRIC_VERSION}
 
     def _compute_normalized_metrics(self):
         """Compute normalized metrics (ms/KLOC)."""
@@ -801,13 +809,13 @@ def generate_performance_report(results: List[Dict]) -> str:
     
     # Summary table
     report.append("PERFORMANCE SUMMARY")
-    report.append("-" * 168)
+    report.append("-" * 178)
     report.append(
-        f"{'Language':<12} {'Status':<10} {'LOC':<8} "
+        f"{'Language':<12} {'Status':<10} {'TOKENS':<10} {'LOC':<8} "
         f"{'make build':<18} {'make analyze':<18} {'make test':<18} {'make test-chess-engine':<25} "
         f"{'make test score':<16} {'make test-ce score':<18}"
     )
-    report.append("-" * 168)
+    report.append("-" * 178)
     
     for result in sorted(results, key=lambda x: x.get("language", "")):
         lang = result.get("language", "Unknown")[:11]
@@ -817,6 +825,7 @@ def generate_performance_report(results: List[Dict]) -> str:
         analyze_time = result.get("timings", {}).get("analyze_seconds", 0)
         test_time = result.get("timings", {}).get("test_seconds", 0)
         test_chess_engine_time = result.get("timings", {}).get("test_chess_engine_seconds", 0)
+        tokens_count = result.get("metrics", {}).get("tokens_count")
         source_loc = result.get("size", {}).get("source_loc", 0)
         
         memory = result.get("memory", {})
@@ -835,6 +844,7 @@ def generate_performance_report(results: List[Dict]) -> str:
 
         report.append(
             f"{lang:<12} {status:<10} "
+            f"{str(tokens_count) if tokens_count is not None else '-':<10} "
             f"{source_loc:<8} "
             f"{fmt_step_cell(build_time, build_mem):<18} "
             f"{fmt_step_cell(analyze_time, analyze_mem):<18} "
@@ -881,12 +891,18 @@ def generate_performance_report(results: List[Dict]) -> str:
 
         # Source size and normalized metrics
         size = result.get("size", {})
+        metric_data = result.get("metrics", {})
         normalized = result.get("normalized", {})
         if size:
             report.append("\nSOURCE SIZE:")
             report.append(
                 f"  Source LOC: {size.get('source_loc', 0)} "
                 f"(files: {size.get('source_files', 0)})"
+            )
+        if metric_data:
+            report.append(
+                f"  TOKENS ({metric_data.get('metric_version', 'unknown')}): "
+                f"{metric_data.get('tokens_count', '-')}"
             )
         if normalized:
             report.append("\nNORMALIZED METRICS:")

--- a/test/test_token_metrics.py
+++ b/test/test_token_metrics.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Unit tests for language-agnostic token metrics."""
+
+import subprocess
+import tempfile
+import unittest
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from token_metrics import TOKEN_METRIC_VERSION, collect_impl_metrics_from_metadata
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _init_git_repo(root: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+
+
+class TokenMetricsTests(unittest.TestCase):
+    def test_ignored_files_are_excluded_with_git_discovery(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            impl = root / "implementations" / "sample"
+            _init_git_repo(root)
+
+            _write(root / ".gitignore", "implementations/sample/ignored.foo\n")
+            _write(impl / "tracked.foo", "alpha + beta\n")
+            _write(impl / "untracked.foo", "gamma + delta\n")
+            _write(impl / "ignored.foo", "should_not_count\n")
+            subprocess.run(["git", "add", ".gitignore", "implementations/sample/tracked.foo"], cwd=root, check=True)
+
+            metrics = collect_impl_metrics_from_metadata(impl, {"source_exts": [".foo"]})
+            self.assertEqual(metrics["source_files"], 2)
+            self.assertEqual(metrics["metric_version"], TOKEN_METRIC_VERSION)
+
+    def test_binary_files_are_skipped_safely(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            impl = root / "implementations" / "sample"
+            _init_git_repo(root)
+
+            _write(impl / "text.foo", "a + b\n")
+            binary_path = impl / "binary.foo"
+            binary_path.parent.mkdir(parents=True, exist_ok=True)
+            binary_path.write_bytes(b"\x00\x01\x02binary")
+
+            metrics = collect_impl_metrics_from_metadata(impl, {"source_exts": [".foo"]})
+            self.assertEqual(metrics["source_files"], 1)
+            self.assertEqual(metrics["skipped_binary_or_unreadable"], 1)
+
+    def test_token_count_is_deterministic_for_same_tree(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            impl = root / "implementations" / "sample"
+            _init_git_repo(root)
+
+            _write(impl / "main.foo", "a + b\nc + d\n")
+            subprocess.run(["git", "add", "implementations/sample/main.foo"], cwd=root, check=True)
+
+            first = collect_impl_metrics_from_metadata(impl, {"source_exts": [".foo"]})["tokens_count"]
+            second = collect_impl_metrics_from_metadata(impl, {"source_exts": [".foo"]})["tokens_count"]
+            self.assertEqual(first, second)
+
+    def test_whitespace_only_changes_do_not_change_token_count(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            impl = root / "implementations" / "sample"
+            _init_git_repo(root)
+
+            source = impl / "main.foo"
+            _write(source, "alpha+beta\n")
+            subprocess.run(["git", "add", "implementations/sample/main.foo"], cwd=root, check=True)
+            before = collect_impl_metrics_from_metadata(impl, {"source_exts": [".foo"]})["tokens_count"]
+
+            _write(source, "alpha   +     beta\n\n")
+            after = collect_impl_metrics_from_metadata(impl, {"source_exts": [".foo"]})["tokens_count"]
+            self.assertEqual(before, after)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/verify_implementations.py
+++ b/test/verify_implementations.py
@@ -41,7 +41,7 @@ REQUIRED_MAKEFILE_TARGETS = {
 
 # Required metadata fields
 REQUIRED_META_FIELDS = {
-    'language', 'version', 'author', 'build', 'run', 'test', 'analyze', 'features', 'max_ai_depth'
+    'language', 'version', 'author', 'build', 'run', 'test', 'analyze', 'features', 'max_ai_depth', 'source_exts'
 }
 
 # Optional but recommended metadata fields
@@ -183,6 +183,25 @@ def validate_metadata(data: Dict, impl_name: str) -> Dict[str, List[str]]:
         extra_features = features - EXPECTED_FEATURES
         if extra_features:
             result['info'].extend([f"Extra feature: {feature}" for feature in extra_features])
+
+    # Check source extensions used for TOKENS metric.
+    source_exts = data.get('source_exts', [])
+    if not isinstance(source_exts, list) or not source_exts:
+        result['errors'].append("source_exts must be a non-empty list")
+    else:
+        invalid_exts = []
+        normalized_exts = set()
+        for ext in source_exts:
+            ext_str = str(ext).strip().lower()
+            if not re.match(r'^\.[a-z0-9_+#-]+$', ext_str):
+                invalid_exts.append(str(ext))
+                continue
+            normalized_exts.add(ext_str)
+        if invalid_exts:
+            result['errors'].append(
+                "source_exts contains invalid extension(s): " + ", ".join(invalid_exts)
+            )
+        result['info'].append(f"Source extensions: {', '.join(sorted(normalized_exts))}")
     
     # Check AI depth
     if 'max_ai_depth' in data:


### PR DESCRIPTION
## Summary
Rebased token-metric rollout onto latest `main` and replaced LOC reporting with Git-aware token metrics.

Implemented:
- new token metric collector (`tokens-v2`) from Git-discovered files (tracked + untracked, excluding ignored)
- README status table switched from `LOC` to `TOKENS`
- benchmark/reporting scripts updated to emit token metrics
- per-implementation metadata wiring for source extensions
- dedicated token metric tests and script integration

## Validation
### Local targeted validation
- `python3 test/test_token_metrics.py` (4 tests, all pass)
- `python3 test/code_size_metrics.py --impl implementations/go`
- `python3 -m py_compile` on updated tooling scripts

### CI
- Core PR checks ran; some unrelated implementation matrix jobs failed due pre-existing implementation/toolchain issues outside token-metric logic.

## Related Issues
Fixes #108