### PR TITLE
imba: stabilize v1 harness behavior

### DIFF
--- a/implementations/imba/chess.imba
+++ b/implementations/imba/chess.imba
@@ -148,11 +148,14 @@ class ChessEngine
 		}
 
 	def export-fen
+		return state-to-fen(state)
+
+	def state-to-fen snapshot
 		let fen = ''
 		for r in [0 ... 8]
 			let empty = 0
 			for c in [0 ... 8]
-				const piece = state.board[r * 8 + c]
+				const piece = snapshot.board[r * 8 + c]
 				if piece
 					if empty > 0
 						fen += empty
@@ -163,14 +166,45 @@ class ChessEngine
 			if empty > 0 then fen += empty
 			if r < 7 then fen += '/'
 
-		const castling = (state.castling.wK ? 'K' : '') +
-			(state.castling.wQ ? 'Q' : '') +
-			(state.castling.bK ? 'k' : '') +
-			(state.castling.bQ ? 'q' : '') or '-'
+		const castling = castling-string(snapshot)
 
-		const ep = state.enPassant === null ? '-' : index-to-algebraic(state.enPassant)
+		const ep = snapshot.enPassant === null ? '-' : index-to-algebraic(snapshot.enPassant)
 
-		return "{fen} {state.turn} {castling} {ep} {state.halfmoveClock} {state.fullmoveNumber}"
+		return "{fen} {snapshot.turn} {castling} {ep} {snapshot.halfmoveClock} {snapshot.fullmoveNumber}"
+
+	def castling-string snapshot
+		let castling = ''
+		if snapshot.castling.wK then castling += 'K'
+		if snapshot.castling.wQ then castling += 'Q'
+		if snapshot.castling.bK then castling += 'k'
+		if snapshot.castling.bQ then castling += 'q'
+		return castling or '-'
+
+	def state-key snapshot = state
+		const boardPart = state-to-fen(snapshot).split(' ').slice(0, 4)
+		return boardPart.join(' ')
+
+	def repetition-count
+		const currentKey = state-key!
+		let count = 1
+		for snapshot in history
+			if state-key(snapshot) === currentKey then count++
+		return count
+
+	def draw-reason
+		if repetition-count! >= 3 then return 'REPETITION'
+		if state.halfmoveClock >= 100 then return '50-MOVE'
+		return null
+
+	def hash-string
+		const source = export-fen!
+		let forward = 2166136261
+		let reverse = 2166136261
+		for char, i in source
+			forward = Math.imul((forward ^ char.charCodeAt(0)) >>> 0, 16777619) >>> 0
+			const reverseCode = source.charCodeAt(source.length - 1 - i)
+			reverse = Math.imul((reverse ^ reverseCode) >>> 0, 16777619) >>> 0
+		return forward.toString(16).padStart(8, '0') + reverse.toString(16).padStart(8, '0')
 
 	def algebraic-to-index sq
 		if !sq or sq.length !== 2 then return null
@@ -382,6 +416,7 @@ class ChessEngine
 		
 		const piece = state.board[move.from]
 		if !piece then return
+		const wasPawn = piece.type === 'p'
 
 		const target = state.board[move.to]
 		let nextEp = null
@@ -430,7 +465,7 @@ class ChessEngine
 		state.board[move.from] = null
 		state.enPassant = nextEp
 		
-		if piece.type === 'p' or target
+		if wasPawn or target
 			state.halfmoveClock = 0
 		else
 			state.halfmoveClock++
@@ -590,6 +625,7 @@ rl.on('line') do(line)
 				engine.state = startState
 				engine.history = []
 				print-board!
+				process.stdout.write("OK: NEW\n")
 		when 'move'
 			const mStr = tokens[1] or ""
 			if mStr.length < 4 or mStr.length > 5
@@ -648,6 +684,7 @@ rl.on('line') do(line)
 			else
 				engine.undo!
 				print-board!
+				process.stdout.write("OK: UNDO\n")
 		when 'fen'
 			const fenStr = tokens.slice(1).join(' ')
 			const nextState = engine.parse-fen(fenStr)
@@ -657,6 +694,7 @@ rl.on('line') do(line)
 				engine.state = nextState
 				engine.history = []
 				print-board!
+				process.stdout.write("OK: FEN\n")
 		when 'export'
 			process.stdout.write("FEN: {engine.export-fen!}\n")
 		when 'ai'
@@ -675,6 +713,10 @@ rl.on('line') do(line)
 			print-board!
 			process.stdout.write("AI: {mS} (depth={depth}, eval={res.score}, time={Date.now! - start})\n")
 		when 'status'
+			const drawReason = engine.draw-reason!
+			if drawReason
+				process.stdout.write("DRAW: {drawReason}\n")
+				return
 			const moves = engine.generate-moves!
 			if moves.length === 0
 				if engine.is-in-check(engine.state.turn)
@@ -686,7 +728,7 @@ rl.on('line') do(line)
 		when 'eval'
 			process.stdout.write("EVALUATION: {engine.evaluate!}\n")
 		when 'hash'
-			process.stdout.write("HASH: 0x{Math.floor(Math.random! * 0xFFFFFFFF).toString(16)}\n")
+			process.stdout.write("HASH: {engine.hash-string!}\n")
 		when 'perft'
 			const d = parseInt(parts[1] or '1')
 			const s = Date.now!

--- a/test/test_harness.py
+++ b/test/test_harness.py
@@ -132,50 +132,71 @@ class ChessEngineTester:
             fl = fcntl.fcntl(fd, fcntl.F_GETFL)
             fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
             try:
-                while self.process.stdout.read(1024): pass
-            except:
-                pass
-            fcntl.fcntl(fd, fcntl.F_SETFL, fl)
+                while True:
+                    try:
+                        chunk = os.read(fd, 4096)
+                    except BlockingIOError:
+                        break
+                    if not chunk:
+                        break
 
-            # Send command
-            self.process.stdin.write(command + "\n")
-            self.process.stdin.flush()
-            
-            start_time = time.time()
-            output_lines = []
-            end_seen_at = None
-            
-            # Keywords that signal the end of an engine response
-            end_keywords = [
-                "OK:", "ERROR:", "CHECKMATE:", "STALEMATE:", 
-                "FEN:", "AI:", "EVALUATION:", "HASH:", 
-                "REPETITION:", "DRAW:", "DRAWS:", "CONCURRENCY:",
-                "960:",
-                "UCIOK", "READYOK", "BESTMOVE", "INFO ", "ID NAME", "ID AUTHOR",
-                "PGN", "TRACE",
-            ]
-            
-            while time.time() - start_time < timeout:
-                if self.process.poll() is not None:
-                    break
+                # Send command
+                self.process.stdin.write(command + "\n")
+                self.process.stdin.flush()
                 
-                # Use select to wait for data with a short timeout
-                ready, _, _ = select.select([self.process.stdout], [], [], 0.1)
+                start_time = time.time()
+                output_lines = []
+                end_seen_at = None
+                pending = ""
                 
-                if ready:
-                    line = self.process.stdout.readline()
-                    if line:
-                        stripped_line = line.strip()
-                        output_lines.append(stripped_line)
-                        if any(kw in stripped_line.upper() for kw in end_keywords):
-                            end_seen_at = time.time()
+                # Keywords that signal the end of an engine response
+                end_keywords = [
+                    "OK:", "ERROR:", "CHECKMATE:", "STALEMATE:", 
+                    "FEN:", "AI:", "EVALUATION:", "HASH:", 
+                    "REPETITION:", "DRAW:", "DRAWS:", "CONCURRENCY:",
+                    "NODES:",
+                    "960:",
+                    "UCIOK", "READYOK", "BESTMOVE", "INFO ", "ID NAME", "ID AUTHOR",
+                    "PGN", "TRACE",
+                ]
+                
+                while time.time() - start_time < timeout:
+                    if self.process.poll() is not None:
+                        break
+                    
+                    # Use select to wait for data with a short timeout
+                    ready, _, _ = select.select([fd], [], [], 0.1)
+                    
+                    if ready:
+                        while True:
+                            try:
+                                chunk = os.read(fd, 4096)
+                            except BlockingIOError:
+                                break
+                            if not chunk:
+                                break
+                            pending += chunk.decode("utf-8", errors="replace")
 
-                # Give a short grace period after an end marker so trailing lines
-                # from the same response (e.g. board + metadata) are captured.
-                if end_seen_at is not None and (time.time() - end_seen_at) >= 0.12:
-                    break
+                        while "\n" in pending:
+                            line, pending = pending.split("\n", 1)
+                            stripped_line = line.strip()
+                            if not stripped_line:
+                                continue
+                            output_lines.append(stripped_line)
+                            if any(kw in stripped_line.upper() for kw in end_keywords):
+                                end_seen_at = time.time()
 
-            return "\n".join(output_lines)
+                    # Give a short grace period after an end marker so trailing lines
+                    # from the same response (e.g. board + metadata) are captured.
+                    if end_seen_at is not None and (time.time() - end_seen_at) >= 0.12:
+                        break
+
+                if pending.strip():
+                    output_lines.append(pending.strip())
+
+                return "\n".join(output_lines)
+            finally:
+                fcntl.fcntl(fd, fcntl.F_SETFL, fl)
             
         except Exception as e:
             self.results["errors"].append(f"Command error: {e}")


### PR DESCRIPTION
## Summary
- stabilize the Imba implementation for the current shared `v1` harness
- make CLI responses terminate cleanly for the harness
- add deterministic hash output and draw detection for repetition / 50-move rule
- harden the shared harness read loop for multiline responses and `Nodes:` output

## Linked issue
- Closes #111
- Related: #95

## Validation
- `make image DIR=imba`
- `make build DIR=imba`
- `make analyze DIR=imba`
- `make test DIR=imba`
- `make test-chess-engine DIR=imba TRACK=v1`
