### PR TITLE
bench: add real PRD-10 concurrency workloads

### DIFF
--- a/implementations/dart/bin/main.dart
+++ b/implementations/dart/bin/main.dart
@@ -1,9 +1,11 @@
-import 'dart:io';
-import 'dart:math';
+import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
+import 'dart:isolate';
+import 'dart:math';
 import 'package:chess_engine/chess_engine.dart';
 
-void main() {
+Future<void> main() async {
   final game = Game();
   var ai = AI();
   String? pgnPath;
@@ -638,7 +640,7 @@ void main() {
           print('ERROR: Unsupported concurrency profile');
           break;
         }
-        print('CONCURRENCY: ${jsonEncode(_buildConcurrencyPayload(profile))}');
+        print('CONCURRENCY: ${jsonEncode(await _buildConcurrencyPayload(profile))}');
         break;
       case 'status':
         _checkGameState(game);
@@ -1093,37 +1095,249 @@ List<String> _extractPgnMoves(String content) {
   return moves;
 }
 
-Map<String, dynamic> _buildConcurrencyPayload(String profile) {
+const List<String> _concurrencyFixtures = <String>[
+  'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+  'r3k2r/pppq1ppp/2npbn2/3Np3/3P4/2N1P3/PPP2PPP/R1BQKB1R w KQkq - 2 8',
+  'rnbqkbnr/ppp1pppp/8/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 3',
+  '8/2k5/8/2K5/3Q4/8/8/8 w - - 0 1',
+];
+
+({int workers, int runs, int readCycles, int statefulCycles})
+_concurrencyProfile(String profile) {
+  if (profile == 'full') {
+    return (workers: 4, runs: 12, readCycles: 10, statefulCycles: 8);
+  }
+  return (workers: 2, runs: 6, readCycles: 5, statefulCycles: 4);
+}
+
+Future<Map<String, dynamic>> _buildConcurrencyPayload(String profile) async {
   final stopwatch = Stopwatch()..start();
   const seed = 12345;
-  const workers = 1;
-  final runs = profile == 'quick' ? 10 : 50;
-  final opsPerRun = profile == 'quick' ? 10000 : 40000;
+  final config = _concurrencyProfile(profile);
   final checksums = <String>[];
-  final multiplier = BigInt.parse('6364136223846793005');
-  final increment = BigInt.parse('1442695040888963407');
-  final mask = BigInt.parse('ffffffffffffffff', radix: 16);
+  var invariantErrors = 0;
+  var opsTotal = 0;
 
-  var checksum = BigInt.from(seed);
-  for (var i = 0; i < runs; i++) {
-    checksum = (checksum * multiplier + increment + BigInt.from(i)) & mask;
-    checksums.add(checksum.toRadixString(16).padLeft(16, '0'));
+  for (var runIndex = 0; runIndex < config.runs; runIndex++) {
+    final futures = <Future<Map<String, int>>>[];
+    for (var workerIndex = 0; workerIndex < config.workers; workerIndex++) {
+      futures.add(
+        Isolate.run(
+          () => _runConcurrencyWorker(
+            profile,
+            seed,
+            runIndex,
+            workerIndex,
+            config.readCycles,
+            config.statefulCycles,
+          ),
+        ),
+      );
+    }
+
+    final results = await Future.wait(futures);
+    var runChecksum = _mixChecksum(
+      seed,
+      'run:$profile:$runIndex:${config.workers}',
+    );
+
+    for (final result in results) {
+      invariantErrors += result['invariant_errors']!;
+      opsTotal += result['ops']!;
+      runChecksum = _mixChecksumInt(runChecksum, result['worker']!);
+      runChecksum = _mixChecksumInt(runChecksum, result['ops']!);
+      runChecksum = _mixChecksumInt(runChecksum, result['checksum']!);
+    }
+
+    checksums.add(_checksumHex(runChecksum));
   }
+
   stopwatch.stop();
 
   return {
     'profile': profile,
     'seed': seed,
-    'workers': workers,
-    'runs': runs,
+    'workers': config.workers,
+    'runs': config.runs,
     'checksums': checksums,
     'deterministic': true,
-    'invariant_errors': 0,
+    'invariant_errors': invariantErrors,
     'deadlocks': 0,
     'timeouts': 0,
     'elapsed_ms': stopwatch.elapsedMilliseconds,
-    'ops_total': runs * opsPerRun * workers,
+    'ops_total': opsTotal,
   };
+}
+
+Map<String, int> _runConcurrencyWorker(
+  String profile,
+  int seed,
+  int runIndex,
+  int workerIndex,
+  int readCycles,
+  int statefulCycles,
+) {
+  final game = Game();
+  var checksum = _mixChecksum(
+    seed,
+    'worker:$profile:$runIndex:$workerIndex',
+  );
+  var invariantErrors = 0;
+  var ops = 0;
+
+  for (var step = 0; step < readCycles; step++) {
+    final fen =
+        _concurrencyFixtures[(runIndex + workerIndex + step) %
+            _concurrencyFixtures.length];
+    try {
+      game.loadFen(fen);
+      final baselineFen = game.board.toFen();
+      checksum = _mixChecksum(checksum, baselineFen);
+
+      final candidates = _sortedBoardMoves(game.board);
+      checksum = _mixChecksumInt(checksum, candidates.length);
+      ops += 2;
+
+      if (candidates.isNotEmpty) {
+        final selected = candidates[_selectionIndex(
+          candidates.length,
+          seed,
+          runIndex,
+          workerIndex,
+          step,
+        )];
+        checksum = _mixChecksum(checksum, selected.notation);
+
+        final clone = game.board.clone();
+        clone.move(selected.notation);
+        checksum = _mixChecksum(checksum, clone.toFen());
+        checksum = _mixChecksum(checksum, _boardHashHex(clone));
+        ops += 3;
+      }
+
+      if (game.board.toFen() != baselineFen) {
+        invariantErrors++;
+        game.loadFen(fen);
+      }
+    } catch (_) {
+      invariantErrors++;
+      game.loadFen(
+        _concurrencyFixtures[(runIndex + workerIndex) % _concurrencyFixtures.length],
+      );
+    }
+  }
+
+  final statefulFen =
+      _concurrencyFixtures[(runIndex * 3 + workerIndex) %
+          _concurrencyFixtures.length];
+  game.loadFen(statefulFen);
+  final baselineFen = game.board.toFen();
+  final baselineHash = _boardHashHex(game.board);
+
+  for (var step = 0; step < statefulCycles; step++) {
+    try {
+      final rootMoves = _sortedBoardMoves(game.board);
+      checksum = _mixChecksumInt(checksum, rootMoves.length);
+      ops++;
+      if (rootMoves.isEmpty) {
+        game.loadFen(statefulFen);
+        continue;
+      }
+
+      final first = rootMoves[_selectionIndex(
+        rootMoves.length,
+        seed + 7,
+        runIndex,
+        workerIndex,
+        step,
+      )];
+      game.move(first.notation);
+      checksum = _mixChecksum(checksum, first.notation);
+      checksum = _mixChecksum(checksum, game.board.toFen());
+      checksum = _mixChecksum(checksum, _boardHashHex(game.board));
+      ops += 3;
+
+      final replyMoves = _sortedBoardMoves(game.board);
+      checksum = _mixChecksumInt(checksum, replyMoves.length);
+      ops++;
+      if (replyMoves.isNotEmpty) {
+        final reply = replyMoves[_selectionIndex(
+          replyMoves.length,
+          seed + 19,
+          runIndex,
+          workerIndex,
+          step,
+        )];
+        game.move(reply.notation);
+        checksum = _mixChecksum(checksum, reply.notation);
+        checksum = _mixChecksum(checksum, game.board.toFen());
+        checksum = _mixChecksum(checksum, _boardHashHex(game.board));
+        game.undo();
+        ops += 4;
+      }
+
+      game.undo();
+      final restoredFen = game.board.toFen();
+      final restoredHash = _boardHashHex(game.board);
+      checksum = _mixChecksum(checksum, restoredHash);
+      ops++;
+
+      if (restoredFen != baselineFen || restoredHash != baselineHash) {
+        invariantErrors++;
+        game.loadFen(statefulFen);
+      }
+    } catch (_) {
+      invariantErrors++;
+      game.loadFen(statefulFen);
+    }
+  }
+
+  return {
+    'worker': workerIndex,
+    'checksum': checksum,
+    'invariant_errors': invariantErrors,
+    'ops': ops,
+  };
+}
+
+List<({String notation, Move move})> _sortedBoardMoves(Board board) {
+  final moves = board.generateMoves();
+  final pairs = <({String notation, Move move})>[];
+  for (final move in moves) {
+    pairs.add((notation: move.toString().toLowerCase(), move: move));
+  }
+  pairs.sort((a, b) => a.notation.compareTo(b.notation));
+  return pairs;
+}
+
+int _selectionIndex(
+  int length,
+  int seed,
+  int runIndex,
+  int workerIndex,
+  int step,
+) {
+  return (seed + runIndex * 17 + workerIndex * 31 + step * 13) % length;
+}
+
+int _mixChecksum(int checksum, String value) {
+  var acc = checksum & 0xffffffff;
+  for (final unit in value.codeUnits) {
+    acc = ((acc ^ unit) * 16777619) & 0xffffffff;
+  }
+  return acc;
+}
+
+int _mixChecksumInt(int checksum, int value) {
+  return _mixChecksum(checksum, value.toString());
+}
+
+String _checksumHex(int checksum) {
+  return (checksum & 0xffffffff).toRadixString(16).padLeft(8, '0');
+}
+
+String _boardHashHex(Board board) {
+  return board.zobristHash.toUnsigned(64).toRadixString(16).padLeft(16, '0');
 }
 
 void _runAiMove(

--- a/implementations/go/chess.go
+++ b/implementations/go/chess.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -1399,33 +1401,66 @@ func (engine *ChessEngine) handleConcurrency(args []string) {
 
 	start := time.Now()
 	seed := uint64(12345)
-	workers := 1
-	runs := 10
-	opsPerRun := 10000
-	if profile == "full" {
-		runs = 50
-		opsPerRun = 40000
+	spec := concurrencyProfileFor(profile)
+
+	resultsCh := make(chan concurrencyWorkerResult, spec.workers)
+	var wg sync.WaitGroup
+
+	for workerID := 0; workerID < spec.workers; workerID++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+
+			workerRuns := make([]concurrencyRunResult, 0, spec.runs)
+			for runIndex := 0; runIndex < spec.runs; runIndex++ {
+				workerRuns = append(workerRuns, safeRunConcurrencyWorkload(id, runIndex, seed, spec))
+			}
+
+			resultsCh <- concurrencyWorkerResult{
+				workerID: id,
+				runs:     workerRuns,
+			}
+		}(workerID)
 	}
 
-	checksums := make([]string, 0, runs)
-	checksum := seed
-	for i := 0; i < runs; i++ {
-		checksum = checksum*6364136223846793005 + 1442695040888963407 + uint64(i)
-		checksums = append(checksums, fmt.Sprintf("%016x", checksum))
+	go func() {
+		wg.Wait()
+		close(resultsCh)
+	}()
+
+	workerResults := make([][]concurrencyRunResult, spec.workers)
+	for workerResult := range resultsCh {
+		workerResults[workerResult.workerID] = workerResult.runs
+	}
+
+	invariantErrors := 0
+	opsTotal := 0
+	checksums := make([]string, 0, spec.runs)
+
+	for runIndex := 0; runIndex < spec.runs; runIndex++ {
+		runChecksum := mixConcurrencyUint64(mixConcurrencyUint64(concurrencyChecksumOffset, seed), uint64(runIndex+1))
+		for workerID := 0; workerID < spec.workers; workerID++ {
+			runResult := workerResults[workerID][runIndex]
+			invariantErrors += runResult.invariantErrors
+			opsTotal += runResult.ops
+			runChecksum = mixConcurrencyUint64(runChecksum, uint64(workerID+1))
+			runChecksum = mixConcurrencyUint64(runChecksum, runResult.checksum)
+		}
+		checksums = append(checksums, fmt.Sprintf("%016x", runChecksum))
 	}
 
 	payload := map[string]interface{}{
 		"profile":          profile,
 		"seed":             seed,
-		"workers":          workers,
-		"runs":             runs,
+		"workers":          spec.workers,
+		"runs":             spec.runs,
 		"checksums":        checksums,
 		"deterministic":    true,
-		"invariant_errors": 0,
+		"invariant_errors": invariantErrors,
 		"deadlocks":        0,
 		"timeouts":         0,
 		"elapsed_ms":       time.Since(start).Milliseconds(),
-		"ops_total":        runs * opsPerRun * workers,
+		"ops_total":        opsTotal,
 	}
 
 	encoded, err := json.Marshal(payload)
@@ -1488,6 +1523,234 @@ func extractPgnMoves(content string) []string {
 		}
 	}
 	return moves
+}
+
+type concurrencyProfile struct {
+	workers int
+	runs    int
+	steps   int
+}
+
+type concurrencyRunResult struct {
+	runIndex        int
+	checksum        uint64
+	ops             int
+	invariantErrors int
+}
+
+type concurrencyWorkerResult struct {
+	workerID int
+	runs     []concurrencyRunResult
+}
+
+var concurrencyWorkloadFENs = []string{
+	StartingPositionFEN,
+	"r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1",
+	"rnbqkbnr/ppp1pppp/8/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 3",
+	"8/2k5/3p4/3P4/2P5/8/3K4/8 w - - 0 1",
+}
+
+const (
+	concurrencyChecksumOffset = uint64(1469598103934665603)
+	concurrencyChecksumPrime  = uint64(1099511628211)
+)
+
+func concurrencyProfileFor(profile string) concurrencyProfile {
+	if profile == "full" {
+		return concurrencyProfile{
+			workers: 4,
+			runs:    16,
+			steps:   24,
+		}
+	}
+
+	return concurrencyProfile{
+		workers: 2,
+		runs:    8,
+		steps:   12,
+	}
+}
+
+func mixConcurrencyUint64(current, value uint64) uint64 {
+	return (current ^ value) * concurrencyChecksumPrime
+}
+
+func mixConcurrencyString(current uint64, value string) uint64 {
+	mixed := current
+	for i := 0; i < len(value); i++ {
+		mixed = mixConcurrencyUint64(mixed, uint64(value[i]))
+	}
+	return mixed
+}
+
+func deterministicConcurrencyMoveIndex(seed uint64, workerID, runIndex, fenIndex, step, moveCount int) int {
+	selector := mixConcurrencyUint64(concurrencyChecksumOffset, seed)
+	selector = mixConcurrencyUint64(selector, uint64(workerID+1))
+	selector = mixConcurrencyUint64(selector, uint64(runIndex+1))
+	selector = mixConcurrencyUint64(selector, uint64(fenIndex+1))
+	selector = mixConcurrencyUint64(selector, uint64(step+1))
+	return int(selector % uint64(moveCount))
+}
+
+func shouldVerifyUndo(workerID, runIndex, fenIndex, step int) bool {
+	return (workerID+runIndex+fenIndex+step)%2 == 0
+}
+
+func normalizedConcurrencyMoveStrings(moves []Move) []string {
+	notations := make([]string, 0, len(moves))
+	for _, move := range moves {
+		notations = append(notations, strings.ToLower(moveToString(move)))
+	}
+	sort.Strings(notations)
+	return notations
+}
+
+func equalStringSlices(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func newConcurrencyGameState(fen string) (*GameState, error) {
+	gs := NewGameState()
+	if err := gs.FromFEN(fen); err != nil {
+		return nil, err
+	}
+
+	gs.MoveHistory = gs.MoveHistory[:0]
+	gs.StateHistory = gs.StateHistory[:0]
+	gs.PositionHistory = gs.PositionHistory[:0]
+	gs.ZobristHash = computeZobristHash(gs)
+
+	return gs, nil
+}
+
+func runConcurrencyWorkload(workerID, runIndex int, seed uint64, spec concurrencyProfile) concurrencyRunResult {
+	result := concurrencyRunResult{
+		runIndex: runIndex,
+		checksum: mixConcurrencyUint64(
+			mixConcurrencyUint64(concurrencyChecksumOffset, seed),
+			uint64((workerID+1)*(runIndex+1)),
+		),
+	}
+
+	for fenIndex, fen := range concurrencyWorkloadFENs {
+		gs, err := newConcurrencyGameState(fen)
+		result.ops++
+		if err != nil {
+			result.invariantErrors++
+			result.checksum = mixConcurrencyString(result.checksum, err.Error())
+			continue
+		}
+
+		result.checksum = mixConcurrencyString(result.checksum, gs.ToFEN())
+		result.checksum = mixConcurrencyUint64(result.checksum, gs.ZobristHash)
+
+		for step := 0; step < spec.steps; step++ {
+			beforeFEN := gs.ToFEN()
+			beforeHash := gs.ZobristHash
+
+			legalMoves := gs.GenerateLegalMoves()
+			result.ops++
+			if len(legalMoves) == 0 {
+				if step == 0 {
+					result.invariantErrors++
+				}
+				result.checksum = mixConcurrencyString(result.checksum, beforeFEN)
+				result.checksum = mixConcurrencyUint64(result.checksum, beforeHash)
+				break
+			}
+
+			sort.Slice(legalMoves, func(i, j int) bool {
+				return strings.ToLower(moveToString(legalMoves[i])) < strings.ToLower(moveToString(legalMoves[j]))
+			})
+
+			move := legalMoves[deterministicConcurrencyMoveIndex(seed, workerID, runIndex, fenIndex, step, len(legalMoves))]
+			moveNotation := strings.ToLower(moveToString(move))
+
+			result.checksum = mixConcurrencyString(result.checksum, moveNotation)
+			result.checksum = mixConcurrencyUint64(result.checksum, uint64(len(legalMoves)))
+
+			gs.MakeMove(move)
+			result.ops++
+
+			afterFEN := gs.ToFEN()
+			afterHash := gs.ZobristHash
+			afterMoves := gs.GenerateLegalMoves()
+			result.ops++
+
+			result.checksum = mixConcurrencyString(result.checksum, afterFEN)
+			result.checksum = mixConcurrencyUint64(result.checksum, afterHash)
+			result.checksum = mixConcurrencyUint64(result.checksum, uint64(len(afterMoves)))
+
+			if shouldVerifyUndo(workerID, runIndex, fenIndex, step) {
+				if !gs.UndoLastMove() {
+					result.invariantErrors++
+					result.checksum = mixConcurrencyString(result.checksum, "undo-failed")
+					break
+				}
+				result.ops++
+
+				if gs.ToFEN() != beforeFEN || gs.ZobristHash != beforeHash {
+					result.invariantErrors++
+				}
+
+				gs.MakeMove(move)
+				result.ops++
+
+				if gs.ToFEN() != afterFEN || gs.ZobristHash != afterHash {
+					result.invariantErrors++
+				}
+				continue
+			}
+
+			reloaded, err := newConcurrencyGameState(afterFEN)
+			result.ops++
+			if err != nil {
+				result.invariantErrors++
+				result.checksum = mixConcurrencyString(result.checksum, "reload-failed")
+				break
+			}
+
+			if reloaded.ToFEN() != afterFEN || reloaded.ZobristHash != afterHash {
+				result.invariantErrors++
+			}
+
+			reloadedMoves := reloaded.GenerateLegalMoves()
+			result.ops++
+			if !equalStringSlices(
+				normalizedConcurrencyMoveStrings(afterMoves),
+				normalizedConcurrencyMoveStrings(reloadedMoves),
+			) {
+				result.invariantErrors++
+			}
+
+			result.checksum = mixConcurrencyUint64(result.checksum, reloaded.ZobristHash)
+		}
+	}
+
+	return result
+}
+
+func safeRunConcurrencyWorkload(workerID, runIndex int, seed uint64, spec concurrencyProfile) (result concurrencyRunResult) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			result = concurrencyRunResult{
+				runIndex:        runIndex,
+				checksum:        mixConcurrencyString(mixConcurrencyUint64(concurrencyChecksumOffset, seed), fmt.Sprintf("panic:%v", recovered)),
+				ops:             0,
+				invariantErrors: 1,
+			}
+		}
+	}()
+
+	return runConcurrencyWorkload(workerID, runIndex, seed, spec)
 }
 
 func (engine *ChessEngine) handlePerft(depth int) {

--- a/implementations/lua/chess.lua
+++ b/implementations/lua/chess.lua
@@ -1585,33 +1585,419 @@ local function trace_event(event, detail)
     end
 end
 
+local function clone_board_state(source)
+    local copy = {}
+    for rank = 1, 8 do
+        copy[rank] = {}
+        for file = 1, 8 do
+            copy[rank][file] = source[rank][file]
+        end
+    end
+    return copy
+end
+
+local function clone_castling_state(source)
+    return {
+        white_king = source.white_king,
+        white_queen = source.white_queen,
+        black_king = source.black_king,
+        black_queen = source.black_queen,
+    }
+end
+
+local function clone_square(square)
+    if not square then
+        return nil
+    end
+    return {square[1], square[2]}
+end
+
+local function clone_move_history(source)
+    local copy = {}
+    for i, entry in ipairs(source) do
+        copy[i] = {}
+        for key, value in pairs(entry) do
+            copy[i][key] = value
+        end
+    end
+    return copy
+end
+
+local function clone_irreversible_history(source)
+    local copy = {}
+    for i, entry in ipairs(source) do
+        copy[i] = {
+            castling_rights = clone_castling_state(entry.castling_rights),
+            en_passant_target = clone_square(entry.en_passant_target),
+            halfmove_clock = entry.halfmove_clock,
+            zobrist_hash = entry.zobrist_hash,
+        }
+    end
+    return copy
+end
+
+local function snapshot_engine_state()
+    local history_copy = {}
+    for i, hash in ipairs(position_history) do
+        history_copy[i] = hash
+    end
+
+    return {
+        board = clone_board_state(board),
+        white_to_move = white_to_move,
+        castling_rights = clone_castling_state(castling_rights),
+        en_passant_target = clone_square(en_passant_target),
+        halfmove_clock = halfmove_clock,
+        fullmove_number = fullmove_number,
+        move_history = clone_move_history(move_history),
+        zobrist_hash = zobrist_hash,
+        position_history = history_copy,
+        irreversible_history = clone_irreversible_history(irreversible_history),
+    }
+end
+
+local function restore_engine_state(state)
+    board = clone_board_state(state.board)
+    white_to_move = state.white_to_move
+    castling_rights = clone_castling_state(state.castling_rights)
+    en_passant_target = clone_square(state.en_passant_target)
+    halfmove_clock = state.halfmove_clock
+    fullmove_number = state.fullmove_number
+    move_history = clone_move_history(state.move_history)
+    zobrist_hash = state.zobrist_hash
+
+    position_history = {}
+    for i, hash in ipairs(state.position_history) do
+        position_history[i] = hash
+    end
+
+    irreversible_history = clone_irreversible_history(state.irreversible_history)
+end
+
+local function workload_move_notation(move)
+    local notation = indices_to_algebraic(move[1], move[2]) .. indices_to_algebraic(move[3], move[4])
+    if move[5] then
+        notation = notation .. tostring(move[5]):lower()
+    end
+    return notation:lower()
+end
+
+local function is_workload_castling_move(move)
+    local piece = board[move[1]][move[2]]
+    return (piece == "K" or piece == "k") and math.abs(move[4] - move[2]) == 2
+end
+
+local function is_workload_en_passant_move(move)
+    local piece = board[move[1]][move[2]]
+    return en_passant_target
+        and (piece == "P" or piece == "p")
+        and move[3] == en_passant_target[1]
+        and move[4] == en_passant_target[2]
+        and board[move[3]][move[4]] == "."
+end
+
+local function is_workload_promotion_move(move)
+    local piece = board[move[1]][move[2]]
+    return move[5] ~= nil or ((piece == "P" and move[3] == 8) or (piece == "p" and move[3] == 1))
+end
+
+local function workload_move_priority(move)
+    local score = 0
+    if is_workload_castling_move(move) then
+        score = score + 400
+    end
+    if is_workload_en_passant_move(move) then
+        score = score + 300
+    end
+    if is_workload_promotion_move(move) then
+        score = score + 200
+    end
+
+    local target = board[move[3]][move[4]]
+    if target and target ~= "." then
+        score = score + 100 + math.abs(PIECE_VALUES[target] or 0)
+    end
+
+    return score
+end
+
+local function choose_workload_move(moves, mode, salt)
+    local filtered = {}
+    for _, move in ipairs(moves) do
+        local include = true
+        if mode == "castle" then
+            include = is_workload_castling_move(move)
+        elseif mode == "en_passant" then
+            include = is_workload_en_passant_move(move)
+        elseif mode == "promotion" then
+            include = is_workload_promotion_move(move)
+        end
+        if include then
+            table.insert(filtered, move)
+        end
+    end
+
+    if #filtered == 0 then
+        filtered = moves
+    end
+
+    local decorated = {}
+    for _, move in ipairs(filtered) do
+        table.insert(decorated, {
+            move = move,
+            notation = workload_move_notation(move),
+            priority = workload_move_priority(move),
+        })
+    end
+
+    table.sort(decorated, function(a, b)
+        if a.priority ~= b.priority then
+            return a.priority > b.priority
+        end
+        return a.notation < b.notation
+    end)
+
+    local index = (salt % #decorated) + 1
+    return decorated[index].move, decorated[index].notation
+end
+
+local function benchmark_mix_int(checksum, value)
+    return xorshift64((checksum ~ (value & 0xFFFFFFFFFFFFFFFF)) & 0xFFFFFFFFFFFFFFFF)
+end
+
+local function benchmark_mix_string(checksum, value)
+    local mixed = benchmark_mix_int(checksum, #value)
+    for i = 1, #value do
+        mixed = benchmark_mix_int(mixed, string.byte(value, i))
+    end
+    return mixed
+end
+
+local function count_kings_on_board()
+    local white_kings = 0
+    local black_kings = 0
+    for rank = 1, 8 do
+        for file = 1, 8 do
+            local piece = board[rank][file]
+            if piece == "K" then
+                white_kings = white_kings + 1
+            elseif piece == "k" then
+                black_kings = black_kings + 1
+            end
+        end
+    end
+    return white_kings, black_kings
+end
+
+local function load_benchmark_position(fen)
+    local success, msg = import_fen(fen)
+    if not success then
+        return false, msg
+    end
+
+    move_history = {}
+    position_history = {}
+    irreversible_history = {}
+    zobrist_hash = compute_hash()
+    return true, "OK"
+end
+
+local function run_concurrency_workload(profile, seed, run_index)
+    local scenarios = {
+        {
+            name = "opening",
+            fen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+            mode = "any",
+        },
+        {
+            name = "castling",
+            fen = "r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1",
+            mode = "castle",
+        },
+        {
+            name = "en_passant",
+            fen = "4k3/8/8/3pP3/8/8/8/4K3 w - d6 0 1",
+            mode = "en_passant",
+        },
+        {
+            name = "promotion",
+            fen = "4k3/P7/8/8/8/8/7p/4K3 w - - 0 1",
+            mode = "promotion",
+        },
+    }
+
+    local plies_per_scenario = profile == "quick" and 2 or 4
+    local checksum = xorshift64((seed + run_index * 97) & 0xFFFFFFFFFFFFFFFF)
+    local invariant_errors = 0
+    local ops_total = 0
+
+    local function record_invariant(condition, detail)
+        if not condition then
+            invariant_errors = invariant_errors + 1
+            checksum = benchmark_mix_string(checksum, "ERR:" .. detail)
+            return false
+        end
+        return true
+    end
+
+    for scenario_index, scenario in ipairs(scenarios) do
+        local ok, msg = load_benchmark_position(scenario.fen)
+        ops_total = ops_total + 2 -- load + recompute hash
+        if not ok then
+            record_invariant(false, scenario.name .. ":load:" .. tostring(msg))
+            break
+        end
+
+        local baseline_fen = export_fen()
+        local baseline_hash = zobrist_hash
+        ops_total = ops_total + 2 -- export + baseline hash validation
+
+        checksum = benchmark_mix_string(checksum, scenario.name)
+        checksum = benchmark_mix_string(checksum, baseline_fen)
+        checksum = benchmark_mix_int(checksum, baseline_hash)
+
+        record_invariant(compute_hash() == zobrist_hash, scenario.name .. ":baseline-hash")
+
+        local white_kings, black_kings = count_kings_on_board()
+        record_invariant(white_kings == 1 and black_kings == 1, scenario.name .. ":king-count")
+
+        for ply = 1, plies_per_scenario do
+            local pre_fen = export_fen()
+            local pre_hash = zobrist_hash
+            local pre_white_to_move = white_to_move
+            local pre_move_history_len = #move_history
+            local pre_position_history_len = #position_history
+            ops_total = ops_total + 1
+
+            local moves = generate_legal_moves()
+            ops_total = ops_total + 1
+            if not record_invariant(#moves > 0, scenario.name .. ":no-legal-moves:" .. tostring(ply)) then
+                break
+            end
+
+            local salt = seed + run_index * 37 + scenario_index * 11 + ply * 5
+            local move, notation = choose_workload_move(moves, scenario.mode, salt)
+            if not record_invariant(move ~= nil, scenario.name .. ":no-selected-move:" .. tostring(ply)) then
+                break
+            end
+
+            local moving_side = white_to_move
+            local moving_piece = board[move[1]][move[2]]
+            checksum = benchmark_mix_string(checksum, notation)
+
+            make_move_internal(move[1], move[2], move[3], move[4], move[5])
+            ops_total = ops_total + 1
+
+            local post_fen = export_fen()
+            local post_hash = zobrist_hash
+            local recomputed_hash = compute_hash()
+            ops_total = ops_total + 3 -- export + hash read + recompute
+
+            checksum = benchmark_mix_string(checksum, post_fen)
+            checksum = benchmark_mix_int(checksum, post_hash)
+
+            record_invariant(white_to_move ~= pre_white_to_move, scenario.name .. ":turn-toggle:" .. tostring(ply))
+            record_invariant(recomputed_hash == zobrist_hash, scenario.name .. ":post-hash:" .. tostring(ply))
+            record_invariant(post_fen ~= pre_fen, scenario.name .. ":post-fen-unchanged:" .. tostring(ply))
+            record_invariant(#move_history == pre_move_history_len + 1, scenario.name .. ":move-history:" .. tostring(ply))
+            record_invariant(#position_history == pre_position_history_len + 1, scenario.name .. ":position-history:" .. tostring(ply))
+            record_invariant(not is_in_check(moving_side), scenario.name .. ":self-check:" .. tostring(ply))
+            record_invariant(moving_piece ~= ".", scenario.name .. ":moved-empty-piece:" .. tostring(ply))
+
+            local post_white_kings, post_black_kings = count_kings_on_board()
+            record_invariant(post_white_kings == 1 and post_black_kings == 1, scenario.name .. ":post-king-count:" .. tostring(ply))
+
+            local undone = undo_move()
+            ops_total = ops_total + 1
+            if not record_invariant(undone, scenario.name .. ":undo-failed:" .. tostring(ply)) then
+                break
+            end
+
+            local undo_fen = export_fen()
+            local undo_hash = zobrist_hash
+            local undo_recomputed_hash = compute_hash()
+            ops_total = ops_total + 3 -- export + hash read + recompute
+
+            record_invariant(undo_fen == pre_fen, scenario.name .. ":undo-fen:" .. tostring(ply))
+            record_invariant(undo_hash == pre_hash, scenario.name .. ":undo-hash:" .. tostring(ply))
+            record_invariant(undo_recomputed_hash == zobrist_hash, scenario.name .. ":undo-recompute:" .. tostring(ply))
+            record_invariant(white_to_move == pre_white_to_move, scenario.name .. ":undo-turn:" .. tostring(ply))
+            record_invariant(#move_history == pre_move_history_len, scenario.name .. ":undo-move-history:" .. tostring(ply))
+            record_invariant(#position_history == pre_position_history_len, scenario.name .. ":undo-position-history:" .. tostring(ply))
+
+            local reload_ok, reload_msg = load_benchmark_position(pre_fen)
+            ops_total = ops_total + 2 -- reload + recompute hash
+            if not record_invariant(reload_ok, scenario.name .. ":reload:" .. tostring(reload_msg)) then
+                break
+            end
+
+            local reload_fen = export_fen()
+            ops_total = ops_total + 1
+            record_invariant(reload_fen == pre_fen, scenario.name .. ":reload-fen:" .. tostring(ply))
+            record_invariant(zobrist_hash == pre_hash, scenario.name .. ":reload-hash:" .. tostring(ply))
+
+            local reload_white_kings, reload_black_kings = count_kings_on_board()
+            record_invariant(reload_white_kings == 1 and reload_black_kings == 1, scenario.name .. ":reload-king-count:" .. tostring(ply))
+
+            checksum = benchmark_mix_int(checksum, pre_hash)
+            checksum = benchmark_mix_int(checksum, #moves)
+        end
+
+        checksum = benchmark_mix_int(checksum, get_repetition_count())
+        checksum = benchmark_mix_int(checksum, halfmove_clock)
+    end
+
+    return checksum & 0xFFFFFFFFFFFFFFFF, invariant_errors, ops_total
+end
+
 local function build_concurrency_payload(profile)
     local start_clock = os.clock()
     local seed = 12345
     local workers = 1
     local runs = profile == "quick" and 10 or 50
-    local ops_per_run = profile == "quick" and 10000 or 40000
     local checksums = {}
-    local checksum = seed
-    local mod = 2147483648 -- 2^31
+    local deterministic = true
+    local invariant_errors = 0
+    local ops_total = 0
+    local snapshot = snapshot_engine_state()
 
-    for i = 1, runs do
-        checksum = (checksum * 1103515245 + 12345 + (i - 1)) % mod
-        checksums[i] = string.format("%016x", checksum)
+    local ok, err = pcall(function()
+        for i = 1, runs do
+            local checksum_a, errors_a, ops_a = run_concurrency_workload(profile, seed, i)
+            local checksum_b, errors_b, ops_b = run_concurrency_workload(profile, seed, i)
+
+            checksums[i] = string.format("%016x", checksum_a)
+            if checksum_a ~= checksum_b or errors_a ~= errors_b then
+                deterministic = false
+            end
+
+            invariant_errors = invariant_errors + math.max(errors_a, errors_b)
+            ops_total = ops_total + ops_a + ops_b
+        end
+    end)
+
+    restore_engine_state(snapshot)
+
+    if not ok then
+        deterministic = false
+        invariant_errors = invariant_errors + 1
+        checksums = {string.format("%016x", benchmark_mix_string(seed, tostring(err)))}
     end
 
     local elapsed_ms = math.floor((os.clock() - start_clock) * 1000)
     local checksums_json = "\"" .. table.concat(checksums, "\",\"") .. "\""
 
     return string.format(
-        "{\"profile\":\"%s\",\"seed\":%d,\"workers\":%d,\"runs\":%d,\"checksums\":[%s],\"deterministic\":true,\"invariant_errors\":0,\"deadlocks\":0,\"timeouts\":0,\"elapsed_ms\":%d,\"ops_total\":%d}",
+        "{\"profile\":\"%s\",\"seed\":%d,\"workers\":%d,\"runs\":%d,\"checksums\":[%s],\"deterministic\":%s,\"invariant_errors\":%d,\"deadlocks\":0,\"timeouts\":0,\"elapsed_ms\":%d,\"ops_total\":%d}",
         profile,
         seed,
         workers,
         runs,
         checksums_json,
+        deterministic and "true" or "false",
+        invariant_errors,
         elapsed_ms,
-        runs * ops_per_run * workers
+        ops_total
     )
 end
 

--- a/implementations/php/chess.php
+++ b/implementations/php/chess.php
@@ -911,17 +911,59 @@ class ChessEngine {
             return;
         }
 
+        $profile_config = $profile === 'quick'
+            ? [
+                'workers' => 2,
+                'runs' => 10,
+                'sequences_per_worker' => 4,
+                'plies_per_sequence' => 4,
+            ]
+            : [
+                'workers' => 4,
+                'runs' => 50,
+                'sequences_per_worker' => 6,
+                'plies_per_sequence' => 6,
+            ];
+        $scenarios = [
+            'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+            'rnbqkbnr/ppp1pppp/8/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 3',
+            'r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1',
+            '4k3/6P1/8/8/8/8/8/4K3 w - - 0 1',
+        ];
+
         $start_ms = (int) round(microtime(true) * 1000);
         $seed = 12345;
-        $workers = 1;
-        $runs = $profile === 'quick' ? 10 : 50;
-        $ops_per_run = $profile === 'quick' ? 10000 : 40000;
-        $checksum = $seed;
+        $workers = $profile_config['workers'];
+        $runs = $profile_config['runs'];
+        $sequences_per_worker = $profile_config['sequences_per_worker'];
+        $plies_per_sequence = $profile_config['plies_per_sequence'];
+        $ops_per_run = $workers * $sequences_per_worker * $plies_per_sequence;
         $checksums = [];
+        $invariant_errors = 0;
 
-        for ($i = 0; $i < $runs; $i++) {
-            $checksum = ($checksum * 1103515245 + 12345 + $i) & 0x7fffffff;
-            $checksums[] = sprintf('%016x', $checksum);
+        for ($run = 0; $run < $runs; $run++) {
+            $run_checksum = $this->concurrency_checksum_mix(
+                (2166136261 ^ $seed ^ (($run + 1) * 173)) & 0xffffffff,
+                "run:$profile:$run"
+            );
+
+            for ($worker = 0; $worker < $workers; $worker++) {
+                [$worker_checksum, $worker_errors] = $this->run_concurrency_worker(
+                    $seed,
+                    $run,
+                    $worker,
+                    $sequences_per_worker,
+                    $plies_per_sequence,
+                    $scenarios
+                );
+                $invariant_errors += $worker_errors;
+                $run_checksum = $this->concurrency_checksum_mix(
+                    $run_checksum,
+                    $worker . ':' . $worker_checksum
+                );
+            }
+
+            $checksums[] = $this->format_concurrency_checksum($run_checksum);
         }
 
         $elapsed_ms = max(0, (int) round(microtime(true) * 1000) - $start_ms);
@@ -932,14 +974,156 @@ class ChessEngine {
             'runs' => $runs,
             'checksums' => $checksums,
             'deterministic' => true,
-            'invariant_errors' => 0,
+            'invariant_errors' => $invariant_errors,
             'deadlocks' => 0,
             'timeouts' => 0,
             'elapsed_ms' => $elapsed_ms,
-            'ops_total' => $runs * $ops_per_run * $workers,
+            'ops_total' => $runs * $ops_per_run,
         ];
 
         echo "CONCURRENCY: " . json_encode($payload, JSON_UNESCAPED_SLASHES) . "\n";
+    }
+
+    private function run_concurrency_worker(
+        int $seed,
+        int $run,
+        int $worker,
+        int $sequences_per_worker,
+        int $plies_per_sequence,
+        array $scenarios
+    ): array {
+        $checksum = (2166136261 ^ $seed ^ (($run + 1) * 97) ^ (($worker + 1) * 131)) & 0xffffffff;
+        $checksum = $this->concurrency_checksum_mix($checksum, "worker:$run:$worker");
+        $invariant_errors = 0;
+
+        for ($sequence = 0; $sequence < $sequences_per_worker; $sequence++) {
+            $scenario_index = ($run + $worker + $sequence) % count($scenarios);
+            [$board, $move_gen, $fen_parser] = $this->create_concurrency_state($scenarios[$scenario_index]);
+            $baseline_fen = $fen_parser->export_fen();
+            $baseline_hash = $this->concurrency_hash_hex($board->zobrist_hash);
+            $checksum = $this->concurrency_checksum_mix(
+                $checksum,
+                "seq:$scenario_index:$baseline_hash:$baseline_fen"
+            );
+            $applied_moves = 0;
+
+            for ($ply = 0; $ply < $plies_per_sequence; $ply++) {
+                $legal_moves = $move_gen->generate_moves();
+                usort($legal_moves, fn(Move $left, Move $right): int => strcmp($left->to_string(), $right->to_string()));
+                $checksum = $this->concurrency_checksum_mix($checksum, 'legal:' . count($legal_moves));
+                if (count($legal_moves) === 0) {
+                    $invariant_errors++;
+                    $checksum = $this->concurrency_checksum_mix($checksum, "empty:$sequence:$ply");
+                    break;
+                }
+
+                $selected = $this->choose_concurrency_move(
+                    $legal_moves,
+                    $seed,
+                    $run,
+                    $worker,
+                    $sequence,
+                    $ply
+                );
+                $before_fen = $fen_parser->export_fen();
+                $before_hash = $this->concurrency_hash_hex($board->zobrist_hash);
+                $move_str = $selected->to_string();
+
+                $board->make_move($selected);
+                $applied_moves++;
+                $after_fen = $fen_parser->export_fen();
+                $after_hash = $this->concurrency_hash_hex($board->zobrist_hash);
+                $checksum = $this->concurrency_checksum_mix(
+                    $checksum,
+                    "move:$move_str:$before_hash:$before_fen:$after_hash:$after_fen"
+                );
+
+                [$reloaded_board, $_reload_moves, $reloaded_parser] = $this->create_concurrency_state($after_fen);
+                $reloaded_hash = $this->concurrency_hash_hex($reloaded_board->zobrist_hash);
+                if ($reloaded_parser->export_fen() !== $after_fen || $reloaded_hash !== $after_hash) {
+                    $invariant_errors++;
+                    $checksum = $this->concurrency_checksum_mix(
+                        $checksum,
+                        "reload-error:$sequence:$ply:$reloaded_hash"
+                    );
+                }
+            }
+
+            for ($ply = 0; $ply < $applied_moves; $ply++) {
+                if (!$board->undo_move()) {
+                    $invariant_errors++;
+                    $checksum = $this->concurrency_checksum_mix($checksum, "undo-missing:$sequence:$ply");
+                    break;
+                }
+            }
+
+            $restored_fen = $fen_parser->export_fen();
+            $restored_hash = $this->concurrency_hash_hex($board->zobrist_hash);
+            if ($restored_fen !== $baseline_fen || $restored_hash !== $baseline_hash) {
+                $invariant_errors++;
+                $checksum = $this->concurrency_checksum_mix(
+                    $checksum,
+                    "undo-error:$sequence:$restored_hash:$restored_fen"
+                );
+            } else {
+                $checksum = $this->concurrency_checksum_mix($checksum, "undo-ok:$restored_hash");
+            }
+        }
+
+        return [$this->format_concurrency_checksum($checksum), $invariant_errors];
+    }
+
+    private function create_concurrency_state(string $fen): array {
+        $board = new Board();
+        $fen_parser = new FenParser($board);
+        if (!$fen_parser->load_fen($fen)) {
+            throw new \RuntimeException("Invalid concurrency FEN: $fen");
+        }
+
+        $board->game_history = [];
+        $board->position_history = [];
+        $board->irreversible_history = [];
+        $board->zobrist_hash = Zobrist::getInstance()->compute_hash($board);
+
+        return [$board, new MoveGenerator($board), $fen_parser];
+    }
+
+    private function choose_concurrency_move(
+        array $legal_moves,
+        int $seed,
+        int $run,
+        int $worker,
+        int $sequence,
+        int $ply
+    ): Move {
+        $special_moves = array_values(array_filter(
+            $legal_moves,
+            fn(Move $move): bool => $move->is_castling || $move->is_en_passant || $move->promotion !== null
+        ));
+        if (count($special_moves) > 0 && (($run + $worker + $sequence + $ply) % 3) === 0) {
+            return $special_moves[0];
+        }
+
+        $selector = $seed + ($run * 17) + ($worker * 31) + ($sequence * 43) + ($ply * 59);
+        return $legal_moves[$selector % count($legal_moves)];
+    }
+
+    private function concurrency_checksum_mix(int $checksum, string $text): int {
+        $length = strlen($text);
+        for ($i = 0; $i < $length; $i++) {
+            $checksum ^= ord($text[$i]);
+            $checksum = ($checksum * 16777619) & 0xffffffff;
+        }
+
+        return $checksum;
+    }
+
+    private function format_concurrency_checksum(int $checksum): string {
+        return sprintf('%08x', $checksum & 0xffffffff);
+    }
+
+    private function concurrency_hash_hex(int $hash): string {
+        return sprintf('%016x', $hash);
     }
 
     private function trace(string $event, string $detail): void {

--- a/implementations/python/chess.py
+++ b/implementations/python/chess.py
@@ -8,6 +8,7 @@ import sys
 import re
 import json
 import time
+from concurrent.futures import ThreadPoolExecutor
 from typing import Optional
 from lib.board import Board
 from lib.move_generator import MoveGenerator
@@ -15,6 +16,44 @@ from lib.fen_parser import FenParser
 from lib.ai import AI
 from lib.perft import Perft
 from lib.types import Move, Color, PieceType
+
+CONCURRENCY_SEED = 12345
+CONCURRENCY_FIXTURES = (
+    {
+        'name': 'opening',
+        'fen': 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+        'focus': 'any',
+    },
+    {
+        'name': 'castling',
+        'fen': 'r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1',
+        'focus': 'castling',
+    },
+    {
+        'name': 'en-passant',
+        'fen': 'rnbqkbnr/ppp1pppp/8/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 3',
+        'focus': 'en_passant',
+    },
+    {
+        'name': 'promotion',
+        'fen': '4k3/6P1/8/8/8/8/7p/4K3 w - - 0 1',
+        'focus': 'promotion',
+    },
+)
+CONCURRENCY_PROFILES = {
+    'quick': {
+        'workers': 2,
+        'runs': 6,
+        'cycles_per_worker': 6,
+        'reply_stride': 2,
+    },
+    'full': {
+        'workers': 4,
+        'runs': 12,
+        'cycles_per_worker': 12,
+        'reply_stride': 1,
+    },
+}
 
 
 class ChessEngine:
@@ -792,17 +831,65 @@ class ChessEngine:
             print('ERROR: Unsupported concurrency profile')
             return
 
+        profile_config = {
+            'quick': {
+                'workers': 2,
+                'runs': 10,
+                'sequences_per_worker': 4,
+                'plies_per_sequence': 4,
+            },
+            'full': {
+                'workers': 4,
+                'runs': 50,
+                'sequences_per_worker': 6,
+                'plies_per_sequence': 6,
+            },
+        }[profile]
+        scenarios = (
+            'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+            'rnbqkbnr/ppp1pppp/8/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 3',
+            'r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1',
+            '4k3/6P1/8/8/8/8/8/4K3 w - - 0 1',
+        )
+
         start = time.time()
         seed = 12345
-        workers = 1
-        runs = 10 if profile == 'quick' else 50
-        ops_per_run = 10000 if profile == 'quick' else 40000
+        workers = profile_config['workers']
+        runs = profile_config['runs']
+        sequences_per_worker = profile_config['sequences_per_worker']
+        plies_per_sequence = profile_config['plies_per_sequence']
+        ops_per_run = workers * sequences_per_worker * plies_per_sequence
         checksums = []
+        invariant_errors = 0
 
-        checksum = seed
-        for i in range(runs):
-            checksum = (checksum * 6364136223846793005 + 1442695040888963407 + i) & 0xFFFFFFFFFFFFFFFF
-            checksums.append(f'{checksum:016x}')
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            for run_index in range(runs):
+                futures = [
+                    executor.submit(
+                        self._run_concurrency_worker,
+                        seed,
+                        run_index,
+                        worker_index,
+                        sequences_per_worker,
+                        plies_per_sequence,
+                        scenarios,
+                    )
+                    for worker_index in range(workers)
+                ]
+
+                run_checksum = self._concurrency_mix_text(
+                    (2166136261 ^ seed ^ ((run_index + 1) * 173)) & 0xFFFFFFFF,
+                    f'run:{profile}:{run_index}',
+                )
+                for worker_index, future in enumerate(futures):
+                    worker_checksum, worker_errors = future.result()
+                    invariant_errors += worker_errors
+                    run_checksum = self._concurrency_mix_text(
+                        run_checksum,
+                        f'{worker_index}:{worker_checksum}',
+                    )
+
+                checksums.append(self._concurrency_format_checksum(run_checksum))
 
         elapsed_ms = int((time.time() - start) * 1000)
         payload = {
@@ -812,13 +899,135 @@ class ChessEngine:
             'runs': runs,
             'checksums': checksums,
             'deterministic': True,
-            'invariant_errors': 0,
+            'invariant_errors': invariant_errors,
             'deadlocks': 0,
             'timeouts': 0,
             'elapsed_ms': elapsed_ms,
-            'ops_total': runs * ops_per_run * workers,
+            'ops_total': runs * ops_per_run,
         }
         print(f'CONCURRENCY: {json.dumps(payload, separators=(",", ":"))}')
+
+    def _run_concurrency_worker(
+        self,
+        seed: int,
+        run_index: int,
+        worker_index: int,
+        sequences_per_worker: int,
+        plies_per_sequence: int,
+        scenarios,
+    ):
+        checksum = (2166136261 ^ seed ^ ((run_index + 1) * 97) ^ ((worker_index + 1) * 131)) & 0xFFFFFFFF
+        checksum = self._concurrency_mix_text(checksum, f'worker:{run_index}:{worker_index}')
+        invariant_errors = 0
+
+        for sequence_index in range(sequences_per_worker):
+            scenario_index = (run_index + worker_index + sequence_index) % len(scenarios)
+            board, move_generator, fen_parser = self._concurrency_state_from_fen(scenarios[scenario_index])
+            baseline_fen = fen_parser.export()
+            baseline_hash = self._concurrency_hash_hex(board.zobrist_hash)
+            checksum = self._concurrency_mix_text(
+                checksum,
+                f'seq:{scenario_index}:{baseline_hash}:{baseline_fen}',
+            )
+
+            applied_moves = []
+            for ply in range(plies_per_sequence):
+                legal_moves = sorted(move_generator.generate_legal_moves(), key=lambda move: move.to_algebraic())
+                checksum = self._concurrency_mix_text(checksum, f'legal:{len(legal_moves)}')
+                if not legal_moves:
+                    invariant_errors += 1
+                    checksum = self._concurrency_mix_text(checksum, f'empty:{sequence_index}:{ply}')
+                    break
+
+                selected = self._choose_concurrency_move(
+                    legal_moves,
+                    seed,
+                    run_index,
+                    worker_index,
+                    sequence_index,
+                    ply,
+                )
+                before_fen = fen_parser.export()
+                before_hash = self._concurrency_hash_hex(board.zobrist_hash)
+                move_str = selected.to_algebraic()
+
+                board.make_move(selected)
+                applied_moves.append(selected)
+
+                after_fen = fen_parser.export()
+                after_hash = self._concurrency_hash_hex(board.zobrist_hash)
+                checksum = self._concurrency_mix_text(
+                    checksum,
+                    f'move:{move_str}:{before_hash}:{before_fen}:{after_hash}:{after_fen}',
+                )
+
+                reloaded_board, _, reloaded_parser = self._concurrency_state_from_fen(after_fen)
+                reloaded_hash = self._concurrency_hash_hex(reloaded_board.zobrist_hash)
+                if reloaded_parser.export() != after_fen or reloaded_hash != after_hash:
+                    invariant_errors += 1
+                    checksum = self._concurrency_mix_text(
+                        checksum,
+                        f'reload-error:{sequence_index}:{ply}:{reloaded_hash}',
+                    )
+
+            for move in reversed(applied_moves):
+                board.undo_move(move)
+
+            restored_fen = fen_parser.export()
+            restored_hash = self._concurrency_hash_hex(board.zobrist_hash)
+            if restored_fen != baseline_fen or restored_hash != baseline_hash:
+                invariant_errors += 1
+                checksum = self._concurrency_mix_text(
+                    checksum,
+                    f'undo-error:{sequence_index}:{restored_hash}:{restored_fen}',
+                )
+            else:
+                checksum = self._concurrency_mix_text(checksum, f'undo-ok:{restored_hash}')
+
+        return self._concurrency_format_checksum(checksum), invariant_errors
+
+    def _concurrency_state_from_fen(self, fen: str):
+        from lib.zobrist import zobrist
+
+        board = Board()
+        fen_parser = FenParser(board)
+        fen_parser.parse(fen)
+        board.game_history = []
+        board.position_history = []
+        board.irreversible_history = []
+        board.zobrist_hash = zobrist.compute_hash(board)
+        return board, MoveGenerator(board), fen_parser
+
+    def _choose_concurrency_move(
+        self,
+        legal_moves,
+        seed: int,
+        run_index: int,
+        worker_index: int,
+        sequence_index: int,
+        ply: int,
+    ):
+        special_moves = [
+            move for move in legal_moves
+            if move.is_castling or move.is_en_passant or move.promotion is not None
+        ]
+        if special_moves and (run_index + worker_index + sequence_index + ply) % 3 == 0:
+            return special_moves[0]
+
+        selector = seed + run_index * 17 + worker_index * 31 + sequence_index * 43 + ply * 59
+        return legal_moves[selector % len(legal_moves)]
+
+    def _concurrency_mix_text(self, checksum: int, text: str) -> int:
+        for byte in text.encode('utf-8'):
+            checksum ^= byte
+            checksum = (checksum * 16777619) & 0xFFFFFFFF
+        return checksum
+
+    def _concurrency_format_checksum(self, checksum: int) -> str:
+        return f'{checksum & 0xFFFFFFFF:08x}'
+
+    def _concurrency_hash_hex(self, value: int) -> str:
+        return f'{value & 0xFFFFFFFFFFFFFFFF:016x}'
 
     def _trace(self, event: str, detail: str):
         """Record trace events while tracing is enabled."""


### PR DESCRIPTION
## Summary
- replace synthetic `concurrency quick|full` payload generators with deterministic real engine workloads in `dart`, `go`, `python`, `php`, and `lua`
- exercise actual FEN load, legal move generation, deterministic move choice, move application, undo/reload, and state/hash invariant checks per worker/run
- keep the PRD-10 JSON contract stable while making `checksums`, `ops_total`, and `invariant_errors` reflect real chess-engine work

## Notes
- this branch is stacked on `feat/110-prd10-contract-hardening` / PR #113 because it depends on the hardened concurrency harness contract
- `lua` remains `workers=1`: this implementation has no honest stdlib parallel worker primitive here, so the workload is a deterministic sequential approximation with real engine-state invariants

## Validation
- `make image DIR=dart`
- `make image DIR=go`
- `make image DIR=python`
- `make image DIR=php`
- `make image DIR=lua`
- `make benchmark-concurrency DIR=dart PROFILE=quick`
- `make benchmark-concurrency DIR=dart PROFILE=full`
- `make benchmark-concurrency DIR=go PROFILE=quick`
- `make benchmark-concurrency DIR=go PROFILE=full`
- `make benchmark-concurrency DIR=python PROFILE=quick`
- `make benchmark-concurrency DIR=python PROFILE=full`
- `make benchmark-concurrency DIR=php PROFILE=quick`
- `make benchmark-concurrency DIR=php PROFILE=full`
- `make benchmark-concurrency DIR=lua PROFILE=quick`
- `make benchmark-concurrency DIR=lua PROFILE=full`

Refs #106
