### PR TITLE
feat(test): add shared unit contract harness (#120)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,14 @@
 # IMPORTANT: All tests and builds MUST run inside Docker containers
 # Convention over Configuration: This Makefile is 100% implementation-agnostic
 
-.PHONY: all image test-chess-engine test build analyze clean help website analyze-tools list-implementations verify workflow validate-website-metadata install-hooks benchmark-stress benchmark-concurrency
+.PHONY: all image test-chess-engine test-unit-contract test build analyze clean help website analyze-tools list-implementations verify workflow validate-website-metadata install-hooks benchmark-stress benchmark-concurrency
 
 # Auto-discover all implementations with Dockerfiles
 IMPLEMENTATIONS := $(shell find implementations -mindepth 1 -maxdepth 1 -type d -exec test -f {}/Dockerfile \; -exec basename {} \; 2>/dev/null | sort)
 TRACK ?= v1
 PROFILE ?= quick
 TIMEOUT ?= 1800
+STRICT ?= 0
 
 # Default target
 all: image build test test-chess-engine
@@ -24,6 +25,8 @@ help:
 	@echo "  make build [DIR=<impl>]             - Run compilation command(s) only"
 	@echo "  make analyze [DIR=<impl>]           - Run static analysis/lint command(s) only"
 	@echo "  make test [DIR=<impl>]              - Run internal implementation test command(s) only"
+	@echo "  make test-unit-contract [DIR=<impl>] [STRICT=1]"
+	@echo "                                     - Run shared unit-contract parity suite (STRICT=1 fails on missing adapters)"
 	@echo "  make test-chess-engine [DIR=<impl>] [TRACK=v1|v2-foundation|v2-functional|v2-system|v2-full|v3-book]"
 	@echo "                                     - Run shared chess engine suite only"
 	@echo "  make benchmark-stress [DIR=<impl>] [TRACK=...] [PROFILE=quick|full] [TIMEOUT=<s>]"
@@ -152,6 +155,38 @@ else
 	done
 	@echo ""
 	@echo "Internal tests complete for all implementations"
+endif
+
+# Shared unit-level contract tests target
+test-unit-contract:
+ifdef DIR
+	@if [ ! -d "implementations/$(DIR)" ]; then \
+		echo "ERROR: Implementation '$(DIR)' not found"; \
+		exit 1; \
+	fi
+	@if [ ! -f "implementations/$(DIR)/Dockerfile" ]; then \
+		echo "ERROR: No Dockerfile found for '$(DIR)'"; \
+		exit 1; \
+	fi
+	@echo "Running unit contract suite for $(DIR)..."
+	@STRICT_FLAG=""; \
+	if [ "$(STRICT)" = "1" ]; then STRICT_FLAG="--require-contract"; fi; \
+	python3 test/unit_contract_harness.py \
+		--impl implementations/$(DIR) \
+		--docker-image chess-$(DIR) \
+		$$STRICT_FLAG
+else
+	@echo "Running shared unit contract suite for all implementations..."
+	@for impl in $(IMPLEMENTATIONS); do \
+		echo ""; \
+		echo "==================== Unit Contract Suite $$impl ===================="; \
+		if ! $(MAKE) test-unit-contract DIR=$$impl STRICT=$(STRICT); then \
+			echo "Unit contract suite failed for $$impl. Stopping."; \
+			exit 1; \
+		fi; \
+	done
+	@echo ""
+	@echo "Shared unit contract suite complete for all implementations"
 endif
 
 # Shared chess engine protocol + behavior tests target

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ make image DIR=<language>
 make build DIR=<language>
 make analyze DIR=<language>
 make test DIR=<language>
+make test-unit-contract DIR=<language>
 make test-chess-engine DIR=<language>
 ```
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -65,8 +65,11 @@ make image DIR=<language>
 make build DIR=<language>
 make analyze DIR=<language>
 make test DIR=<language>
+make test-unit-contract DIR=<language>
 make test-chess-engine DIR=<language>
 ```
+
+`make test-unit-contract` is the shared unit-parity lane. It is currently opt-in per implementation via `org.chess.test_contract`; use `STRICT=1` to make missing adapters fail.
 
 Optional broad checks:
 

--- a/docs/IMPLEMENTATION_GUIDELINES.md
+++ b/docs/IMPLEMENTATION_GUIDELINES.md
@@ -40,6 +40,7 @@ Root integration commands use:
 - `make build DIR=<language>`
 - `make analyze DIR=<language>`
 - `make test DIR=<language>`
+- `make test-unit-contract DIR=<language>`
 - `make test-chess-engine DIR=<language>`
 
 ## Required Engine Commands
@@ -67,6 +68,9 @@ Board rendering, move legality, error messages, and output format must match the
 - `org.chess.test`
 - `org.chess.analyze`
 - `org.chess.run`
+
+Recommended for the shared unit-parity lane:
+- `org.chess.test_contract` - adapter command invoked by `test/unit_contract_harness.py`; the harness appends `--suite` and `--report`
 
 ## Functional Requirements Checklist
 
@@ -96,6 +100,7 @@ make image DIR=<language>
 make build DIR=<language>
 make analyze DIR=<language>
 make test DIR=<language>
+make test-unit-contract DIR=<language>
 make test-chess-engine DIR=<language>
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,9 @@ Use this page as the main entrypoint for project documentation.
 
 - Root commands: [Makefile](../Makefile)
 - Shared test suite: [test/test_suite.json](../test/test_suite.json)
+- Shared unit contract suite: [test/contracts/unit_v1.json](../test/contracts/unit_v1.json)
 - Test harness: [test/test_harness.py](../test/test_harness.py)
+- Unit contract harness: [test/unit_contract_harness.py](../test/unit_contract_harness.py)
 - CI triage workflow notes: [docs/ISSUE_TRIAGE_WORKFLOW.md](ISSUE_TRIAGE_WORKFLOW.md)
 
 ## Additional References

--- a/implementations/python/Dockerfile
+++ b/implementations/python/Dockerfile
@@ -12,6 +12,7 @@ LABEL org.chess.source_exts=".py"
 LABEL org.chess.benchmark.build="skip"
 LABEL org.chess.build="python3 -m py_compile chess.py"
 LABEL org.chess.test="python3 test_engine.py"
+LABEL org.chess.test_contract="python3 test_contract_runner.py"
 LABEL org.chess.analyze="python3 -m py_compile chess.py lib/*.py"
 
 CMD ["python3", "chess.py"]

--- a/implementations/python/test_contract_runner.py
+++ b/implementations/python/test_contract_runner.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Shared unit-contract adapter for the Python chess implementation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from lib.ai import AI
+from lib.board import Board
+from lib.fen_parser import FenParser
+from lib.move_generator import MoveGenerator
+from lib.types import Move
+from lib.zobrist import zobrist
+
+
+def build_context(setup: Dict[str, Any]) -> Dict[str, Any]:
+    board = Board()
+    move_generator = MoveGenerator(board)
+    fen_parser = FenParser(board)
+    ai = AI(board, move_generator)
+
+    if setup["type"] == "fen":
+        fen_parser.parse(setup["value"])
+        board.game_history = []
+        board.position_history = []
+        board.irreversible_history = []
+        board.zobrist_hash = zobrist.compute_hash(board)
+
+    return {
+        "board": board,
+        "move_generator": move_generator,
+        "fen_parser": fen_parser,
+        "ai": ai,
+    }
+
+
+def find_legal_move(context: Dict[str, Any], move_text: str):
+    requested = Move.from_algebraic(move_text)
+    if requested is None:
+        raise ValueError(f"Invalid move: {move_text}")
+
+    legal_moves = context["move_generator"].generate_legal_moves()
+    for move in legal_moves:
+        if (
+            move.from_row == requested.from_row
+            and move.from_col == requested.from_col
+            and move.to_row == requested.to_row
+            and move.to_col == requested.to_col
+            and move.promotion == requested.promotion
+        ):
+            return move
+
+    raise ValueError(f"Illegal move: {move_text}")
+
+
+def execute_case(case: Dict[str, Any]) -> Dict[str, Any]:
+    case_id = case["id"]
+    try:
+        context = build_context(case["setup"])
+        board = context["board"]
+        fen_parser = context["fen_parser"]
+        operation = case["operation"]
+        operation_type = operation["type"]
+
+        if operation_type == "export_fen":
+            actual = fen_parser.export()
+        elif operation_type == "legal_move_count":
+            actual = len(context["move_generator"].generate_legal_moves())
+        elif operation_type == "apply_move_export_fen":
+            move = find_legal_move(context, operation["move"])
+            board.make_move(move)
+            actual = fen_parser.export()
+        elif operation_type == "apply_move_undo_export_fen":
+            move = find_legal_move(context, operation["move"])
+            board.make_move(move)
+            board.undo_move(move)
+            actual = fen_parser.export()
+        elif operation_type == "apply_move_status":
+            move = find_legal_move(context, operation["move"])
+            board.make_move(move)
+            actual = board.get_game_status()
+        elif operation_type == "ai_best_move":
+            best_move, _score = context["ai"].get_best_move(operation["depth"])
+            if best_move is None:
+                raise ValueError("AI did not return a move")
+            actual = best_move.to_algebraic().lower()
+        else:
+            raise ValueError(f"Unsupported operation: {operation_type}")
+
+        return {
+            "id": case_id,
+            "status": "passed",
+            "normalized_actual": actual,
+        }
+    except Exception as exc:  # pragma: no cover - adapter surfaces failures in JSON
+        return {
+            "id": case_id,
+            "status": "failed",
+            "error": str(exc),
+        }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run shared unit contract cases")
+    parser.add_argument("--suite", required=True, help="Path to contract suite JSON")
+    parser.add_argument("--report", required=True, help="Path to write JSON report")
+    args = parser.parse_args()
+
+    suite_path = Path(args.suite)
+    report_path = Path(args.report)
+    suite = json.loads(suite_path.read_text(encoding="utf-8"))
+
+    report = {
+        "schema_version": "1.0",
+        "suite": suite["suite"],
+        "implementation": "python",
+        "cases": [execute_case(case) for case in suite["cases"]],
+    }
+    report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/typescript/Dockerfile
+++ b/implementations/typescript/Dockerfile
@@ -13,6 +13,7 @@ LABEL org.chess.estimated_perft4_ms=800
 LABEL org.chess.source_exts=".ts"
 LABEL org.chess.build="npm run build"
 LABEL org.chess.test="npm test"
+LABEL org.chess.test_contract="node unit_contract_runner.js"
 LABEL org.chess.analyze="npm run lint"
 
 CMD ["node", "dist/chess.js"]

--- a/implementations/typescript/unit_contract_runner.js
+++ b/implementations/typescript/unit_contract_runner.js
@@ -1,0 +1,153 @@
+const fs = require("fs");
+const { Board } = require("./dist/board");
+const { MoveGenerator } = require("./dist/moveGenerator");
+const { FenParser } = require("./dist/fen");
+const { AI } = require("./dist/ai");
+
+function buildContext(setup) {
+  const board = new Board();
+  const moveGenerator = new MoveGenerator(board);
+  const fenParser = new FenParser(board);
+  const ai = new AI(board, moveGenerator);
+
+  if (setup.type === "fen") {
+    fenParser.parseFen(setup.value);
+  }
+
+  return { board, moveGenerator, fenParser, ai };
+}
+
+function moveToUci(board, move) {
+  return (
+    board.squareToAlgebraic(move.from) +
+    board.squareToAlgebraic(move.to) +
+    (move.promotion ? move.promotion.toLowerCase() : "")
+  );
+}
+
+function findLegalMove(context, moveText) {
+  if (typeof moveText !== "string" || moveText.length < 4) {
+    throw new Error(`Invalid move: ${moveText}`);
+  }
+
+  const from = context.board.algebraicToSquare(moveText.slice(0, 2));
+  const to = context.board.algebraicToSquare(moveText.slice(2, 4));
+  const promotion =
+    moveText.length > 4 ? moveText.slice(4, 5).toUpperCase() : undefined;
+
+  const legalMoves = context.moveGenerator.getLegalMoves(context.board.getTurn());
+  const move = legalMoves.find(
+    (candidate) =>
+      candidate.from === from &&
+      candidate.to === to &&
+      candidate.promotion === promotion,
+  );
+
+  if (!move) {
+    throw new Error(`Illegal move: ${moveText}`);
+  }
+
+  return move;
+}
+
+function getGameStatus(context) {
+  const color = context.board.getTurn();
+  if (context.moveGenerator.isCheckmate(color)) {
+    return "checkmate";
+  }
+  if (context.moveGenerator.isStalemate(color)) {
+    return "stalemate";
+  }
+  return "ongoing";
+}
+
+function executeCase(testCase) {
+  const caseId = testCase.id;
+
+  try {
+    const context = buildContext(testCase.setup);
+    const operation = testCase.operation;
+    let actual;
+
+    switch (operation.type) {
+      case "export_fen":
+        actual = context.fenParser.exportFen();
+        break;
+      case "legal_move_count":
+        actual = context.moveGenerator.getLegalMoves(context.board.getTurn()).length;
+        break;
+      case "apply_move_export_fen": {
+        const move = findLegalMove(context, operation.move);
+        context.board.makeMove(move);
+        actual = context.fenParser.exportFen();
+        break;
+      }
+      case "apply_move_undo_export_fen": {
+        const move = findLegalMove(context, operation.move);
+        context.board.makeMove(move);
+        context.board.undoMove();
+        actual = context.fenParser.exportFen();
+        break;
+      }
+      case "apply_move_status": {
+        const move = findLegalMove(context, operation.move);
+        context.board.makeMove(move);
+        actual = getGameStatus(context);
+        break;
+      }
+      case "ai_best_move": {
+        const result = context.ai.findBestMove(operation.depth);
+        if (!result.move) {
+          throw new Error("AI did not return a move");
+        }
+        actual = moveToUci(context.board, result.move);
+        break;
+      }
+      default:
+        throw new Error(`Unsupported operation: ${operation.type}`);
+    }
+
+    return {
+      id: caseId,
+      status: "passed",
+      normalized_actual: actual,
+    };
+  } catch (error) {
+    return {
+      id: caseId,
+      status: "failed",
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 2; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key.startsWith("--") || value === undefined) {
+      throw new Error("Expected --suite <path> --report <path>");
+    }
+    args[key.slice(2)] = value;
+  }
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  if (!args.suite || !args.report) {
+    throw new Error("Missing --suite or --report");
+  }
+
+  const suite = JSON.parse(fs.readFileSync(args.suite, "utf8"));
+  const report = {
+    schema_version: "1.0",
+    suite: suite.suite,
+    implementation: "typescript",
+    cases: suite.cases.map(executeCase),
+  };
+  fs.writeFileSync(args.report, JSON.stringify(report, null, 2));
+}
+
+main();

--- a/llms.txt
+++ b/llms.txt
@@ -30,9 +30,11 @@ Use this file as a compact map of canonical project docs.
 
 ## Build/Test Automation
 
-- [Makefile](Makefile): Canonical `make image/build/analyze/test/test-chess-engine` targets.
+- [Makefile](Makefile): Canonical `make image/build/analyze/test/test-unit-contract/test-chess-engine` targets.
 - [test/test_suite.json](test/test_suite.json): Shared behavioral test definitions.
 - [test/test_harness.py](test/test_harness.py): Shared harness invoked by CI and local workflows.
+- [test/contracts/unit_v1.json](test/contracts/unit_v1.json): Shared unit-scope parity contract.
+- [test/unit_contract_harness.py](test/unit_contract_harness.py): Docker-backed validator for implementation unit-contract adapters.
 
 ## Supporting References
 

--- a/test/contracts/unit_v1.json
+++ b/test/contracts/unit_v1.json
@@ -1,0 +1,179 @@
+{
+  "schema_version": "1.0",
+  "suite": "unit_v1",
+  "description": "Shared unit-scope contract scenarios for v1 chess engine semantics.",
+  "required_features": [
+    "fen",
+    "move_generation",
+    "move_execution",
+    "special_moves",
+    "game_end",
+    "ai"
+  ],
+  "cases": [
+    {
+      "id": "starting_position_fen",
+      "feature": "fen",
+      "required": true,
+      "setup": {
+        "type": "new_game"
+      },
+      "operation": {
+        "type": "export_fen"
+      },
+      "expect": {
+        "value": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+      },
+      "compare": "fen_exact"
+    },
+    {
+      "id": "fen_round_trip",
+      "feature": "fen",
+      "required": true,
+      "setup": {
+        "type": "fen",
+        "value": "r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1"
+      },
+      "operation": {
+        "type": "export_fen"
+      },
+      "expect": {
+        "value": "r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1"
+      },
+      "compare": "fen_exact"
+    },
+    {
+      "id": "starting_position_legal_move_count",
+      "feature": "move_generation",
+      "required": true,
+      "setup": {
+        "type": "new_game"
+      },
+      "operation": {
+        "type": "legal_move_count"
+      },
+      "expect": {
+        "value": 20
+      },
+      "compare": "integer_exact"
+    },
+    {
+      "id": "move_apply_and_undo_restores_fen",
+      "feature": "move_execution",
+      "required": true,
+      "setup": {
+        "type": "new_game"
+      },
+      "operation": {
+        "type": "apply_move_undo_export_fen",
+        "move": "e2e4"
+      },
+      "expect": {
+        "value": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+      },
+      "compare": "fen_exact"
+    },
+    {
+      "id": "kingside_castling_result",
+      "feature": "special_moves",
+      "required": true,
+      "setup": {
+        "type": "fen",
+        "value": "r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1"
+      },
+      "operation": {
+        "type": "apply_move_export_fen",
+        "move": "e1g1"
+      },
+      "expect": {
+        "value": "r3k2r/8/8/8/8/8/8/R4RK1 b kq - 1 1"
+      },
+      "compare": "fen_exact"
+    },
+    {
+      "id": "en_passant_capture_result",
+      "feature": "special_moves",
+      "required": true,
+      "setup": {
+        "type": "fen",
+        "value": "rnbqkbnr/ppp1p1pp/8/3pPp2/8/8/PPPP1PPP/RNBQKBNR w KQkq f6 0 3"
+      },
+      "operation": {
+        "type": "apply_move_export_fen",
+        "move": "e5f6"
+      },
+      "expect": {
+        "value": "rnbqkbnr/ppp1p1pp/5P2/3p4/8/8/PPPP1PPP/RNBQKBNR b KQkq - 0 3"
+      },
+      "compare": "fen_exact"
+    },
+    {
+      "id": "promotion_to_queen_result",
+      "feature": "special_moves",
+      "required": true,
+      "setup": {
+        "type": "fen",
+        "value": "4k3/P7/8/8/8/8/8/4K3 w - - 0 1"
+      },
+      "operation": {
+        "type": "apply_move_export_fen",
+        "move": "a7a8q"
+      },
+      "expect": {
+        "value": "Q3k3/8/8/8/8/8/8/4K3 b - - 0 1"
+      },
+      "compare": "fen_exact"
+    },
+    {
+      "id": "checkmate_after_move",
+      "feature": "game_end",
+      "required": true,
+      "setup": {
+        "type": "fen",
+        "value": "6k1/5ppp/8/8/8/8/5PPP/R5K1 w - - 0 1"
+      },
+      "operation": {
+        "type": "apply_move_status",
+        "move": "a1a8"
+      },
+      "expect": {
+        "value": "checkmate"
+      },
+      "compare": "status_exact"
+    },
+    {
+      "id": "stalemate_after_move",
+      "feature": "game_end",
+      "required": true,
+      "setup": {
+        "type": "fen",
+        "value": "7k/5Q2/8/8/8/8/8/7K w - - 0 1"
+      },
+      "operation": {
+        "type": "apply_move_status",
+        "move": "f7g6"
+      },
+      "expect": {
+        "value": "stalemate"
+      },
+      "compare": "status_exact"
+    },
+    {
+      "id": "ai_deterministic_capture",
+      "feature": "ai",
+      "required": true,
+      "setup": {
+        "type": "fen",
+        "value": "rnbqkbnr/pppp1ppp/8/4p3/3P4/8/PPP1PPPP/RNBQKBNR w KQkq - 0 2"
+      },
+      "operation": {
+        "type": "ai_best_move",
+        "depth": 2
+      },
+      "expect": {
+        "value": "d4e5"
+      },
+      "compare": "move_exact"
+    }
+  ]
+}

--- a/test/test_suite.json
+++ b/test/test_suite.json
@@ -8,6 +8,7 @@
         {
           "id": "basic_movement",
           "name": "Basic Piece Movement",
+          "feature": "move_execution",
           "commands": [
             {"cmd": "new"},
             {"cmd": "move e2e4"},
@@ -22,6 +23,7 @@
         {
           "id": "invalid_move",
           "name": "Invalid Move Detection",
+          "feature": "move_generation",
           "commands": [
             {"cmd": "new"},
             {"cmd": "move e2e5"}
@@ -32,6 +34,7 @@
         {
           "id": "turn_order",
           "name": "Turn Order Enforcement",
+          "feature": "move_generation",
           "commands": [
             {"cmd": "new"},
             {"cmd": "move e7e5"}
@@ -48,6 +51,7 @@
         {
           "id": "castling_kingside",
           "name": "Kingside Castling",
+          "feature": "special_moves",
           "commands": [
             {"cmd": "fen r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1"},
             {"cmd": "move e1g1"},
@@ -59,6 +63,7 @@
         {
           "id": "castling_queenside",
           "name": "Queenside Castling",
+          "feature": "special_moves",
           "commands": [
             {"cmd": "fen r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1"},
             {"cmd": "move e1c1"},
@@ -70,6 +75,7 @@
         {
           "id": "en_passant",
           "name": "En Passant Capture",
+          "feature": "special_moves",
           "commands": [
             {"cmd": "fen rnbqkbnr/ppp1p1pp/8/3pPp2/8/8/PPPP1PPP/RNBQKBNR w KQkq f6 0 3"},
             {"cmd": "move e5f6"},
@@ -81,6 +87,7 @@
         {
           "id": "promotion",
           "name": "Pawn Promotion",
+          "feature": "fen",
           "commands": [
             {"cmd": "fen 8/P7/8/8/8/8/8/8 w - - 0 1"},
             {"cmd": "move a7a8"},
@@ -98,6 +105,7 @@
         {
           "id": "fools_mate",
           "name": "Fool's Mate",
+          "feature": "game_end",
           "commands": [
             {"cmd": "new"},
             {"cmd": "move f2f3"},
@@ -112,6 +120,7 @@
         {
           "id": "back_rank_mate",
           "name": "Back Rank Mate",
+          "feature": "game_end",
           "commands": [
             {"cmd": "fen 6k1/5ppp/8/8/8/8/5PPP/R5K1 w - - 0 1"},
             {"cmd": "move a1a8"},
@@ -123,6 +132,7 @@
         {
           "id": "stalemate",
           "name": "Stalemate Detection",
+          "feature": "game_end",
           "commands": [
             {"cmd": "fen 7k/5Q2/8/8/8/8/8/7K w - - 0 1"},
             {"cmd": "move f7g6"},
@@ -140,6 +150,7 @@
         {
           "id": "ai_basic",
           "name": "AI Basic Move",
+          "feature": "ai",
           "commands": [
             {"cmd": "new"},
             {"cmd": "ai 1"},
@@ -151,6 +162,7 @@
         {
           "id": "ai_capture",
           "name": "AI Obvious Capture",
+          "feature": "ai",
           "commands": [
             {"cmd": "fen rnbqkbnr/pppp1ppp/8/4p3/3P4/8/PPP1PPPP/RNBQKBNR w KQkq - 0 2"},
             {"cmd": "ai 2"}
@@ -161,6 +173,7 @@
         {
           "id": "ai_mate_in_one",
           "name": "AI Finds Mate in One",
+          "feature": "ai",
           "commands": [
             {"cmd": "fen 6k1/5ppp/8/8/8/8/5PPP/R5K1 w - - 0 1"},
             {"cmd": "ai 2"}
@@ -171,6 +184,7 @@
         {
           "id": "ai_deterministic_start",
           "name": "AI Deterministic - Starting Position",
+          "feature": "ai",
           "description": "Tests that AI makes deterministic move choices from starting position",
           "commands": [
             {"cmd": "new"},
@@ -182,6 +196,7 @@
         {
           "id": "ai_promotion_choice",
           "name": "AI Promotion to Queen",
+          "feature": "ai",
           "description": "Tests that AI correctly promotes to queen",
           "commands": [
             {"cmd": "fen 4k3/P7/8/8/8/8/8/4K3 w - - 0 1"},
@@ -193,6 +208,7 @@
         {
           "id": "ai_evaluation_consistency",
           "name": "AI Evaluation Consistency",
+          "feature": "ai",
           "description": "Tests that AI evaluation is consistent and deterministic",
           "commands": [
             {"cmd": "fen rnbqkbnr/pppp1ppp/8/4p3/3P4/8/PPP1PPPP/RNBQKBNR w KQkq - 0 2"},
@@ -212,6 +228,7 @@
         {
           "id": "undo_functionality",
           "name": "Undo Move",
+          "feature": "move_execution",
           "commands": [
             {"cmd": "new"},
             {"cmd": "move e2e4"},
@@ -277,6 +294,7 @@
         {
           "id": "fen_import",
           "name": "FEN Import",
+          "feature": "fen",
           "commands": [
             {"cmd": "fen rnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w KQkq c6 0 2"},
             {"cmd": "export"}
@@ -287,6 +305,7 @@
         {
           "id": "fen_export",
           "name": "FEN Export",
+          "feature": "fen",
           "commands": [
             {"cmd": "new"},
             {"cmd": "export"}

--- a/test/test_unit_contract_harness.py
+++ b/test/test_unit_contract_harness.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Unit tests for the shared unit-contract harness."""
+
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+TEST_DIR = REPO_ROOT / "test"
+if str(TEST_DIR) not in sys.path:
+    sys.path.insert(0, str(TEST_DIR))
+
+from unit_contract_harness import (
+    compare_values,
+    evaluate_report,
+    lint_feature_vocabulary,
+    validate_contract_suite,
+    validate_report_schema,
+)
+
+
+class UnitContractHarnessTests(unittest.TestCase):
+    def test_validate_contract_suite_accepts_minimal_valid_suite(self):
+        suite = {
+            "schema_version": "1.0",
+            "suite": "unit_v1",
+            "required_features": ["move_generation"],
+            "cases": [
+                {
+                    "id": "starting_position_legal_move_count",
+                    "feature": "move_generation",
+                    "required": True,
+                    "setup": {"type": "new_game"},
+                    "operation": {"type": "legal_move_count"},
+                    "expect": {"value": 20},
+                    "compare": "integer_exact",
+                }
+            ],
+        }
+
+        self.assertEqual(validate_contract_suite(suite), [])
+
+    def test_lint_feature_vocabulary_detects_drift(self):
+        contract_suite = {
+            "schema_version": "1.0",
+            "suite": "unit_v1",
+            "required_features": ["fen", "ai"],
+            "cases": [
+                {
+                    "id": "c1",
+                    "feature": "fen",
+                    "required": True,
+                    "setup": {"type": "new_game"},
+                    "operation": {"type": "export_fen"},
+                    "expect": {"value": "x"},
+                    "compare": "string_exact",
+                },
+                {
+                    "id": "c2",
+                    "feature": "ai",
+                    "required": True,
+                    "setup": {"type": "new_game"},
+                    "operation": {"type": "ai_best_move", "depth": 1},
+                    "expect": {"value": "e2e4"},
+                    "compare": "move_exact",
+                },
+            ],
+        }
+        protocol_suite = {
+            "test_categories": {
+                "ai": {
+                    "required": True,
+                    "tests": [
+                        {"id": "ai_basic", "feature": "ai"},
+                    ],
+                }
+            }
+        }
+
+        errors = lint_feature_vocabulary(contract_suite, protocol_suite)
+        self.assertEqual(
+            errors,
+            ["Required unit-contract features missing from protocol suite: fen"],
+        )
+
+    def test_validate_report_schema_rejects_duplicate_case_ids(self):
+        report = {
+            "schema_version": "1.0",
+            "suite": "unit_v1",
+            "implementation": "python",
+            "cases": [
+                {"id": "c1", "status": "passed", "normalized_actual": 20},
+                {"id": "c1", "status": "passed", "normalized_actual": 20},
+            ],
+        }
+
+        errors = validate_report_schema(report, "unit_v1")
+        self.assertIn("Duplicate report case id: c1", errors)
+
+    def test_evaluate_report_requires_all_required_cases(self):
+        suite = {
+            "cases": [
+                {
+                    "id": "c1",
+                    "feature": "move_generation",
+                    "required": True,
+                    "setup": {"type": "new_game"},
+                    "operation": {"type": "legal_move_count"},
+                    "expect": {"value": 20},
+                    "compare": "integer_exact",
+                }
+            ]
+        }
+        report = {
+            "schema_version": "1.0",
+            "suite": "unit_v1",
+            "implementation": "python",
+            "cases": [],
+        }
+
+        evaluation = evaluate_report(suite, report)
+        self.assertIn("Missing report result for contract case 'c1'", evaluation["errors"])
+        self.assertEqual(evaluation["failed"], 1)
+
+    def test_compare_values_normalizes_move_case(self):
+        matches, expected, actual = compare_values("move_exact", "d4e5", "D4E5")
+        self.assertTrue(matches)
+        self.assertEqual(expected, "d4e5")
+        self.assertEqual(actual, "d4e5")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit_contract_harness.py
+++ b/test/unit_contract_harness.py
@@ -1,0 +1,565 @@
+#!/usr/bin/env python3
+"""Run shared unit-contract suites against implementation-provided adapters."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+import tempfile
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+# Ensure repository root is importable.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from chess_metadata import get_metadata
+
+DEFAULT_SUITE = REPO_ROOT / "test" / "contracts" / "unit_v1.json"
+DEFAULT_PROTOCOL_SUITE = REPO_ROOT / "test" / "test_suite.json"
+CONTAINER_REPO_ROOT = Path("/repo")
+
+SUPPORTED_COMPARE_TYPES = {
+    "fen_exact",
+    "integer_exact",
+    "move_exact",
+    "move_set_exact",
+    "status_exact",
+    "string_exact",
+}
+SUPPORTED_SETUP_TYPES = {"new_game", "fen"}
+SUPPORTED_OPERATION_TYPES = {
+    "export_fen",
+    "legal_move_count",
+    "apply_move_export_fen",
+    "apply_move_undo_export_fen",
+    "apply_move_status",
+    "ai_best_move",
+}
+VALID_CASE_STATUSES = {"passed", "failed", "skipped"}
+
+
+def resolve_impl_path(impl: str) -> Path:
+    candidate = Path(impl)
+    if candidate.exists():
+        return candidate.resolve()
+
+    fallback = REPO_ROOT / "implementations" / impl
+    if fallback.exists():
+        return fallback.resolve()
+
+    raise FileNotFoundError(f"Implementation not found: {impl}")
+
+
+def load_json(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def validate_contract_suite(suite: Dict[str, Any]) -> List[str]:
+    errors: List[str] = []
+
+    if suite.get("schema_version") != "1.0":
+        errors.append("Contract suite schema_version must be '1.0'")
+    if not isinstance(suite.get("suite"), str) or not suite["suite"].strip():
+        errors.append("Contract suite must define a non-empty 'suite' name")
+
+    declared_required_features = suite.get("required_features", [])
+    if declared_required_features and not isinstance(declared_required_features, list):
+        errors.append("Contract suite 'required_features' must be a list when present")
+    elif declared_required_features:
+        for feature in declared_required_features:
+            if not isinstance(feature, str) or not feature.strip():
+                errors.append("Contract suite required_features entries must be non-empty strings")
+
+    cases = suite.get("cases")
+    if not isinstance(cases, list) or not cases:
+        errors.append("Contract suite must contain a non-empty 'cases' list")
+        return errors
+
+    seen_ids = set()
+    seen_required_features = set()
+    for index, case in enumerate(cases, start=1):
+        case_label = f"case #{index}"
+        if not isinstance(case, dict):
+            errors.append(f"{case_label} must be an object")
+            continue
+
+        missing_keys = {
+            "id",
+            "feature",
+            "required",
+            "setup",
+            "operation",
+            "expect",
+            "compare",
+        } - set(case.keys())
+        if missing_keys:
+            errors.append(f"{case_label} missing keys: {', '.join(sorted(missing_keys))}")
+            continue
+
+        case_id = case.get("id")
+        if not isinstance(case_id, str) or not case_id.strip():
+            errors.append(f"{case_label} has an invalid 'id'")
+        elif case_id in seen_ids:
+            errors.append(f"Duplicate contract case id: {case_id}")
+        else:
+            seen_ids.add(case_id)
+
+        feature = case.get("feature")
+        if not isinstance(feature, str) or not feature.strip():
+            errors.append(f"{case_label} has an invalid 'feature'")
+        elif case.get("required"):
+            seen_required_features.add(feature)
+
+        if not isinstance(case.get("required"), bool):
+            errors.append(f"{case_label} 'required' must be a boolean")
+
+        setup = case.get("setup")
+        if not isinstance(setup, dict):
+            errors.append(f"{case_label} 'setup' must be an object")
+        else:
+            setup_type = setup.get("type")
+            if setup_type not in SUPPORTED_SETUP_TYPES:
+                errors.append(
+                    f"{case_label} has unsupported setup type '{setup_type}'"
+                )
+            if setup_type == "fen" and not isinstance(setup.get("value"), str):
+                errors.append(f"{case_label} fen setup must include string 'value'")
+
+        operation = case.get("operation")
+        if not isinstance(operation, dict):
+            errors.append(f"{case_label} 'operation' must be an object")
+        else:
+            op_type = operation.get("type")
+            if op_type not in SUPPORTED_OPERATION_TYPES:
+                errors.append(
+                    f"{case_label} has unsupported operation type '{op_type}'"
+                )
+            if op_type in {
+                "apply_move_export_fen",
+                "apply_move_undo_export_fen",
+                "apply_move_status",
+            } and not isinstance(operation.get("move"), str):
+                errors.append(f"{case_label} move operation must include string 'move'")
+            if op_type == "ai_best_move" and not isinstance(operation.get("depth"), int):
+                errors.append(f"{case_label} ai_best_move must include integer 'depth'")
+
+        expect = case.get("expect")
+        if not isinstance(expect, dict) or "value" not in expect:
+            errors.append(f"{case_label} 'expect' must be an object containing 'value'")
+
+        compare = case.get("compare")
+        if compare not in SUPPORTED_COMPARE_TYPES:
+            errors.append(f"{case_label} has unsupported compare mode '{compare}'")
+
+    if isinstance(declared_required_features, list) and declared_required_features:
+        declared_feature_set = set(declared_required_features)
+        if declared_feature_set != seen_required_features:
+            errors.append(
+                "Contract suite required_features must match the feature set of required cases"
+            )
+
+    return errors
+
+
+def extract_protocol_features(protocol_suite: Dict[str, Any]) -> Tuple[set[str], List[str]]:
+    features: set[str] = set()
+    errors: List[str] = []
+
+    categories = protocol_suite.get("test_categories", {})
+    if not isinstance(categories, dict):
+        return features, ["Protocol suite must contain 'test_categories' object"]
+
+    for category_id, category in categories.items():
+        if not isinstance(category, dict) or not category.get("required", False):
+            continue
+        tests = category.get("tests", [])
+        if not isinstance(tests, list):
+            errors.append(f"Protocol category '{category_id}' tests must be a list")
+            continue
+        for test in tests:
+            test_id = test.get("id", "<unknown>")
+            feature = test.get("feature")
+            if not isinstance(feature, str) or not feature.strip():
+                errors.append(
+                    f"Required protocol test '{test_id}' in category '{category_id}' is missing a feature annotation"
+                )
+                continue
+            features.add(feature)
+
+    return features, errors
+
+
+def lint_feature_vocabulary(
+    contract_suite: Dict[str, Any],
+    protocol_suite: Dict[str, Any],
+) -> List[str]:
+    errors: List[str] = []
+
+    declared_required = contract_suite.get("required_features") or []
+    unit_features = (
+        set(declared_required)
+        if declared_required
+        else {
+            case["feature"]
+            for case in contract_suite.get("cases", [])
+            if isinstance(case, dict) and case.get("required")
+        }
+    )
+
+    protocol_features, protocol_errors = extract_protocol_features(protocol_suite)
+    errors.extend(protocol_errors)
+
+    missing_in_protocol = sorted(unit_features - protocol_features)
+    if missing_in_protocol:
+        errors.append(
+            "Required unit-contract features missing from protocol suite: "
+            + ", ".join(missing_in_protocol)
+        )
+
+    missing_in_contract = sorted(protocol_features - unit_features)
+    if missing_in_contract:
+        errors.append(
+            "Required protocol-suite features missing from unit contract suite: "
+            + ", ".join(missing_in_contract)
+        )
+
+    return errors
+
+
+def normalize_value(compare: str, value: Any) -> Any:
+    if compare == "fen_exact":
+        return " ".join(str(value).strip().split())
+    if compare == "integer_exact":
+        return int(value)
+    if compare == "move_exact":
+        return str(value).strip().lower()
+    if compare == "move_set_exact":
+        if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+            raise TypeError("move_set_exact expects a sequence of moves")
+        return sorted(normalize_value("move_exact", item) for item in value)
+    if compare == "status_exact":
+        return str(value).strip().lower()
+    if compare == "string_exact":
+        return str(value).strip()
+    raise ValueError(f"Unsupported compare mode: {compare}")
+
+
+def compare_values(compare: str, expected: Any, actual: Any) -> Tuple[bool, Any, Any]:
+    normalized_expected = normalize_value(compare, expected)
+    normalized_actual = normalize_value(compare, actual)
+    return normalized_expected == normalized_actual, normalized_expected, normalized_actual
+
+
+def validate_report_schema(report: Dict[str, Any], expected_suite: str) -> List[str]:
+    errors: List[str] = []
+
+    if report.get("schema_version") != "1.0":
+        errors.append("Report schema_version must be '1.0'")
+    if report.get("suite") != expected_suite:
+        errors.append(
+            f"Report suite must be '{expected_suite}', got '{report.get('suite')}'"
+        )
+    if not isinstance(report.get("implementation"), str) or not report["implementation"].strip():
+        errors.append("Report must define non-empty 'implementation'")
+    cases = report.get("cases")
+    if not isinstance(cases, list):
+        errors.append("Report 'cases' must be a list")
+        return errors
+
+    seen_ids = set()
+    for index, case in enumerate(cases, start=1):
+        case_label = f"report case #{index}"
+        if not isinstance(case, dict):
+            errors.append(f"{case_label} must be an object")
+            continue
+        case_id = case.get("id")
+        if not isinstance(case_id, str) or not case_id.strip():
+            errors.append(f"{case_label} has invalid 'id'")
+            continue
+        if case_id in seen_ids:
+            errors.append(f"Duplicate report case id: {case_id}")
+        seen_ids.add(case_id)
+        status = case.get("status")
+        if status not in VALID_CASE_STATUSES:
+            errors.append(
+                f"Report case '{case_id}' has invalid status '{status}'"
+            )
+
+    return errors
+
+
+def evaluate_report(
+    contract_suite: Dict[str, Any],
+    report: Dict[str, Any],
+) -> Dict[str, Any]:
+    suite_cases = {case["id"]: case for case in contract_suite["cases"]}
+    report_cases = {case["id"]: case for case in report.get("cases", []) if isinstance(case, dict) and "id" in case}
+
+    errors: List[str] = []
+    passed = 0
+    failed = 0
+    skipped = 0
+
+    for report_case_id in sorted(report_cases):
+        if report_case_id not in suite_cases:
+            errors.append(f"Report contains unknown case id '{report_case_id}'")
+
+    for case_id, suite_case in suite_cases.items():
+        report_case = report_cases.get(case_id)
+        if report_case is None:
+            errors.append(f"Missing report result for contract case '{case_id}'")
+            failed += 1
+            continue
+
+        status = report_case.get("status")
+        compare = suite_case["compare"]
+        expected_value = suite_case["expect"]["value"]
+
+        if status == "passed":
+            if "normalized_actual" not in report_case:
+                errors.append(
+                    f"Passed report case '{case_id}' must include 'normalized_actual'"
+                )
+                failed += 1
+                continue
+            try:
+                matches, normalized_expected, normalized_actual = compare_values(
+                    compare,
+                    expected_value,
+                    report_case["normalized_actual"],
+                )
+            except Exception as exc:
+                errors.append(f"Case '{case_id}' normalization failed: {exc}")
+                failed += 1
+                continue
+            if not matches:
+                errors.append(
+                    f"Case '{case_id}' expected {normalized_expected!r} but got {normalized_actual!r}"
+                )
+                failed += 1
+                continue
+            passed += 1
+        elif status == "skipped":
+            skipped += 1
+            if suite_case["required"]:
+                errors.append(f"Required case '{case_id}' was skipped")
+                failed += 1
+        elif status == "failed":
+            failed += 1
+            message = report_case.get("error") or "adapter reported failure"
+            if suite_case["required"]:
+                errors.append(f"Required case '{case_id}' failed: {message}")
+        else:
+            failed += 1
+            errors.append(f"Case '{case_id}' has invalid status '{status}'")
+
+    return {
+        "errors": errors,
+        "passed": passed,
+        "failed": failed,
+        "skipped": skipped,
+        "total": len(suite_cases),
+    }
+
+
+def docker_image_exists(image: str) -> bool:
+    result = subprocess.run(
+        ["docker", "image", "inspect", image],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def repo_to_container_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        relative = resolved.relative_to(REPO_ROOT)
+    except ValueError as exc:
+        raise ValueError(f"Path must be inside repository root: {resolved}") from exc
+    return str(CONTAINER_REPO_ROOT / relative)
+
+
+def run_contract_command(
+    image: str,
+    command: str,
+    suite_path: Path,
+) -> Tuple[int, str, str, str | None]:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        temp_root = Path(tmp_dir)
+        report_path = temp_root / "unit-report.json"
+        suite_in_container = repo_to_container_path(suite_path)
+        report_in_container = "/work/unit-report.json"
+        shell_command = (
+            f"{command} --suite {shlex.quote(suite_in_container)} "
+            f"--report {shlex.quote(report_in_container)}"
+        )
+        docker_args = [
+            "docker",
+            "run",
+            "--rm",
+            "--network",
+            "none",
+            "-v",
+            f"{REPO_ROOT}:/repo:ro",
+            "-v",
+            f"{temp_root}:/work",
+            image,
+        ]
+
+        for shell in ("sh", "bash"):
+            result = subprocess.run(
+                docker_args + [shell, "-c", f"cd /app && {shell_command}"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode == 0 or "executable file not found in $PATH" not in (result.stderr or "").lower():
+                report_text = None
+                if report_path.exists():
+                    report_text = report_path.read_text(encoding="utf-8")
+                return result.returncode, result.stdout, result.stderr, report_text
+
+        return result.returncode, result.stdout, result.stderr, None
+
+
+def run_for_implementation(
+    impl_path: Path,
+    suite_path: Path,
+    protocol_suite_path: Path,
+    docker_image: str | None,
+    require_contract: bool,
+) -> int:
+    metadata = get_metadata(str(impl_path))
+    suite = load_json(suite_path)
+    protocol_suite = load_json(protocol_suite_path)
+
+    suite_errors = validate_contract_suite(suite)
+    suite_errors.extend(lint_feature_vocabulary(suite, protocol_suite))
+    if suite_errors:
+        print("Contract suite validation failed:")
+        for error in suite_errors:
+            print(f"- {error}")
+        return 1
+
+    contract_command = metadata.get("test_contract", "")
+    impl_name = impl_path.name
+    image = docker_image or f"chess-{impl_name}"
+
+    if not contract_command:
+        message = (
+            f"SKIPPED: {impl_name} does not declare org.chess.test_contract"
+        )
+        print(message)
+        return 1 if require_contract else 0
+
+    if not docker_image_exists(image):
+        print(
+            f"ERROR: Docker image '{image}' not found. Run: make image DIR={impl_name}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Running unit contract suite for {impl_name} using image '{image}'")
+    print(f"Contract command: {contract_command}")
+
+    returncode, stdout, stderr, report_text = run_contract_command(
+        image,
+        contract_command,
+        suite_path,
+    )
+    if stdout.strip():
+        print(stdout.strip())
+    if returncode != 0:
+        print(f"ERROR: Contract adapter exited with status {returncode}")
+        if stderr.strip():
+            print(stderr.strip())
+        return 1
+
+    if report_text is None:
+        print("ERROR: Contract adapter did not write /work/unit-report.json")
+        if stderr.strip():
+            print(stderr.strip())
+        return 1
+
+    try:
+        report = json.loads(report_text)
+    except Exception as exc:
+        print(f"ERROR: Failed to load contract report: {exc}")
+        return 1
+
+    report_errors = validate_report_schema(report, suite["suite"])
+    evaluation = evaluate_report(suite, report)
+    report_errors.extend(evaluation["errors"])
+
+    print(
+        "Summary: "
+        f"{evaluation['passed']}/{evaluation['total']} passed, "
+        f"{evaluation['failed']} failed, "
+        f"{evaluation['skipped']} skipped"
+    )
+
+    if report_errors:
+        for error in report_errors:
+            print(f"- {error}")
+        return 1
+
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run shared unit-contract suite in Docker")
+    parser.add_argument("--impl", required=True, help="Implementation name or path")
+    parser.add_argument(
+        "--suite",
+        default=str(DEFAULT_SUITE),
+        help="Path to contract suite JSON",
+    )
+    parser.add_argument(
+        "--protocol-suite",
+        default=str(DEFAULT_PROTOCOL_SUITE),
+        help="Path to protocol suite JSON used for feature-vocabulary linting",
+    )
+    parser.add_argument(
+        "--docker-image",
+        help="Docker image name (defaults to chess-<impl>)",
+    )
+    parser.add_argument(
+        "--require-contract",
+        action="store_true",
+        help="Fail when org.chess.test_contract is missing",
+    )
+    args = parser.parse_args()
+
+    try:
+        impl_path = resolve_impl_path(args.impl)
+    except FileNotFoundError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    suite_path = Path(args.suite).resolve()
+    protocol_suite_path = Path(args.protocol_suite).resolve()
+
+    return run_for_implementation(
+        impl_path=impl_path,
+        suite_path=suite_path,
+        protocol_suite_path=protocol_suite_path,
+        docker_image=args.docker_image,
+        require_contract=args.require_contract,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/verify_implementations.py
+++ b/test/verify_implementations.py
@@ -46,7 +46,8 @@ REQUIRED_META_FIELDS = {
 
 # Optional but recommended metadata fields
 RECOMMENDED_META_FIELDS = {
-    'estimated_perft4_ms'
+    'estimated_perft4_ms',
+    'test_contract',
 }
 
 # Expected features in metadata
@@ -155,7 +156,11 @@ def check_makefile_targets(makefile_path: Path) -> Tuple[Set[str], Set[str]]:
     missing_targets = REQUIRED_MAKEFILE_TARGETS - found_targets
     return found_targets, missing_targets
 
-def validate_metadata(data: Dict, impl_name: str) -> Dict[str, List[str]]:
+def validate_metadata(
+    data: Dict,
+    impl_name: str,
+    require_test_contract: bool = False,
+) -> Dict[str, List[str]]:
     """Validate combined metadata."""
     result = {
         'errors': [],
@@ -169,7 +174,10 @@ def validate_metadata(data: Dict, impl_name: str) -> Dict[str, List[str]]:
         result['errors'].extend([f"Missing required field: {field}" for field in missing_required])
     
     # Check recommended fields
-    missing_recommended = RECOMMENDED_META_FIELDS - set(data.keys())
+    missing_recommended = set(RECOMMENDED_META_FIELDS - set(data.keys()))
+    if require_test_contract and 'test_contract' in missing_recommended:
+        result['errors'].append("Missing required field: test_contract")
+        missing_recommended.remove('test_contract')
     if missing_recommended:
         result['warnings'].extend([f"Missing recommended field: {field}" for field in missing_recommended])
     
@@ -221,6 +229,8 @@ def validate_metadata(data: Dict, impl_name: str) -> Dict[str, List[str]]:
     # Info
     result['info'].append(f"Language: {data.get('language', 'unknown')}")
     result['info'].append(f"Version: {data.get('version', 'unknown')}")
+    if 'test_contract' in data:
+        result['info'].append("Unit contract adapter declared")
     
     return result
 
@@ -228,7 +238,7 @@ def check_meta_path_standards(data: dict, impl_name: str) -> Dict[str, List[str]
     """Check path standards (Prevention Guideline 1)."""
     result = {'errors': [], 'warnings': []}
     
-    path_fields = ['build', 'run', 'analyze', 'test']
+    path_fields = ['build', 'run', 'analyze', 'test', 'test_contract']
     
     for field in path_fields:
         if field in data:
@@ -588,7 +598,10 @@ def check_python_dependencies(impl_dir: Path) -> Dict[str, List[str]]:
         result['warnings'].append("No requirements file found")
     return result
 
-def verify_implementation(impl_dir: Path) -> Dict:
+def verify_implementation(
+    impl_dir: Path,
+    require_test_contract: bool = False,
+) -> Dict:
     """Verify a single implementation."""
     impl_name = impl_dir.name
     result = {
@@ -644,7 +657,11 @@ def verify_implementation(impl_dir: Path) -> Dict:
         result['summary']['errors'] += len(missing_targets)
     
     if metadata:
-        meta_result = validate_metadata(metadata, impl_name)
+        meta_result = validate_metadata(
+            metadata,
+            impl_name,
+            require_test_contract=require_test_contract,
+        )
         result['chess_meta'] = meta_result
         result['summary']['errors'] += len(meta_result['errors'])
         result['summary']['warnings'] += len(meta_result['warnings'])
@@ -779,6 +796,11 @@ def main():
     parser = argparse.ArgumentParser(description="Verify Chess Engine Implementation")
     parser.add_argument("base_dir", nargs="?", help="Base directory")
     parser.add_argument("--implementation", "-i", help="Verify only one")
+    parser.add_argument(
+        "--require-test-contract",
+        action="store_true",
+        help="Treat missing org.chess.test_contract metadata as an error",
+    )
     args = parser.parse_args()
     
     base_dir = Path(args.base_dir) if args.base_dir else Path(os.getcwd())
@@ -789,7 +811,10 @@ def main():
     
     results = []
     for impl_dir in sorted(implementations):
-        result = verify_implementation(impl_dir)
+        result = verify_implementation(
+            impl_dir,
+            require_test_contract=args.require_test_contract,
+        )
         results.append(result)
         print_implementation_report(result)
     


### PR DESCRIPTION
## Summary
- add a shared unit contract manifest and Docker-backed harness for cross-language unit parity
- wire `make test-unit-contract` and `org.chess.test_contract` verification into shared tooling
- add pilot contract adapters for the Python and TypeScript implementations

Closes #120.

## Validation
- `python3 -m unittest discover -s test -p 'test_unit_contract_harness.py'`
- `python3 -m unittest discover -s test -p 'test_token_metrics.py'`
- `python3 test/verify_implementations.py --implementation python --require-test-contract`
- `python3 test/verify_implementations.py --implementation typescript --require-test-contract`
- `make image DIR=python`
- `make test-unit-contract DIR=python STRICT=1`
- `make image DIR=typescript`
- `make test-unit-contract DIR=typescript STRICT=1`
