### PR TITLE
feat: expose semantic complexity and LOC in README matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,40 +17,40 @@ Core references:
 All implementations target parity for core features: `perft`, `fen`, `ai`, `castling`, `en_passant`, `promotion`.
 
 <!-- status-table-start -->
-
-| Language | TOKENS | make build | make analyze | make test | make test-chess-engine | Features |
-|----------|--------|------------|--------------|-----------|------------------------|----------|
-| 💠 Crystal | [9,441](implementations/crystal/src/chess_engine.cr) | 1.3s, 249 MB | 979ms, 197 MB | 2.5s, 526 MB | 9.8s, 62 MB | 🟡 6/9 |
-| 🎯 Dart | [21,057](implementations/dart/bin/main.dart) | 195ms, 5 MB | 185ms, 5 MB | 190ms, 5 MB | 10.5s, 62 MB | 🟢 6/9 |
-| 🌳 Elm | [7,868](implementations/elm/src/ChessEngine.elm) | 192ms, 7 MB | 187ms, 7 MB | 184ms, 7 MB | 9.8s, 62 MB | 🟡 6/9 |
-| ✨ Gleam | [112,398](implementations/gleam/src/chess_engine.gleam) | 265ms, 6 MB | 335ms, 7 MB | 770ms, 56 MB | 10s, 63 MB | 🟢 6/9 |
-| 🐹 Go | [24,803](implementations/go/chess.go) | 546ms, 87 MB | 1.2s, 112 MB | 1.1s, 128 MB | 10.5s, 62 MB | 🟢 6/9 |
-| 📐 Haskell | [11,812](implementations/haskell/src/Main.hs) | 332ms, 42 MB | 191ms, 7 MB | 234ms, 7 MB | 1m 10s, 62 MB | 🟡 6/9 |
-| 🪶 Imba | [13,544](implementations/imba/chess.imba) | 199ms, 6 MB | 189ms, 7 MB | 194ms, 7 MB | 9.9s, 62 MB | 🟢 6/9 |
-| 🟨 Javascript | [7,472](implementations/javascript/chess.js) | -, - MB | 207ms, 7 MB | 185ms, 7 MB | 1m 10s, 62 MB | 🟡 6/9 |
-| 🔮 Julia | [12,280](implementations/julia/chess.jl) | -, - MB | 182ms, 7 MB | 179ms, 7 MB | 13.6s, 62 MB | 🟡 6/9 |
-| 🧡 Kotlin | [9,666](implementations/kotlin/src/main/kotlin/ChessEngine.kt) | 154ms, 7 MB | 153ms, 7 MB | 151ms, 7 MB | 10s, 62 MB | 🟡 6/9 |
-| 🪐 Lua | [20,806](implementations/lua/chess.lua) | -, - MB | 212ms, 7 MB | 195ms, 7 MB | 10.9s, 63 MB | 🟡 6/9 |
-| 🦊 Nim | [8,410](implementations/nim/chess.nim) | 209ms, 7 MB | 193ms, 7 MB | 199ms, 7 MB | 9.8s, 62 MB | 🟡 6/9 |
-| 🐘 Php | [26,871](implementations/php/chess.php) | -, - MB | 281ms, 9 MB | 168ms, 9 MB | 13.1s, 63 MB | 🟡 6/9 |
-| 🐍 Python | [26,928](implementations/python/chess.py) | -, - MB | 220ms, 6 MB | 190ms, 7 MB | 16.7s, 62 MB | 🟡 6/9 |
-| 🧠 Rescript | [11,181](implementations/rescript/src/Chess.res) | 199ms, 7 MB | 193ms, 7 MB | 196ms, 5 MB | 9.9s, 62 MB | 🟡 6/9 |
-| ❤️ Ruby | [9,600](implementations/ruby/chess.rb) | -, - MB | 2.3s, 230 MB | 299ms, 9 MB | 12.1s, 62 MB | 🟡 6/9 |
-| 🦀 Rust | [12,770](implementations/rust/src/main.rs) | 150ms, 7 MB | 148ms, 7 MB | 144ms, 7 MB | 9.7s, 62 MB | 🟡 6/9 |
-| 🐦 Swift | [7,650](implementations/swift/src/main.swift) | 192ms, 7 MB | 184ms, 7 MB | 188ms, 7 MB | 3m 00s, - MB | 🟡 6/9 |
-| 📘 Typescript | [13,192](implementations/typescript/src/chess.ts) | 193ms, 7 MB | 193ms, 7 MB | 188ms, 6 MB | 9.9s, 62 MB | 🟡 6/9 |
-| ⚡ Zig | [13,277](implementations/zig/src/main.zig) | 215ms, 6 MB | 183ms, 7 MB | 184ms, 7 MB | 58s, 62 MB | 🟡 6/9 |
+| Language | Complexity | LOC | make build | make analyze | make test | make test-chess-engine | Features |
+|----------|------------|-----|------------|--------------|-----------|------------------------|----------|
+| 💠 Crystal | [5,325.75](implementations/crystal/src/chess_engine.cr) | 2,201 | 1.3s, 249 MB | 979ms, 197 MB | 2.5s, 526 MB | 9.8s, 62 MB | 🟢 6/9 |
+| 🎯 Dart | [10,100.25](implementations/dart/bin/main.dart) | 3,308 | 195ms, 5 MB | 185ms, 5 MB | 190ms, 5 MB | 10.5s, 62 MB | 🟡 6/9 |
+| 🌳 Elm | [5,305](implementations/elm/src/ChessEngine.elm) | 1,669 | 192ms, 7 MB | 187ms, 7 MB | 184ms, 7 MB | 9.8s, 62 MB | 🟢 6/9 |
+| ✨ Gleam | [27,937](implementations/gleam/src/chess_engine.gleam) | 14,964 | 265ms, 6 MB | 335ms, 7 MB | 770ms, 56 MB | 10s, 63 MB | 🟢 6/9 |
+| 🐹 Go | [9,967.5](implementations/go/chess.go) | 3,919 | 546ms, 87 MB | 1.2s, 112 MB | 1.1s, 128 MB | 10.5s, 62 MB | 🟢 6/9 |
+| 📐 Haskell | [5,560.5](implementations/haskell/src/Main.hs) | 1,407 | 332ms, 42 MB | 191ms, 7 MB | 234ms, 7 MB | 1m 10s, 62 MB | 🟢 6/9 |
+| 🪶 Imba | [6,002](implementations/imba/chess.imba) | 1,634 | 199ms, 6 MB | 189ms, 7 MB | 194ms, 7 MB | 9.9s, 62 MB | 🟡 6/9 |
+| 🟨 Javascript | [2,661](implementations/javascript/chess.js) | 820 | -, - MB | 207ms, 7 MB | 185ms, 7 MB | 1m 10s, 62 MB | 🔴 6/9 |
+| 🔮 Julia | [5,517.5](implementations/julia/chess.jl) | 1,949 | -, - MB | 182ms, 7 MB | 179ms, 7 MB | 13.6s, 62 MB | 🟡 6/9 |
+| 🧡 Kotlin | [4,868.5](implementations/kotlin/src/main/kotlin/ChessEngine.kt) | 1,525 | 154ms, 7 MB | 153ms, 7 MB | 151ms, 7 MB | 10s, 62 MB | 🟡 6/9 |
+| 🪐 Lua | [10,381.5](implementations/lua/chess.lua) | 2,885 | -, - MB | 212ms, 7 MB | 195ms, 7 MB | 10.9s, 63 MB | 🟢 6/9 |
+| 🦊 Nim | [5,748](implementations/nim/chess.nim) | 1,339 | 209ms, 7 MB | 193ms, 7 MB | 199ms, 7 MB | 9.8s, 62 MB | 🟢 6/9 |
+| 🐘 Php | [9,808.25](implementations/php/chess.php) | 3,445 | -, - MB | 281ms, 9 MB | 168ms, 9 MB | 13.1s, 63 MB | 🟢 6/9 |
+| 🐍 Python | [9,146.5](implementations/python/chess.py) | 3,678 | -, - MB | 220ms, 6 MB | 190ms, 7 MB | 16.7s, 62 MB | 🟡 6/9 |
+| 🧠 Rescript | [4,903.75](implementations/rescript/src/Chess.res) | 1,688 | 199ms, 7 MB | 193ms, 7 MB | 196ms, 5 MB | 9.9s, 62 MB | 🟡 6/9 |
+| ❤️ Ruby | [4,133.25](implementations/ruby/chess.rb) | 1,908 | -, - MB | 2.3s, 230 MB | 299ms, 9 MB | 12.1s, 62 MB | 🟡 6/9 |
+| 🦀 Rust | [6,761](implementations/rust/src/main.rs) | 1,854 | 150ms, 7 MB | 148ms, 7 MB | 144ms, 7 MB | 9.7s, 62 MB | 🟢 6/9 |
+| 🐦 Swift | [3,387](implementations/swift/src/main.swift) | 932 | 192ms, 7 MB | 184ms, 7 MB | 188ms, 7 MB | 3m 00s, - MB | 🟢 6/9 |
+| 📘 Typescript | [6,211](implementations/typescript/src/chess.ts) | 2,038 | 193ms, 7 MB | 193ms, 7 MB | 188ms, 6 MB | 9.9s, 62 MB | 🟡 6/9 |
+| ⚡ Zig | [8,232.75](implementations/zig/src/main.zig) | 1,633 | 215ms, 6 MB | 183ms, 7 MB | 184ms, 7 MB | 58s, 62 MB | 🟢 6/9 |
 <!-- status-table-end -->
 
 Legend:
 - `Features`: `🟢/🟡/🔴` status badge followed by implemented features count from metadata, e.g. `🟡 6/9`.
-- `TOKENS`: `tokens-v2` computed from Git-discovered files (tracked + untracked, excluding ignored) filtered by metadata `org.chess.source_exts`.
+- `Complexity`: weighted `tokens-v3` semantic `complexity_score`, linked to the implementation entrypoint.
+- `LOC`: source lines of code from Git-discovered source files filtered by metadata `org.chess.source_exts`.
 - `make ...` columns: `<duration>, <peak memory>`.
 - `-`: metric missing or intentionally skipped.
 
 ## Semantic Token Metrics (tokens-v3)
 
-In addition to raw `tokens-v2`, the shared Bun tooling exposes `tokens-v3` semantic metrics powered by Shiki. These metrics classify tokens into semantic categories and compute a weighted `complexity_score` that down-weights punctuation and excludes comments from scoring.
+The README matrix uses the weighted `complexity_score` from `tokens-v3`. Raw `tokens-v2` counts and the full semantic breakdown remain available in the versioned report JSON files and through the shared Bun tooling. These metrics are powered by Shiki and classify tokens into semantic categories while down-weighting punctuation and excluding comments from scoring.
 
 ### Running semantic analysis
 
@@ -63,6 +63,9 @@ bun run scripts/semantic-tokens/semantic_tokens.mjs --all implementations/ --pre
 
 # Shared metrics pipeline (tokens-v2 + optional tokens-v3)
 ./workflow code-size-metrics --impl implementations/rust
+
+# Refresh semantic metrics inside versioned reports
+./workflow refresh-report-metrics
 ```
 
 ### Complexity score
@@ -91,6 +94,7 @@ make test DIR=<language>
 make test-unit-contract DIR=<language>
 make test-chess-engine DIR=<language>
 ./workflow semantic-tokens implementations/<language> --pretty
+./workflow refresh-report-metrics
 ```
 
 All implementation build/test/analyze operations are Docker-only.

--- a/reports/bun.json
+++ b/reports/bun.json
@@ -43,7 +43,7 @@
         "memory_mb": 116.9140625,
         "peak_memory_mb": 116.9140625,
         "avg_memory_mb": 98.26328125,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 5,
         "psutil_available": true
       },
@@ -72,7 +72,7 @@
         "memory_mb": 32.08984375,
         "peak_memory_mb": 61.86328125,
         "avg_memory_mb": 61.56069176557863,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 674,
         "psutil_available": true
       }
@@ -86,7 +86,7 @@
       "metric_version": "tokens-v2"
     },
     "normalized": {
-      "build_ms_per_kloc": 0.0,
+      "build_ms_per_kloc": 0,
       "analyze_ms_per_kloc": 298.7830271813545,
       "runtime_ms_per_kloc": 281.838914560452
     },
@@ -135,7 +135,7 @@
       ]
     },
     "errors": [
-      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting bun implementation at implementations/bun\n----------------------------------------\nRunning test: Hash Command Baseline \u2713\nRunning test: Hash Command After Move \u2713\nRunning test: Draws Command \u2717\nRunning test: Go Movetime \u2717\nRunning test: PGN Show \u2717\nRunning test: PGN Fixture Morphy \u2717\nRunning test: PGN Fixture Byrne-Fischer \u2717\nRunning test: Book Load Stats \u2717\nRunning test: Book AI Move \u2717\nRunning test: UCI Handshake \u2717\nRunning"
+      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting bun implementation at implementations/bun\n----------------------------------------\nRunning test: Hash Command Baseline ✓\nRunning test: Hash Command After Move ✓\nRunning test: Draws Command ✗\nRunning test: Go Movetime ✗\nRunning test: PGN Show ✗\nRunning test: PGN Fixture Morphy ✗\nRunning test: PGN Fixture Byrne-Fischer ✗\nRunning test: Book Load Stats ✗\nRunning test: Book AI Move ✗\nRunning test: UCI Handshake ✗\nRunning"
     ],
     "status": "completed"
   }

--- a/reports/crystal.json
+++ b/reports/crystal.json
@@ -42,7 +42,7 @@
         "memory_mb": 116.39453125,
         "peak_memory_mb": 116.39453125,
         "avg_memory_mb": 96.71171875,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 5,
         "psutil_available": true
       },
@@ -71,17 +71,17 @@
         "memory_mb": 32.12890625,
         "peak_memory_mb": 62.0234375,
         "avg_memory_mb": 60.03675986842105,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 95,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 1692,
-      "source_files": 7
+      "source_loc": 2201,
+      "source_files": 10
     },
     "metrics": {
-      "tokens_count": 9441,
+      "tokens_count": 12598,
       "metric_version": "tokens-v2"
     },
     "normalized": {
@@ -134,8 +134,31 @@
       ]
     },
     "errors": [
-      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting crystal implementation at implementations/crystal\n----------------------------------------\nRunning test: Hash Command Baseline \u2713\nRunning test: Hash Command After Move \u2713\nRunning test: Draws Command \u2717\nRunning test: Go Movetime \u2717\nRunning test: PGN Show \u2713\nRunning test: PGN Fixture Morphy \u2717\nRunning test: PGN Fixture Byrne-Fischer \u2717\nRunning test: Book Load Stats \u2717\nRunning test: Book AI Move \u2717\nRunning test: UCI Handshake \u2717"
+      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting crystal implementation at implementations/crystal\n----------------------------------------\nRunning test: Hash Command Baseline ✓\nRunning test: Hash Command After Move ✓\nRunning test: Draws Command ✗\nRunning test: Go Movetime ✗\nRunning test: PGN Show ✓\nRunning test: PGN Fixture Morphy ✗\nRunning test: PGN Fixture Byrne-Fischer ✗\nRunning test: Book Load Stats ✗\nRunning test: Book AI Move ✗\nRunning test: UCI Handshake ✗"
     ],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 5325.75,
+      "total_tokens": 7946,
+      "semantic_tokens": 7880,
+      "by_category": {
+        "keyword": 969,
+        "identifier": 2560,
+        "type": 19,
+        "operator": 1020,
+        "literal": 1759,
+        "punctuation": 1553,
+        "comment": 66,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.123,
+        "comment_ratio": 0.008,
+        "punctuation_ratio": 0.197,
+        "complexity_per_loc": 2.42,
+        "complexity_per_file": 532.58
+      }
+    }
   }
 ]

--- a/reports/dart.json
+++ b/reports/dart.json
@@ -42,7 +42,7 @@
         "memory_mb": 111.22265625,
         "peak_memory_mb": 111.22265625,
         "avg_memory_mb": 94.6640625,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 5,
         "psutil_available": true
       },
@@ -71,13 +71,13 @@
         "memory_mb": 32.45703125,
         "peak_memory_mb": 62.21875,
         "avg_memory_mb": 60.3673422029703,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 101,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 3295,
+      "source_loc": 3308,
       "source_files": 13
     },
     "metrics": {
@@ -137,6 +137,29 @@
       "failed": []
     },
     "errors": [],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 10100.25,
+      "total_tokens": 13220,
+      "semantic_tokens": 13192,
+      "by_category": {
+        "keyword": 1193,
+        "identifier": 6306,
+        "type": 81,
+        "operator": 2067,
+        "literal": 2402,
+        "punctuation": 1143,
+        "comment": 28,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.09,
+        "comment_ratio": 0.002,
+        "punctuation_ratio": 0.087,
+        "complexity_per_loc": 3.05,
+        "complexity_per_file": 776.94
+      }
+    }
   }
 ]

--- a/reports/elm.json
+++ b/reports/elm.json
@@ -42,7 +42,7 @@
         "memory_mb": 116.0546875,
         "peak_memory_mb": 116.0546875,
         "avg_memory_mb": 85.30338541666667,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 3,
         "psutil_available": true
       },
@@ -71,13 +71,13 @@
         "memory_mb": 32.16796875,
         "peak_memory_mb": 62.2109375,
         "avg_memory_mb": 60.210438829787236,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 94,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 1663,
+      "source_loc": 1669,
       "source_files": 7
     },
     "metrics": {
@@ -134,8 +134,31 @@
       ]
     },
     "errors": [
-      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting elm implementation at implementations/elm\n----------------------------------------\nRunning test: Hash Command Baseline \u2717\nRunning test: Hash Command After Move \u2717\nRunning test: Draws Command \u2717\nRunning test: Go Movetime \u2717\nRunning test: PGN Show \u2713\nRunning test: PGN Fixture Morphy \u2717\nRunning test: PGN Fixture Byrne-Fischer \u2717\nRunning test: Book Load Stats \u2717\nRunning test: Book AI Move \u2717\nRunning test: UCI Handshake \u2717\nRunning"
+      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting elm implementation at implementations/elm\n----------------------------------------\nRunning test: Hash Command Baseline ✗\nRunning test: Hash Command After Move ✗\nRunning test: Draws Command ✗\nRunning test: Go Movetime ✗\nRunning test: PGN Show ✓\nRunning test: PGN Fixture Morphy ✗\nRunning test: PGN Fixture Byrne-Fischer ✗\nRunning test: Book Load Stats ✗\nRunning test: Book AI Move ✗\nRunning test: UCI Handshake ✗\nRunning"
     ],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 5305,
+      "total_tokens": 6310,
+      "semantic_tokens": 6286,
+      "by_category": {
+        "keyword": 1553,
+        "identifier": 2943,
+        "type": 0,
+        "operator": 1007,
+        "literal": 439,
+        "punctuation": 344,
+        "comment": 24,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.247,
+        "comment_ratio": 0.004,
+        "punctuation_ratio": 0.055,
+        "complexity_per_loc": 3.18,
+        "complexity_per_file": 757.86
+      }
+    }
   }
 ]

--- a/reports/gleam.json
+++ b/reports/gleam.json
@@ -42,7 +42,7 @@
         "memory_mb": 116.65234375,
         "peak_memory_mb": 116.65234375,
         "avg_memory_mb": 100.85221354166667,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 6,
         "psutil_available": true
       },
@@ -71,17 +71,17 @@
         "memory_mb": 33.03125,
         "peak_memory_mb": 62.98046875,
         "avg_memory_mb": 60.87455702319588,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 97,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 14933,
+      "source_loc": 14964,
       "source_files": 31
     },
     "metrics": {
-      "tokens_count": 112398,
+      "tokens_count": 112410,
       "metric_version": "tokens-v2"
     },
     "normalized": {
@@ -137,6 +137,29 @@
       "failed": []
     },
     "errors": [],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 27937,
+      "total_tokens": 37725,
+      "semantic_tokens": 30634,
+      "by_category": {
+        "keyword": 2755,
+        "identifier": 17922,
+        "type": 4563,
+        "operator": 3824,
+        "literal": 1570,
+        "punctuation": 0,
+        "comment": 7091,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.09,
+        "comment_ratio": 0.188,
+        "punctuation_ratio": 0,
+        "complexity_per_loc": 1.87,
+        "complexity_per_file": 901.19
+      }
+    }
   }
 ]

--- a/reports/go.json
+++ b/reports/go.json
@@ -42,7 +42,7 @@
         "memory_mb": 116.265625,
         "peak_memory_mb": 116.265625,
         "avg_memory_mb": 101.0078125,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 6,
         "psutil_available": true
       },
@@ -71,13 +71,13 @@
         "memory_mb": 32.5234375,
         "peak_memory_mb": 62.3671875,
         "avg_memory_mb": 60.51392326732673,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 101,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 3913,
+      "source_loc": 3919,
       "source_files": 7
     },
     "metrics": {
@@ -137,6 +137,29 @@
       "failed": []
     },
     "errors": [],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 9967.5,
+      "total_tokens": 14666,
+      "semantic_tokens": 14552,
+      "by_category": {
+        "keyword": 1445,
+        "identifier": 5126,
+        "type": 396,
+        "operator": 1955,
+        "literal": 2462,
+        "punctuation": 3168,
+        "comment": 114,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.099,
+        "comment_ratio": 0.008,
+        "punctuation_ratio": 0.218,
+        "complexity_per_loc": 2.54,
+        "complexity_per_file": 1423.93
+      }
+    }
   }
 ]

--- a/reports/haskell.json
+++ b/reports/haskell.json
@@ -42,7 +42,7 @@
         "memory_mb": 114.45703125,
         "peak_memory_mb": 114.45703125,
         "avg_memory_mb": 99.60611979166667,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 6,
         "psutil_available": true
       },
@@ -71,13 +71,13 @@
         "memory_mb": 32.1015625,
         "peak_memory_mb": 61.95703125,
         "avg_memory_mb": 61.64646399962742,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 671,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 1398,
+      "source_loc": 1407,
       "source_files": 14
     },
     "metrics": {
@@ -134,8 +134,31 @@
       ]
     },
     "errors": [
-      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting haskell implementation at implementations/haskell\n----------------------------------------\nRunning test: Hash Command Baseline \u2717\nRunning test: Hash Command After Move \u2717\nRunning test: Draws Command \u2717\nRunning test: Go Movetime \u2717\nRunning test: PGN Show \u2717\nRunning test: PGN Fixture Morphy \u2717\nRunning test: PGN Fixture Byrne-Fischer \u2717\nRunning test: Book Load Stats \u2717\nRunning test: Book AI Move \u2717\nRunning test: UCI Handshake \u2717"
+      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting haskell implementation at implementations/haskell\n----------------------------------------\nRunning test: Hash Command Baseline ✗\nRunning test: Hash Command After Move ✗\nRunning test: Draws Command ✗\nRunning test: Go Movetime ✗\nRunning test: PGN Show ✗\nRunning test: PGN Fixture Morphy ✗\nRunning test: PGN Fixture Byrne-Fischer ✗\nRunning test: Book Load Stats ✗\nRunning test: Book AI Move ✗\nRunning test: UCI Handshake ✗"
     ],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 5560.5,
+      "total_tokens": 7895,
+      "semantic_tokens": 7846,
+      "by_category": {
+        "keyword": 973,
+        "identifier": 2786,
+        "type": 0,
+        "operator": 1954,
+        "literal": 1165,
+        "punctuation": 968,
+        "comment": 49,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.124,
+        "comment_ratio": 0.006,
+        "punctuation_ratio": 0.123,
+        "complexity_per_loc": 3.95,
+        "complexity_per_file": 397.18
+      }
+    }
   }
 ]

--- a/reports/imba.json
+++ b/reports/imba.json
@@ -42,7 +42,7 @@
         "memory_mb": 111.46484375,
         "peak_memory_mb": 111.46484375,
         "avg_memory_mb": 84.45442708333333,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 3,
         "psutil_available": true
       },
@@ -71,17 +71,17 @@
         "memory_mb": 32.4765625,
         "peak_memory_mb": 62.3671875,
         "avg_memory_mb": 60.385032894736845,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 95,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 1589,
+      "source_loc": 1634,
       "source_files": 1
     },
     "metrics": {
-      "tokens_count": 13544,
+      "tokens_count": 13741,
       "metric_version": "tokens-v2"
     },
     "normalized": {
@@ -137,6 +137,29 @@
       "failed": []
     },
     "errors": [],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 6002,
+      "total_tokens": 8715,
+      "semantic_tokens": 8715,
+      "by_category": {
+        "keyword": 679,
+        "identifier": 2498,
+        "type": 849,
+        "operator": 1532,
+        "literal": 1683,
+        "punctuation": 1474,
+        "comment": 0,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.078,
+        "comment_ratio": 0,
+        "punctuation_ratio": 0.169,
+        "complexity_per_loc": 3.67,
+        "complexity_per_file": 6002
+      }
+    }
   }
 ]

--- a/reports/javascript.json
+++ b/reports/javascript.json
@@ -43,7 +43,7 @@
         "memory_mb": 115.84375,
         "peak_memory_mb": 115.84375,
         "avg_memory_mb": 102.51227678571429,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 7,
         "psutil_available": true
       },
@@ -72,13 +72,13 @@
         "memory_mb": 32.06640625,
         "peak_memory_mb": 61.8671875,
         "avg_memory_mb": 61.553426106770836,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 672,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 816,
+      "source_loc": 820,
       "source_files": 4
     },
     "metrics": {
@@ -86,7 +86,7 @@
       "metric_version": "tokens-v2"
     },
     "normalized": {
-      "build_ms_per_kloc": 0.0,
+      "build_ms_per_kloc": 0,
       "analyze_ms_per_kloc": 253.5850394005869,
       "runtime_ms_per_kloc": 226.43833768134024
     },
@@ -135,8 +135,31 @@
       ]
     },
     "errors": [
-      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting javascript implementation at implementations/javascript\n----------------------------------------\nRunning test: Hash Command Baseline \u2713\nRunning test: Hash Command After Move \u2713\nRunning test: Draws Command \u2717\nRunning test: Go Movetime \u2717\nRunning test: PGN Show \u2717\nRunning test: PGN Fixture Morphy \u2717\nRunning test: PGN Fixture Byrne-Fischer \u2717\nRunning test: Book Load Stats \u2717\nRunning test: Book AI Move \u2717\nRunning test: UCI Hands"
+      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting javascript implementation at implementations/javascript\n----------------------------------------\nRunning test: Hash Command Baseline ✓\nRunning test: Hash Command After Move ✓\nRunning test: Draws Command ✗\nRunning test: Go Movetime ✗\nRunning test: PGN Show ✗\nRunning test: PGN Fixture Morphy ✗\nRunning test: PGN Fixture Byrne-Fischer ✗\nRunning test: Book Load Stats ✗\nRunning test: Book AI Move ✗\nRunning test: UCI Hands"
     ],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 2661,
+      "total_tokens": 4468,
+      "semantic_tokens": 4149,
+      "by_category": {
+        "keyword": 393,
+        "identifier": 1256,
+        "type": 1,
+        "operator": 731,
+        "literal": 814,
+        "punctuation": 954,
+        "comment": 319,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.095,
+        "comment_ratio": 0.071,
+        "punctuation_ratio": 0.23,
+        "complexity_per_loc": 3.25,
+        "complexity_per_file": 665.25
+      }
+    }
   }
 ]

--- a/reports/julia.json
+++ b/reports/julia.json
@@ -43,7 +43,7 @@
         "memory_mb": 110.9140625,
         "peak_memory_mb": 110.9140625,
         "avg_memory_mb": 83.99609375,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 3,
         "psutil_available": true
       },
@@ -72,13 +72,13 @@
         "memory_mb": 61.93359375,
         "peak_memory_mb": 61.93359375,
         "avg_memory_mb": 61.62977099236641,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 131,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 1941,
+      "source_loc": 1949,
       "source_files": 9
     },
     "metrics": {
@@ -86,7 +86,7 @@
       "metric_version": "tokens-v2"
     },
     "normalized": {
-      "build_ms_per_kloc": 0.0,
+      "build_ms_per_kloc": 0,
       "analyze_ms_per_kloc": 93.88520753242378,
       "runtime_ms_per_kloc": 92.06138524365511
     },
@@ -138,6 +138,29 @@
       "failed": []
     },
     "errors": [],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 5517.5,
+      "total_tokens": 8570,
+      "semantic_tokens": 8488,
+      "by_category": {
+        "keyword": 802,
+        "identifier": 2391,
+        "type": 147,
+        "operator": 1958,
+        "literal": 1604,
+        "punctuation": 1586,
+        "comment": 82,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.094,
+        "comment_ratio": 0.01,
+        "punctuation_ratio": 0.187,
+        "complexity_per_loc": 2.83,
+        "complexity_per_file": 613.06
+      }
+    }
   }
 ]

--- a/reports/kotlin.json
+++ b/reports/kotlin.json
@@ -42,7 +42,7 @@
         "memory_mb": 111.6328125,
         "peak_memory_mb": 111.6328125,
         "avg_memory_mb": 90.1943359375,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 4,
         "psutil_available": true
       },
@@ -71,13 +71,13 @@
         "memory_mb": 32.2265625,
         "peak_memory_mb": 62.00390625,
         "avg_memory_mb": 60.06946681701031,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 97,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 1524,
+      "source_loc": 1525,
       "source_files": 8
     },
     "metrics": {
@@ -134,8 +134,31 @@
       ]
     },
     "errors": [
-      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting kotlin implementation at implementations/kotlin\n----------------------------------------\nRunning test: Hash Command Baseline \u2713\nRunning test: Hash Command After Move \u2713\nRunning test: Draws Command \u2717\nRunning test: Go Movetime \u2717\nRunning test: PGN Show \u2717\nRunning test: PGN Fixture Morphy \u2717\nRunning test: PGN Fixture Byrne-Fischer \u2717\nRunning test: Book Load Stats \u2717\nRunning test: Book AI Move \u2717\nRunning test: UCI Handshake \u2717\nR"
+      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting kotlin implementation at implementations/kotlin\n----------------------------------------\nRunning test: Hash Command Baseline ✓\nRunning test: Hash Command After Move ✓\nRunning test: Draws Command ✗\nRunning test: Go Movetime ✗\nRunning test: PGN Show ✗\nRunning test: PGN Fixture Morphy ✗\nRunning test: PGN Fixture Byrne-Fischer ✗\nRunning test: Book Load Stats ✗\nRunning test: Book AI Move ✗\nRunning test: UCI Handshake ✗\nR"
     ],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 4868.5,
+      "total_tokens": 5647,
+      "semantic_tokens": 5586,
+      "by_category": {
+        "keyword": 876,
+        "identifier": 3024,
+        "type": 251,
+        "operator": 764,
+        "literal": 671,
+        "punctuation": 0,
+        "comment": 61,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.157,
+        "comment_ratio": 0.011,
+        "punctuation_ratio": 0,
+        "complexity_per_loc": 3.19,
+        "complexity_per_file": 608.56
+      }
+    }
   }
 ]

--- a/reports/lua.json
+++ b/reports/lua.json
@@ -43,7 +43,7 @@
         "memory_mb": 111.15234375,
         "peak_memory_mb": 111.15234375,
         "avg_memory_mb": 84.37760416666667,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 3,
         "psutil_available": true
       },
@@ -72,13 +72,13 @@
         "memory_mb": 32.74609375,
         "peak_memory_mb": 62.6484375,
         "avg_memory_mb": 60.862909226190474,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 105,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 2884,
+      "source_loc": 2885,
       "source_files": 1
     },
     "metrics": {
@@ -86,7 +86,7 @@
       "metric_version": "tokens-v2"
     },
     "normalized": {
-      "build_ms_per_kloc": 0.0,
+      "build_ms_per_kloc": 0,
       "analyze_ms_per_kloc": 73.52749616858368,
       "runtime_ms_per_kloc": 67.56099682409787
     },
@@ -138,6 +138,29 @@
       "failed": []
     },
     "errors": [],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 10381.5,
+      "total_tokens": 12945,
+      "semantic_tokens": 12852,
+      "by_category": {
+        "keyword": 2325,
+        "identifier": 5575,
+        "type": 51,
+        "operator": 2459,
+        "literal": 2362,
+        "punctuation": 80,
+        "comment": 93,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.181,
+        "comment_ratio": 0.007,
+        "punctuation_ratio": 0.006,
+        "complexity_per_loc": 3.6,
+        "complexity_per_file": 10381.5
+      }
+    }
   }
 ]

--- a/reports/mojo.json
+++ b/reports/mojo.json
@@ -40,7 +40,7 @@
         "memory_mb": 17.45703125,
         "peak_memory_mb": 116.04296875,
         "avg_memory_mb": 90.57769097222223,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 9,
         "psutil_available": true
       },
@@ -67,9 +67,9 @@
       },
       "test_chess_engine": {
         "memory_mb": 31.91796875,
-        "peak_memory_mb": 62.0,
+        "peak_memory_mb": 62,
         "avg_memory_mb": 60.532430959302324,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 129,
         "psutil_available": true
       }
@@ -138,7 +138,7 @@
       "make build failed: ",
       "make analyze failed: ",
       "make test failed: ",
-      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting mojo implementation at implementations/mojo\n----------------------------------------\nRunning test: Hash Command Baseline \u2717\nRunning test: Hash Command After Move \u2717\nRunning test: Draws Command \u2717\nRunning test: Go Movetime \u2717\nRunning test: PGN Show \u2717\nRunning test: PGN Fixture Morphy \u2717\nRunning test: PGN Fixture Byrne-Fischer \u2717\nRunning test: Book Load Stats \u2717\nRunning test: Book AI Move \u2717\nRunning test: UCI Handshake \u2717\nRunni"
+      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting mojo implementation at implementations/mojo\n----------------------------------------\nRunning test: Hash Command Baseline ✗\nRunning test: Hash Command After Move ✗\nRunning test: Draws Command ✗\nRunning test: Go Movetime ✗\nRunning test: PGN Show ✗\nRunning test: PGN Fixture Morphy ✗\nRunning test: PGN Fixture Byrne-Fischer ✗\nRunning test: Book Load Stats ✗\nRunning test: Book AI Move ✗\nRunning test: UCI Handshake ✗\nRunni"
     ],
     "status": "completed"
   }

--- a/reports/nim.json
+++ b/reports/nim.json
@@ -42,7 +42,7 @@
         "memory_mb": 111.53515625,
         "peak_memory_mb": 111.53515625,
         "avg_memory_mb": 90.8740234375,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 4,
         "psutil_available": true
       },
@@ -71,17 +71,17 @@
         "memory_mb": 32.3515625,
         "peak_memory_mb": 62.12109375,
         "avg_memory_mb": 60.121426196808514,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 94,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 1105,
+      "source_loc": 1339,
       "source_files": 1
     },
     "metrics": {
-      "tokens_count": 8410,
+      "tokens_count": 10036,
       "metric_version": "tokens-v2"
     },
     "normalized": {
@@ -134,8 +134,31 @@
       ]
     },
     "errors": [
-      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting nim implementation at implementations/nim\n----------------------------------------\nRunning test: Hash Command Baseline \u2713\nRunning test: Hash Command After Move \u2713\nRunning test: Draws Command \u2717\nRunning test: Go Movetime \u2717\nRunning test: PGN Show \u2717\nRunning test: PGN Fixture Morphy \u2717\nRunning test: PGN Fixture Byrne-Fischer \u2717\nRunning test: Book Load Stats \u2717\nRunning test: Book AI Move \u2717\nRunning test: UCI Handshake \u2717\nRunning"
+      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting nim implementation at implementations/nim\n----------------------------------------\nRunning test: Hash Command Baseline ✓\nRunning test: Hash Command After Move ✓\nRunning test: Draws Command ✗\nRunning test: Go Movetime ✗\nRunning test: PGN Show ✗\nRunning test: PGN Fixture Morphy ✗\nRunning test: PGN Fixture Byrne-Fischer ✗\nRunning test: Book Load Stats ✗\nRunning test: Book AI Move ✗\nRunning test: UCI Handshake ✗\nRunning"
     ],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 5748,
+      "total_tokens": 7345,
+      "semantic_tokens": 7252,
+      "by_category": {
+        "keyword": 1064,
+        "identifier": 2932,
+        "type": 248,
+        "operator": 1939,
+        "literal": 1069,
+        "punctuation": 0,
+        "comment": 93,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.147,
+        "comment_ratio": 0.013,
+        "punctuation_ratio": 0,
+        "complexity_per_loc": 4.29,
+        "complexity_per_file": 5748
+      }
+    }
   }
 ]

--- a/reports/performance_data.json
+++ b/reports/performance_data.json
@@ -50,7 +50,7 @@
         "memory_mb": 17.45703125,
         "peak_memory_mb": 116.04296875,
         "avg_memory_mb": 90.57769097222223,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 9,
         "psutil_available": true
       },
@@ -77,9 +77,9 @@
       },
       "test_chess_engine": {
         "memory_mb": 31.91796875,
-        "peak_memory_mb": 62.0,
+        "peak_memory_mb": 62,
         "avg_memory_mb": 60.532430959302324,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 129,
         "psutil_available": true
       }
@@ -148,7 +148,7 @@
       "make build failed: ",
       "make analyze failed: ",
       "make test failed: ",
-      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting mojo implementation at implementations/mojo\n----------------------------------------\nRunning test: Hash Command Baseline \u2717\nRunning test: Hash Command After Move \u2717\nRunning test: Draws Command \u2717\nRunning test: Go Movetime \u2717\nRunning test: PGN Show \u2717\nRunning test: PGN Fixture Morphy \u2717\nRunning test: PGN Fixture Byrne-Fischer \u2717\nRunning test: Book Load Stats \u2717\nRunning test: Book AI Move \u2717\nRunning test: UCI Handshake \u2717\nRunni"
+      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting mojo implementation at implementations/mojo\n----------------------------------------\nRunning test: Hash Command Baseline ✗\nRunning test: Hash Command After Move ✗\nRunning test: Draws Command ✗\nRunning test: Go Movetime ✗\nRunning test: PGN Show ✗\nRunning test: PGN Fixture Morphy ✗\nRunning test: PGN Fixture Byrne-Fischer ✗\nRunning test: Book Load Stats ✗\nRunning test: Book AI Move ✗\nRunning test: UCI Handshake ✗\nRunni"
     ],
     "status": "completed"
   },
@@ -160,7 +160,38 @@
     "issues": [
       "Missing CONCURRENCY: payload"
     ],
-    "payload": null
+    "payload": null,
+    "size": {
+      "source_loc": 1908,
+      "source_files": 10
+    },
+    "metrics": {
+      "tokens_count": 9603,
+      "metric_version": "tokens-v2"
+    },
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 4133.25,
+      "total_tokens": 5810,
+      "semantic_tokens": 5713,
+      "by_category": {
+        "keyword": 821,
+        "identifier": 2142,
+        "type": 23,
+        "operator": 816,
+        "literal": 1046,
+        "punctuation": 865,
+        "comment": 97,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.144,
+        "comment_ratio": 0.017,
+        "punctuation_ratio": 0.151,
+        "complexity_per_loc": 2.17,
+        "complexity_per_file": 413.33
+      }
+    }
   },
   {
     "implementation": "swift",
@@ -170,7 +201,38 @@
     "issues": [
       "Missing CONCURRENCY: payload"
     ],
-    "payload": null
+    "payload": null,
+    "size": {
+      "source_loc": 932,
+      "source_files": 3
+    },
+    "metrics": {
+      "tokens_count": 7650,
+      "metric_version": "tokens-v2"
+    },
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 3387,
+      "total_tokens": 4654,
+      "semantic_tokens": 4614,
+      "by_category": {
+        "keyword": 486,
+        "identifier": 1926,
+        "type": 120,
+        "operator": 747,
+        "literal": 591,
+        "punctuation": 744,
+        "comment": 40,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.105,
+        "comment_ratio": 0.009,
+        "punctuation_ratio": 0.161,
+        "complexity_per_loc": 3.63,
+        "complexity_per_file": 1129
+      }
+    }
   },
   {
     "language": "haskell",
@@ -215,7 +277,7 @@
         "memory_mb": 114.45703125,
         "peak_memory_mb": 114.45703125,
         "avg_memory_mb": 99.60611979166667,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 6,
         "psutil_available": true
       },
@@ -244,13 +306,13 @@
         "memory_mb": 32.1015625,
         "peak_memory_mb": 61.95703125,
         "avg_memory_mb": 61.64646399962742,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 671,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 1398,
+      "source_loc": 1407,
       "source_files": 14
     },
     "metrics": {
@@ -307,9 +369,32 @@
       ]
     },
     "errors": [
-      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting haskell implementation at implementations/haskell\n----------------------------------------\nRunning test: Hash Command Baseline \u2717\nRunning test: Hash Command After Move \u2717\nRunning test: Draws Command \u2717\nRunning test: Go Movetime \u2717\nRunning test: PGN Show \u2717\nRunning test: PGN Fixture Morphy \u2717\nRunning test: PGN Fixture Byrne-Fischer \u2717\nRunning test: Book Load Stats \u2717\nRunning test: Book AI Move \u2717\nRunning test: UCI Handshake \u2717"
+      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting haskell implementation at implementations/haskell\n----------------------------------------\nRunning test: Hash Command Baseline ✗\nRunning test: Hash Command After Move ✗\nRunning test: Draws Command ✗\nRunning test: Go Movetime ✗\nRunning test: PGN Show ✗\nRunning test: PGN Fixture Morphy ✗\nRunning test: PGN Fixture Byrne-Fischer ✗\nRunning test: Book Load Stats ✗\nRunning test: Book AI Move ✗\nRunning test: UCI Handshake ✗"
     ],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 5560.5,
+      "total_tokens": 7895,
+      "semantic_tokens": 7846,
+      "by_category": {
+        "keyword": 973,
+        "identifier": 2786,
+        "type": 0,
+        "operator": 1954,
+        "literal": 1165,
+        "punctuation": 968,
+        "comment": 49,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.124,
+        "comment_ratio": 0.006,
+        "punctuation_ratio": 0.123,
+        "complexity_per_loc": 3.95,
+        "complexity_per_file": 397.18
+      }
+    }
   },
   {
     "language": "swift",
@@ -354,7 +439,7 @@
         "memory_mb": 115.7578125,
         "peak_memory_mb": 115.7578125,
         "avg_memory_mb": 100.23763020833333,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 6,
         "psutil_available": true
       },
@@ -381,7 +466,7 @@
       }
     },
     "size": {
-      "source_loc": 929,
+      "source_loc": 932,
       "source_files": 3
     },
     "metrics": {
@@ -440,7 +525,30 @@
     "errors": [
       "track v2-full suite timeout after 180.1s"
     ],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 3387,
+      "total_tokens": 4654,
+      "semantic_tokens": 4614,
+      "by_category": {
+        "keyword": 486,
+        "identifier": 1926,
+        "type": 120,
+        "operator": 747,
+        "literal": 591,
+        "punctuation": 744,
+        "comment": 40,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.105,
+        "comment_ratio": 0.009,
+        "punctuation_ratio": 0.161,
+        "complexity_per_loc": 3.63,
+        "complexity_per_file": 1129
+      }
+    }
   },
   {
     "implementation": "lua",
@@ -471,6 +579,37 @@
       "timeouts": 0,
       "elapsed_ms": 76,
       "ops_total": 2400
+    },
+    "size": {
+      "source_loc": 2885,
+      "source_files": 1
+    },
+    "metrics": {
+      "tokens_count": 20806,
+      "metric_version": "tokens-v2"
+    },
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 10381.5,
+      "total_tokens": 12945,
+      "semantic_tokens": 12852,
+      "by_category": {
+        "keyword": 2325,
+        "identifier": 5575,
+        "type": 51,
+        "operator": 2459,
+        "literal": 2362,
+        "punctuation": 80,
+        "comment": 93,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.181,
+        "comment_ratio": 0.007,
+        "punctuation_ratio": 0.006,
+        "complexity_per_loc": 3.6,
+        "complexity_per_file": 10381.5
+      }
     }
   },
   {
@@ -516,7 +655,7 @@
         "memory_mb": 116.65234375,
         "peak_memory_mb": 116.65234375,
         "avg_memory_mb": 100.85221354166667,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 6,
         "psutil_available": true
       },
@@ -545,17 +684,17 @@
         "memory_mb": 33.03125,
         "peak_memory_mb": 62.98046875,
         "avg_memory_mb": 60.87455702319588,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 97,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 14933,
+      "source_loc": 14964,
       "source_files": 31
     },
     "metrics": {
-      "tokens_count": 112398,
+      "tokens_count": 112410,
       "metric_version": "tokens-v2"
     },
     "normalized": {
@@ -611,7 +750,30 @@
       "failed": []
     },
     "errors": [],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 27937,
+      "total_tokens": 37725,
+      "semantic_tokens": 30634,
+      "by_category": {
+        "keyword": 2755,
+        "identifier": 17922,
+        "type": 4563,
+        "operator": 3824,
+        "literal": 1570,
+        "punctuation": 0,
+        "comment": 7091,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.09,
+        "comment_ratio": 0.188,
+        "punctuation_ratio": 0,
+        "complexity_per_loc": 1.87,
+        "complexity_per_file": 901.19
+      }
+    }
   },
   {
     "implementation": "zig",
@@ -621,7 +783,38 @@
     "issues": [
       "Missing CONCURRENCY: payload"
     ],
-    "payload": null
+    "payload": null,
+    "size": {
+      "source_loc": 1633,
+      "source_files": 8
+    },
+    "metrics": {
+      "tokens_count": 13277,
+      "metric_version": "tokens-v2"
+    },
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 8232.75,
+      "total_tokens": 10783,
+      "semantic_tokens": 10670,
+      "by_category": {
+        "keyword": 1300,
+        "identifier": 5510,
+        "type": 17,
+        "operator": 1100,
+        "literal": 680,
+        "punctuation": 2063,
+        "comment": 113,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.122,
+        "comment_ratio": 0.01,
+        "punctuation_ratio": 0.193,
+        "complexity_per_loc": 5.04,
+        "complexity_per_file": 1029.09
+      }
+    }
   },
   {
     "language": "bun",
@@ -667,7 +860,7 @@
         "memory_mb": 116.9140625,
         "peak_memory_mb": 116.9140625,
         "avg_memory_mb": 98.26328125,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 5,
         "psutil_available": true
       },
@@ -696,7 +889,7 @@
         "memory_mb": 32.08984375,
         "peak_memory_mb": 61.86328125,
         "avg_memory_mb": 61.56069176557863,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 674,
         "psutil_available": true
       }
@@ -710,7 +903,7 @@
       "metric_version": "tokens-v2"
     },
     "normalized": {
-      "build_ms_per_kloc": 0.0,
+      "build_ms_per_kloc": 0,
       "analyze_ms_per_kloc": 298.7830271813545,
       "runtime_ms_per_kloc": 281.838914560452
     },
@@ -759,7 +952,7 @@
       ]
     },
     "errors": [
-      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting bun implementation at implementations/bun\n----------------------------------------\nRunning test: Hash Command Baseline \u2713\nRunning test: Hash Command After Move \u2713\nRunning test: Draws Command \u2717\nRunning test: Go Movetime \u2717\nRunning test: PGN Show \u2717\nRunning test: PGN Fixture Morphy \u2717\nRunning test: PGN Fixture Byrne-Fischer \u2717\nRunning test: Book Load Stats \u2717\nRunning test: Book AI Move \u2717\nRunning test: UCI Handshake \u2717\nRunning"
+      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting bun implementation at implementations/bun\n----------------------------------------\nRunning test: Hash Command Baseline ✓\nRunning test: Hash Command After Move ✓\nRunning test: Draws Command ✗\nRunning test: Go Movetime ✗\nRunning test: PGN Show ✗\nRunning test: PGN Fixture Morphy ✗\nRunning test: PGN Fixture Byrne-Fischer ✗\nRunning test: Book Load Stats ✗\nRunning test: Book AI Move ✗\nRunning test: UCI Handshake ✗\nRunning"
     ],
     "status": "completed"
   },
@@ -771,7 +964,38 @@
     "issues": [
       "Missing CONCURRENCY: payload"
     ],
-    "payload": null
+    "payload": null,
+    "size": {
+      "source_loc": 1854,
+      "source_files": 9
+    },
+    "metrics": {
+      "tokens_count": 12770,
+      "metric_version": "tokens-v2"
+    },
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 6761,
+      "total_tokens": 9569,
+      "semantic_tokens": 9513,
+      "by_category": {
+        "keyword": 963,
+        "identifier": 3103,
+        "type": 807,
+        "operator": 2300,
+        "literal": 612,
+        "punctuation": 1728,
+        "comment": 56,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.101,
+        "comment_ratio": 0.006,
+        "punctuation_ratio": 0.182,
+        "complexity_per_loc": 3.65,
+        "complexity_per_file": 751.22
+      }
+    }
   },
   {
     "implementation": "gleam",
@@ -795,6 +1019,37 @@
       "timeouts": 0,
       "elapsed_ms": 42,
       "ops_total": 1024
+    },
+    "size": {
+      "source_loc": 14964,
+      "source_files": 31
+    },
+    "metrics": {
+      "tokens_count": 112410,
+      "metric_version": "tokens-v2"
+    },
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 27937,
+      "total_tokens": 37725,
+      "semantic_tokens": 30634,
+      "by_category": {
+        "keyword": 2755,
+        "identifier": 17922,
+        "type": 4563,
+        "operator": 3824,
+        "literal": 1570,
+        "punctuation": 0,
+        "comment": 7091,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.09,
+        "comment_ratio": 0.188,
+        "punctuation_ratio": 0,
+        "complexity_per_loc": 1.87,
+        "complexity_per_file": 901.19
+      }
     }
   },
   {
@@ -842,7 +1097,7 @@
         "memory_mb": 116.7265625,
         "peak_memory_mb": 116.7265625,
         "avg_memory_mb": 100.17643229166667,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 6,
         "psutil_available": true
       },
@@ -871,21 +1126,21 @@
         "memory_mb": 32.50390625,
         "peak_memory_mb": 62.2421875,
         "avg_memory_mb": 61.0767578125,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 160,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 3672,
+      "source_loc": 3678,
       "source_files": 13
     },
     "metrics": {
-      "tokens_count": 26928,
+      "tokens_count": 26934,
       "metric_version": "tokens-v2"
     },
     "normalized": {
-      "build_ms_per_kloc": 0.0,
+      "build_ms_per_kloc": 0,
       "analyze_ms_per_kloc": 59.84566050676998,
       "runtime_ms_per_kloc": 51.7470254877294
     },
@@ -937,7 +1192,30 @@
       "failed": []
     },
     "errors": [],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 9146.5,
+      "total_tokens": 14587,
+      "semantic_tokens": 14477,
+      "by_category": {
+        "keyword": 1314,
+        "identifier": 3871,
+        "type": 304,
+        "operator": 2004,
+        "literal": 3638,
+        "punctuation": 3346,
+        "comment": 110,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.091,
+        "comment_ratio": 0.008,
+        "punctuation_ratio": 0.231,
+        "complexity_per_loc": 2.49,
+        "complexity_per_file": 703.58
+      }
+    }
   },
   {
     "language": "nim",
@@ -982,7 +1260,7 @@
         "memory_mb": 111.53515625,
         "peak_memory_mb": 111.53515625,
         "avg_memory_mb": 90.8740234375,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 4,
         "psutil_available": true
       },
@@ -1011,17 +1289,17 @@
         "memory_mb": 32.3515625,
         "peak_memory_mb": 62.12109375,
         "avg_memory_mb": 60.121426196808514,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 94,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 1105,
+      "source_loc": 1339,
       "source_files": 1
     },
     "metrics": {
-      "tokens_count": 8410,
+      "tokens_count": 10036,
       "metric_version": "tokens-v2"
     },
     "normalized": {
@@ -1074,9 +1352,32 @@
       ]
     },
     "errors": [
-      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting nim implementation at implementations/nim\n----------------------------------------\nRunning test: Hash Command Baseline \u2713\nRunning test: Hash Command After Move \u2713\nRunning test: Draws Command \u2717\nRunning test: Go Movetime \u2717\nRunning test: PGN Show \u2717\nRunning test: PGN Fixture Morphy \u2717\nRunning test: PGN Fixture Byrne-Fischer \u2717\nRunning test: Book Load Stats \u2717\nRunning test: Book AI Move \u2717\nRunning test: UCI Handshake \u2717\nRunning"
+      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting nim implementation at implementations/nim\n----------------------------------------\nRunning test: Hash Command Baseline ✓\nRunning test: Hash Command After Move ✓\nRunning test: Draws Command ✗\nRunning test: Go Movetime ✗\nRunning test: PGN Show ✗\nRunning test: PGN Fixture Morphy ✗\nRunning test: PGN Fixture Byrne-Fischer ✗\nRunning test: Book Load Stats ✗\nRunning test: Book AI Move ✗\nRunning test: UCI Handshake ✗\nRunning"
     ],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 5748,
+      "total_tokens": 7345,
+      "semantic_tokens": 7252,
+      "by_category": {
+        "keyword": 1064,
+        "identifier": 2932,
+        "type": 248,
+        "operator": 1939,
+        "literal": 1069,
+        "punctuation": 0,
+        "comment": 93,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.147,
+        "comment_ratio": 0.013,
+        "punctuation_ratio": 0,
+        "complexity_per_loc": 4.29,
+        "complexity_per_file": 5748
+      }
+    }
   },
   {
     "language": "php",
@@ -1122,7 +1423,7 @@
         "memory_mb": 116.51171875,
         "peak_memory_mb": 116.51171875,
         "avg_memory_mb": 92.1982421875,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 4,
         "psutil_available": true
       },
@@ -1151,13 +1452,13 @@
         "memory_mb": 32.78125,
         "peak_memory_mb": 62.55078125,
         "avg_memory_mb": 61.08642578125,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 128,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 3435,
+      "source_loc": 3445,
       "source_files": 10
     },
     "metrics": {
@@ -1165,7 +1466,7 @@
       "metric_version": "tokens-v2"
     },
     "normalized": {
-      "build_ms_per_kloc": 0.0,
+      "build_ms_per_kloc": 0,
       "analyze_ms_per_kloc": 81.70642880546647,
       "runtime_ms_per_kloc": 48.80626128750597
     },
@@ -1217,7 +1518,30 @@
       "failed": []
     },
     "errors": [],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 9808.25,
+      "total_tokens": 15321,
+      "semantic_tokens": 15076,
+      "by_category": {
+        "keyword": 1535,
+        "identifier": 4571,
+        "type": 21,
+        "operator": 3200,
+        "literal": 2576,
+        "punctuation": 3173,
+        "comment": 245,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.102,
+        "comment_ratio": 0.016,
+        "punctuation_ratio": 0.21,
+        "complexity_per_loc": 2.85,
+        "complexity_per_file": 980.83
+      }
+    }
   },
   {
     "implementation": "elm",
@@ -1227,7 +1551,38 @@
     "issues": [
       "Missing CONCURRENCY: payload"
     ],
-    "payload": null
+    "payload": null,
+    "size": {
+      "source_loc": 1669,
+      "source_files": 7
+    },
+    "metrics": {
+      "tokens_count": 7868,
+      "metric_version": "tokens-v2"
+    },
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 5305,
+      "total_tokens": 6310,
+      "semantic_tokens": 6286,
+      "by_category": {
+        "keyword": 1553,
+        "identifier": 2943,
+        "type": 0,
+        "operator": 1007,
+        "literal": 439,
+        "punctuation": 344,
+        "comment": 24,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.247,
+        "comment_ratio": 0.004,
+        "punctuation_ratio": 0.055,
+        "complexity_per_loc": 3.18,
+        "complexity_per_file": 757.86
+      }
+    }
   },
   {
     "language": "typescript",
@@ -1273,7 +1628,7 @@
         "memory_mb": 17.4921875,
         "peak_memory_mb": 110.98046875,
         "avg_memory_mb": 67.3212890625,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 4,
         "psutil_available": true
       },
@@ -1302,17 +1657,17 @@
         "memory_mb": 31.9375,
         "peak_memory_mb": 61.9140625,
         "avg_memory_mb": 59.93112664473684,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 95,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 1838,
-      "source_files": 11
+      "source_loc": 2038,
+      "source_files": 21
     },
     "metrics": {
-      "tokens_count": 13192,
+      "tokens_count": 14364,
       "metric_version": "tokens-v2"
     },
     "normalized": {
@@ -1365,9 +1720,32 @@
       ]
     },
     "errors": [
-      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting typescript implementation at implementations/typescript\n----------------------------------------\nRunning test: Hash Command Baseline \u2713\nRunning test: Hash Command After Move \u2713\nRunning test: Draws Command \u2717\nRunning test: Go Movetime \u2717\nRunning test: PGN Show \u2717\nRunning test: PGN Fixture Morphy \u2717\nRunning test: PGN Fixture Byrne-Fischer \u2717\nRunning test: Book Load Stats \u2717\nRunning test: Book AI Move \u2717\nRunning test: UCI Hands"
+      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting typescript implementation at implementations/typescript\n----------------------------------------\nRunning test: Hash Command Baseline ✓\nRunning test: Hash Command After Move ✓\nRunning test: Draws Command ✗\nRunning test: Go Movetime ✗\nRunning test: PGN Show ✗\nRunning test: PGN Fixture Morphy ✗\nRunning test: PGN Fixture Byrne-Fischer ✗\nRunning test: Book Load Stats ✗\nRunning test: Book AI Move ✗\nRunning test: UCI Hands"
     ],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 6211,
+      "total_tokens": 9433,
+      "semantic_tokens": 9409,
+      "by_category": {
+        "keyword": 1012,
+        "identifier": 2767,
+        "type": 425,
+        "operator": 1445,
+        "literal": 1378,
+        "punctuation": 2382,
+        "comment": 24,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.108,
+        "comment_ratio": 0.003,
+        "punctuation_ratio": 0.253,
+        "complexity_per_loc": 3.05,
+        "complexity_per_file": 295.76
+      }
+    }
   },
   {
     "implementation": "kotlin",
@@ -1377,7 +1755,38 @@
     "issues": [
       "Missing CONCURRENCY: payload"
     ],
-    "payload": null
+    "payload": null,
+    "size": {
+      "source_loc": 1525,
+      "source_files": 8
+    },
+    "metrics": {
+      "tokens_count": 9666,
+      "metric_version": "tokens-v2"
+    },
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 4868.5,
+      "total_tokens": 5647,
+      "semantic_tokens": 5586,
+      "by_category": {
+        "keyword": 876,
+        "identifier": 3024,
+        "type": 251,
+        "operator": 764,
+        "literal": 671,
+        "punctuation": 0,
+        "comment": 61,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.157,
+        "comment_ratio": 0.011,
+        "punctuation_ratio": 0,
+        "complexity_per_loc": 3.19,
+        "complexity_per_file": 608.56
+      }
+    }
   },
   {
     "implementation": "julia",
@@ -1401,6 +1810,37 @@
       "timeouts": 0,
       "elapsed_ms": 42,
       "ops_total": 1024
+    },
+    "size": {
+      "source_loc": 1949,
+      "source_files": 9
+    },
+    "metrics": {
+      "tokens_count": 12280,
+      "metric_version": "tokens-v2"
+    },
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 5517.5,
+      "total_tokens": 8570,
+      "semantic_tokens": 8488,
+      "by_category": {
+        "keyword": 802,
+        "identifier": 2391,
+        "type": 147,
+        "operator": 1958,
+        "literal": 1604,
+        "punctuation": 1586,
+        "comment": 82,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.094,
+        "comment_ratio": 0.01,
+        "punctuation_ratio": 0.187,
+        "complexity_per_loc": 2.83,
+        "complexity_per_file": 613.06
+      }
     }
   },
   {
@@ -1447,7 +1887,7 @@
         "memory_mb": 110.9140625,
         "peak_memory_mb": 110.9140625,
         "avg_memory_mb": 83.99609375,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 3,
         "psutil_available": true
       },
@@ -1476,13 +1916,13 @@
         "memory_mb": 61.93359375,
         "peak_memory_mb": 61.93359375,
         "avg_memory_mb": 61.62977099236641,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 131,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 1941,
+      "source_loc": 1949,
       "source_files": 9
     },
     "metrics": {
@@ -1490,7 +1930,7 @@
       "metric_version": "tokens-v2"
     },
     "normalized": {
-      "build_ms_per_kloc": 0.0,
+      "build_ms_per_kloc": 0,
       "analyze_ms_per_kloc": 93.88520753242378,
       "runtime_ms_per_kloc": 92.06138524365511
     },
@@ -1542,7 +1982,30 @@
       "failed": []
     },
     "errors": [],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 5517.5,
+      "total_tokens": 8570,
+      "semantic_tokens": 8488,
+      "by_category": {
+        "keyword": 802,
+        "identifier": 2391,
+        "type": 147,
+        "operator": 1958,
+        "literal": 1604,
+        "punctuation": 1586,
+        "comment": 82,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.094,
+        "comment_ratio": 0.01,
+        "punctuation_ratio": 0.187,
+        "complexity_per_loc": 2.83,
+        "complexity_per_file": 613.06
+      }
+    }
   },
   {
     "language": "ruby",
@@ -1588,7 +2051,7 @@
         "memory_mb": 116.0703125,
         "peak_memory_mb": 116.0703125,
         "avg_memory_mb": 93.64296875,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 5,
         "psutil_available": true
       },
@@ -1617,21 +2080,21 @@
         "memory_mb": 32.26171875,
         "peak_memory_mb": 62.1953125,
         "avg_memory_mb": 60.581256734913794,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 116,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 1906,
+      "source_loc": 1908,
       "source_files": 10
     },
     "metrics": {
-      "tokens_count": 9600,
+      "tokens_count": 9603,
       "metric_version": "tokens-v2"
     },
     "normalized": {
-      "build_ms_per_kloc": 0.0,
+      "build_ms_per_kloc": 0,
       "analyze_ms_per_kloc": 1220.912147794165,
       "runtime_ms_per_kloc": 157.0988301840559
     },
@@ -1680,9 +2143,32 @@
       ]
     },
     "errors": [
-      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting ruby implementation at implementations/ruby\n----------------------------------------\nRunning test: Hash Command Baseline \u2713\nRunning test: Hash Command After Move \u2713\nRunning test: Draws Command \u2717\nRunning test: Go Movetime \u2717\nRunning test: PGN Show \u2717\nRunning test: PGN Fixture Morphy \u2717\nRunning test: PGN Fixture Byrne-Fischer \u2717\nRunning test: Book Load Stats \u2717\nRunning test: Book AI Move \u2717\nRunning test: UCI Handshake \u2717\nRunni"
+      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting ruby implementation at implementations/ruby\n----------------------------------------\nRunning test: Hash Command Baseline ✓\nRunning test: Hash Command After Move ✓\nRunning test: Draws Command ✗\nRunning test: Go Movetime ✗\nRunning test: PGN Show ✗\nRunning test: PGN Fixture Morphy ✗\nRunning test: PGN Fixture Byrne-Fischer ✗\nRunning test: Book Load Stats ✗\nRunning test: Book AI Move ✗\nRunning test: UCI Handshake ✗\nRunni"
     ],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 4133.25,
+      "total_tokens": 5810,
+      "semantic_tokens": 5713,
+      "by_category": {
+        "keyword": 821,
+        "identifier": 2142,
+        "type": 23,
+        "operator": 816,
+        "literal": 1046,
+        "punctuation": 865,
+        "comment": 97,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.144,
+        "comment_ratio": 0.017,
+        "punctuation_ratio": 0.151,
+        "complexity_per_loc": 2.17,
+        "complexity_per_file": 413.33
+      }
+    }
   },
   {
     "language": "crystal",
@@ -1727,7 +2213,7 @@
         "memory_mb": 116.39453125,
         "peak_memory_mb": 116.39453125,
         "avg_memory_mb": 96.71171875,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 5,
         "psutil_available": true
       },
@@ -1756,17 +2242,17 @@
         "memory_mb": 32.12890625,
         "peak_memory_mb": 62.0234375,
         "avg_memory_mb": 60.03675986842105,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 95,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 1692,
-      "source_files": 7
+      "source_loc": 2201,
+      "source_files": 10
     },
     "metrics": {
-      "tokens_count": 9441,
+      "tokens_count": 12598,
       "metric_version": "tokens-v2"
     },
     "normalized": {
@@ -1819,9 +2305,32 @@
       ]
     },
     "errors": [
-      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting crystal implementation at implementations/crystal\n----------------------------------------\nRunning test: Hash Command Baseline \u2713\nRunning test: Hash Command After Move \u2713\nRunning test: Draws Command \u2717\nRunning test: Go Movetime \u2717\nRunning test: PGN Show \u2713\nRunning test: PGN Fixture Morphy \u2717\nRunning test: PGN Fixture Byrne-Fischer \u2717\nRunning test: Book Load Stats \u2717\nRunning test: Book AI Move \u2717\nRunning test: UCI Handshake \u2717"
+      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting crystal implementation at implementations/crystal\n----------------------------------------\nRunning test: Hash Command Baseline ✓\nRunning test: Hash Command After Move ✓\nRunning test: Draws Command ✗\nRunning test: Go Movetime ✗\nRunning test: PGN Show ✓\nRunning test: PGN Fixture Morphy ✗\nRunning test: PGN Fixture Byrne-Fischer ✗\nRunning test: Book Load Stats ✗\nRunning test: Book AI Move ✗\nRunning test: UCI Handshake ✗"
     ],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 5325.75,
+      "total_tokens": 7946,
+      "semantic_tokens": 7880,
+      "by_category": {
+        "keyword": 969,
+        "identifier": 2560,
+        "type": 19,
+        "operator": 1020,
+        "literal": 1759,
+        "punctuation": 1553,
+        "comment": 66,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.123,
+        "comment_ratio": 0.008,
+        "punctuation_ratio": 0.197,
+        "complexity_per_loc": 2.42,
+        "complexity_per_file": 532.58
+      }
+    }
   },
   {
     "implementation": "go",
@@ -1850,6 +2359,37 @@
       "seed": 12345,
       "timeouts": 0,
       "workers": 2
+    },
+    "size": {
+      "source_loc": 3919,
+      "source_files": 7
+    },
+    "metrics": {
+      "tokens_count": 24803,
+      "metric_version": "tokens-v2"
+    },
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 9967.5,
+      "total_tokens": 14666,
+      "semantic_tokens": 14552,
+      "by_category": {
+        "keyword": 1445,
+        "identifier": 5126,
+        "type": 396,
+        "operator": 1955,
+        "literal": 2462,
+        "punctuation": 3168,
+        "comment": 114,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.099,
+        "comment_ratio": 0.008,
+        "punctuation_ratio": 0.218,
+        "complexity_per_loc": 2.54,
+        "complexity_per_file": 1423.93
+      }
     }
   },
   {
@@ -1895,7 +2435,7 @@
         "memory_mb": 116.0546875,
         "peak_memory_mb": 116.0546875,
         "avg_memory_mb": 85.30338541666667,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 3,
         "psutil_available": true
       },
@@ -1924,13 +2464,13 @@
         "memory_mb": 32.16796875,
         "peak_memory_mb": 62.2109375,
         "avg_memory_mb": 60.210438829787236,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 94,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 1663,
+      "source_loc": 1669,
       "source_files": 7
     },
     "metrics": {
@@ -1987,9 +2527,32 @@
       ]
     },
     "errors": [
-      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting elm implementation at implementations/elm\n----------------------------------------\nRunning test: Hash Command Baseline \u2717\nRunning test: Hash Command After Move \u2717\nRunning test: Draws Command \u2717\nRunning test: Go Movetime \u2717\nRunning test: PGN Show \u2713\nRunning test: PGN Fixture Morphy \u2717\nRunning test: PGN Fixture Byrne-Fischer \u2717\nRunning test: Book Load Stats \u2717\nRunning test: Book AI Move \u2717\nRunning test: UCI Handshake \u2717\nRunning"
+      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting elm implementation at implementations/elm\n----------------------------------------\nRunning test: Hash Command Baseline ✗\nRunning test: Hash Command After Move ✗\nRunning test: Draws Command ✗\nRunning test: Go Movetime ✗\nRunning test: PGN Show ✓\nRunning test: PGN Fixture Morphy ✗\nRunning test: PGN Fixture Byrne-Fischer ✗\nRunning test: Book Load Stats ✗\nRunning test: Book AI Move ✗\nRunning test: UCI Handshake ✗\nRunning"
     ],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 5305,
+      "total_tokens": 6310,
+      "semantic_tokens": 6286,
+      "by_category": {
+        "keyword": 1553,
+        "identifier": 2943,
+        "type": 0,
+        "operator": 1007,
+        "literal": 439,
+        "punctuation": 344,
+        "comment": 24,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.247,
+        "comment_ratio": 0.004,
+        "punctuation_ratio": 0.055,
+        "complexity_per_loc": 3.18,
+        "complexity_per_file": 757.86
+      }
+    }
   },
   {
     "implementation": "haskell",
@@ -1999,7 +2562,38 @@
     "issues": [
       "Missing CONCURRENCY: payload"
     ],
-    "payload": null
+    "payload": null,
+    "size": {
+      "source_loc": 1407,
+      "source_files": 14
+    },
+    "metrics": {
+      "tokens_count": 11812,
+      "metric_version": "tokens-v2"
+    },
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 5560.5,
+      "total_tokens": 7895,
+      "semantic_tokens": 7846,
+      "by_category": {
+        "keyword": 973,
+        "identifier": 2786,
+        "type": 0,
+        "operator": 1954,
+        "literal": 1165,
+        "punctuation": 968,
+        "comment": 49,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.124,
+        "comment_ratio": 0.006,
+        "punctuation_ratio": 0.123,
+        "complexity_per_loc": 3.95,
+        "complexity_per_file": 397.18
+      }
+    }
   },
   {
     "implementation": "crystal",
@@ -2009,7 +2603,38 @@
     "issues": [
       "Missing CONCURRENCY: payload"
     ],
-    "payload": null
+    "payload": null,
+    "size": {
+      "source_loc": 2201,
+      "source_files": 10
+    },
+    "metrics": {
+      "tokens_count": 12598,
+      "metric_version": "tokens-v2"
+    },
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 5325.75,
+      "total_tokens": 7946,
+      "semantic_tokens": 7880,
+      "by_category": {
+        "keyword": 969,
+        "identifier": 2560,
+        "type": 19,
+        "operator": 1020,
+        "literal": 1759,
+        "punctuation": 1553,
+        "comment": 66,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.123,
+        "comment_ratio": 0.008,
+        "punctuation_ratio": 0.197,
+        "complexity_per_loc": 2.42,
+        "complexity_per_file": 532.58
+      }
+    }
   },
   {
     "language": "lua",
@@ -2055,7 +2680,7 @@
         "memory_mb": 111.15234375,
         "peak_memory_mb": 111.15234375,
         "avg_memory_mb": 84.37760416666667,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 3,
         "psutil_available": true
       },
@@ -2084,13 +2709,13 @@
         "memory_mb": 32.74609375,
         "peak_memory_mb": 62.6484375,
         "avg_memory_mb": 60.862909226190474,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 105,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 2884,
+      "source_loc": 2885,
       "source_files": 1
     },
     "metrics": {
@@ -2098,7 +2723,7 @@
       "metric_version": "tokens-v2"
     },
     "normalized": {
-      "build_ms_per_kloc": 0.0,
+      "build_ms_per_kloc": 0,
       "analyze_ms_per_kloc": 73.52749616858368,
       "runtime_ms_per_kloc": 67.56099682409787
     },
@@ -2150,7 +2775,30 @@
       "failed": []
     },
     "errors": [],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 10381.5,
+      "total_tokens": 12945,
+      "semantic_tokens": 12852,
+      "by_category": {
+        "keyword": 2325,
+        "identifier": 5575,
+        "type": 51,
+        "operator": 2459,
+        "literal": 2362,
+        "punctuation": 80,
+        "comment": 93,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.181,
+        "comment_ratio": 0.007,
+        "punctuation_ratio": 0.006,
+        "complexity_per_loc": 3.6,
+        "complexity_per_file": 10381.5
+      }
+    }
   },
   {
     "language": "javascript",
@@ -2196,7 +2844,7 @@
         "memory_mb": 115.84375,
         "peak_memory_mb": 115.84375,
         "avg_memory_mb": 102.51227678571429,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 7,
         "psutil_available": true
       },
@@ -2225,13 +2873,13 @@
         "memory_mb": 32.06640625,
         "peak_memory_mb": 61.8671875,
         "avg_memory_mb": 61.553426106770836,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 672,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 816,
+      "source_loc": 820,
       "source_files": 4
     },
     "metrics": {
@@ -2239,7 +2887,7 @@
       "metric_version": "tokens-v2"
     },
     "normalized": {
-      "build_ms_per_kloc": 0.0,
+      "build_ms_per_kloc": 0,
       "analyze_ms_per_kloc": 253.5850394005869,
       "runtime_ms_per_kloc": 226.43833768134024
     },
@@ -2288,9 +2936,32 @@
       ]
     },
     "errors": [
-      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting javascript implementation at implementations/javascript\n----------------------------------------\nRunning test: Hash Command Baseline \u2713\nRunning test: Hash Command After Move \u2713\nRunning test: Draws Command \u2717\nRunning test: Go Movetime \u2717\nRunning test: PGN Show \u2717\nRunning test: PGN Fixture Morphy \u2717\nRunning test: PGN Fixture Byrne-Fischer \u2717\nRunning test: Book Load Stats \u2717\nRunning test: Book AI Move \u2717\nRunning test: UCI Hands"
+      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting javascript implementation at implementations/javascript\n----------------------------------------\nRunning test: Hash Command Baseline ✓\nRunning test: Hash Command After Move ✓\nRunning test: Draws Command ✗\nRunning test: Go Movetime ✗\nRunning test: PGN Show ✗\nRunning test: PGN Fixture Morphy ✗\nRunning test: PGN Fixture Byrne-Fischer ✗\nRunning test: Book Load Stats ✗\nRunning test: Book AI Move ✗\nRunning test: UCI Hands"
     ],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 2661,
+      "total_tokens": 4468,
+      "semantic_tokens": 4149,
+      "by_category": {
+        "keyword": 393,
+        "identifier": 1256,
+        "type": 1,
+        "operator": 731,
+        "literal": 814,
+        "punctuation": 954,
+        "comment": 319,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.095,
+        "comment_ratio": 0.071,
+        "punctuation_ratio": 0.23,
+        "complexity_per_loc": 3.25,
+        "complexity_per_file": 665.25
+      }
+    }
   },
   {
     "language": "kotlin",
@@ -2335,7 +3006,7 @@
         "memory_mb": 111.6328125,
         "peak_memory_mb": 111.6328125,
         "avg_memory_mb": 90.1943359375,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 4,
         "psutil_available": true
       },
@@ -2364,13 +3035,13 @@
         "memory_mb": 32.2265625,
         "peak_memory_mb": 62.00390625,
         "avg_memory_mb": 60.06946681701031,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 97,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 1524,
+      "source_loc": 1525,
       "source_files": 8
     },
     "metrics": {
@@ -2427,9 +3098,32 @@
       ]
     },
     "errors": [
-      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting kotlin implementation at implementations/kotlin\n----------------------------------------\nRunning test: Hash Command Baseline \u2713\nRunning test: Hash Command After Move \u2713\nRunning test: Draws Command \u2717\nRunning test: Go Movetime \u2717\nRunning test: PGN Show \u2717\nRunning test: PGN Fixture Morphy \u2717\nRunning test: PGN Fixture Byrne-Fischer \u2717\nRunning test: Book Load Stats \u2717\nRunning test: Book AI Move \u2717\nRunning test: UCI Handshake \u2717\nR"
+      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting kotlin implementation at implementations/kotlin\n----------------------------------------\nRunning test: Hash Command Baseline ✓\nRunning test: Hash Command After Move ✓\nRunning test: Draws Command ✗\nRunning test: Go Movetime ✗\nRunning test: PGN Show ✗\nRunning test: PGN Fixture Morphy ✗\nRunning test: PGN Fixture Byrne-Fischer ✗\nRunning test: Book Load Stats ✗\nRunning test: Book AI Move ✗\nRunning test: UCI Handshake ✗\nR"
     ],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 4868.5,
+      "total_tokens": 5647,
+      "semantic_tokens": 5586,
+      "by_category": {
+        "keyword": 876,
+        "identifier": 3024,
+        "type": 251,
+        "operator": 764,
+        "literal": 671,
+        "punctuation": 0,
+        "comment": 61,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.157,
+        "comment_ratio": 0.011,
+        "punctuation_ratio": 0,
+        "complexity_per_loc": 3.19,
+        "complexity_per_file": 608.56
+      }
+    }
   },
   {
     "language": "zig",
@@ -2474,7 +3168,7 @@
         "memory_mb": 111.0546875,
         "peak_memory_mb": 111.0546875,
         "avg_memory_mb": 90.814453125,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 4,
         "psutil_available": true
       },
@@ -2503,13 +3197,13 @@
         "memory_mb": 32.1015625,
         "peak_memory_mb": 61.96484375,
         "avg_memory_mb": 61.59710122526978,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 556,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 1625,
+      "source_loc": 1633,
       "source_files": 8
     },
     "metrics": {
@@ -2566,9 +3260,32 @@
       ]
     },
     "errors": [
-      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting zig implementation at implementations/zig\n----------------------------------------\nRunning test: Hash Command Baseline \u2717\nRunning test: Hash Command After Move \u2717\nRunning test: Draws Command \u2717\nRunning test: Go Movetime \u2717\nRunning test: PGN Show \u2717\nRunning test: PGN Fixture Morphy \u2717\nRunning test: PGN Fixture Byrne-Fischer \u2717\nRunning test: Book Load Stats \u2717\nRunning test: Book AI Move \u2717\nRunning test: UCI Handshake \u2717\nRunning"
+      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting zig implementation at implementations/zig\n----------------------------------------\nRunning test: Hash Command Baseline ✗\nRunning test: Hash Command After Move ✗\nRunning test: Draws Command ✗\nRunning test: Go Movetime ✗\nRunning test: PGN Show ✗\nRunning test: PGN Fixture Morphy ✗\nRunning test: PGN Fixture Byrne-Fischer ✗\nRunning test: Book Load Stats ✗\nRunning test: Book AI Move ✗\nRunning test: UCI Handshake ✗\nRunning"
     ],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 8232.75,
+      "total_tokens": 10783,
+      "semantic_tokens": 10670,
+      "by_category": {
+        "keyword": 1300,
+        "identifier": 5510,
+        "type": 17,
+        "operator": 1100,
+        "literal": 680,
+        "punctuation": 2063,
+        "comment": 113,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.122,
+        "comment_ratio": 0.01,
+        "punctuation_ratio": 0.193,
+        "complexity_per_loc": 5.04,
+        "complexity_per_file": 1029.09
+      }
+    }
   },
   {
     "implementation": "typescript",
@@ -2578,7 +3295,38 @@
     "issues": [
       "Missing CONCURRENCY: payload"
     ],
-    "payload": null
+    "payload": null,
+    "size": {
+      "source_loc": 2038,
+      "source_files": 21
+    },
+    "metrics": {
+      "tokens_count": 14364,
+      "metric_version": "tokens-v2"
+    },
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 6211,
+      "total_tokens": 9433,
+      "semantic_tokens": 9409,
+      "by_category": {
+        "keyword": 1012,
+        "identifier": 2767,
+        "type": 425,
+        "operator": 1445,
+        "literal": 1378,
+        "punctuation": 2382,
+        "comment": 24,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.108,
+        "comment_ratio": 0.003,
+        "punctuation_ratio": 0.253,
+        "complexity_per_loc": 3.05,
+        "complexity_per_file": 295.76
+      }
+    }
   },
   {
     "language": "go",
@@ -2623,7 +3371,7 @@
         "memory_mb": 116.265625,
         "peak_memory_mb": 116.265625,
         "avg_memory_mb": 101.0078125,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 6,
         "psutil_available": true
       },
@@ -2652,13 +3400,13 @@
         "memory_mb": 32.5234375,
         "peak_memory_mb": 62.3671875,
         "avg_memory_mb": 60.51392326732673,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 101,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 3913,
+      "source_loc": 3919,
       "source_files": 7
     },
     "metrics": {
@@ -2718,7 +3466,30 @@
       "failed": []
     },
     "errors": [],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 9967.5,
+      "total_tokens": 14666,
+      "semantic_tokens": 14552,
+      "by_category": {
+        "keyword": 1445,
+        "identifier": 5126,
+        "type": 396,
+        "operator": 1955,
+        "literal": 2462,
+        "punctuation": 3168,
+        "comment": 114,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.099,
+        "comment_ratio": 0.008,
+        "punctuation_ratio": 0.218,
+        "complexity_per_loc": 2.54,
+        "complexity_per_file": 1423.93
+      }
+    }
   },
   {
     "implementation": "imba",
@@ -2749,6 +3520,37 @@
       "timeouts": 0,
       "elapsed_ms": 0,
       "ops_total": 100000
+    },
+    "size": {
+      "source_loc": 1634,
+      "source_files": 1
+    },
+    "metrics": {
+      "tokens_count": 13741,
+      "metric_version": "tokens-v2"
+    },
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 6002,
+      "total_tokens": 8715,
+      "semantic_tokens": 8715,
+      "by_category": {
+        "keyword": 679,
+        "identifier": 2498,
+        "type": 849,
+        "operator": 1532,
+        "literal": 1683,
+        "punctuation": 1474,
+        "comment": 0,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.078,
+        "comment_ratio": 0,
+        "punctuation_ratio": 0.169,
+        "complexity_per_loc": 3.67,
+        "complexity_per_file": 6002
+      }
     }
   },
   {
@@ -2759,7 +3561,38 @@
     "issues": [
       "Missing CONCURRENCY: payload"
     ],
-    "payload": null
+    "payload": null,
+    "size": {
+      "source_loc": 1688,
+      "source_files": 11
+    },
+    "metrics": {
+      "tokens_count": 11181,
+      "metric_version": "tokens-v2"
+    },
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 4903.75,
+      "total_tokens": 6701,
+      "semantic_tokens": 6685,
+      "by_category": {
+        "keyword": 695,
+        "identifier": 2732,
+        "type": 298,
+        "operator": 1113,
+        "literal": 642,
+        "punctuation": 1205,
+        "comment": 16,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.104,
+        "comment_ratio": 0.002,
+        "punctuation_ratio": 0.18,
+        "complexity_per_loc": 2.91,
+        "complexity_per_file": 445.8
+      }
+    }
   },
   {
     "language": "rust",
@@ -2804,7 +3637,7 @@
         "memory_mb": 111.58203125,
         "peak_memory_mb": 111.58203125,
         "avg_memory_mb": 90.685546875,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 4,
         "psutil_available": true
       },
@@ -2831,15 +3664,15 @@
       },
       "test_chess_engine": {
         "memory_mb": 32.31640625,
-        "peak_memory_mb": 62.0,
+        "peak_memory_mb": 62,
         "avg_memory_mb": 60.037582236842105,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 95,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 1852,
+      "source_loc": 1854,
       "source_files": 9
     },
     "metrics": {
@@ -2896,9 +3729,32 @@
       ]
     },
     "errors": [
-      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting rust implementation at implementations/rust\n----------------------------------------\nRunning test: Hash Command Baseline \u2713\nRunning test: Hash Command After Move \u2713\nRunning test: Draws Command \u2717\nRunning test: Go Movetime \u2717\nRunning test: PGN Show \u2717\nRunning test: PGN Fixture Morphy \u2717\nRunning test: PGN Fixture Byrne-Fischer \u2717\nRunning test: Book Load Stats \u2717\nRunning test: Book AI Move \u2717\nRunning test: UCI Handshake \u2717\nRunni"
+      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting rust implementation at implementations/rust\n----------------------------------------\nRunning test: Hash Command Baseline ✓\nRunning test: Hash Command After Move ✓\nRunning test: Draws Command ✗\nRunning test: Go Movetime ✗\nRunning test: PGN Show ✗\nRunning test: PGN Fixture Morphy ✗\nRunning test: PGN Fixture Byrne-Fischer ✗\nRunning test: Book Load Stats ✗\nRunning test: Book AI Move ✗\nRunning test: UCI Handshake ✗\nRunni"
     ],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 6761,
+      "total_tokens": 9569,
+      "semantic_tokens": 9513,
+      "by_category": {
+        "keyword": 963,
+        "identifier": 3103,
+        "type": 807,
+        "operator": 2300,
+        "literal": 612,
+        "punctuation": 1728,
+        "comment": 56,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.101,
+        "comment_ratio": 0.006,
+        "punctuation_ratio": 0.182,
+        "complexity_per_loc": 3.65,
+        "complexity_per_file": 751.22
+      }
+    }
   },
   {
     "language": "imba",
@@ -2943,7 +3799,7 @@
         "memory_mb": 111.46484375,
         "peak_memory_mb": 111.46484375,
         "avg_memory_mb": 84.45442708333333,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 3,
         "psutil_available": true
       },
@@ -2972,17 +3828,17 @@
         "memory_mb": 32.4765625,
         "peak_memory_mb": 62.3671875,
         "avg_memory_mb": 60.385032894736845,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 95,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 1589,
+      "source_loc": 1634,
       "source_files": 1
     },
     "metrics": {
-      "tokens_count": 13544,
+      "tokens_count": 13741,
       "metric_version": "tokens-v2"
     },
     "normalized": {
@@ -3038,7 +3894,30 @@
       "failed": []
     },
     "errors": [],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 6002,
+      "total_tokens": 8715,
+      "semantic_tokens": 8715,
+      "by_category": {
+        "keyword": 679,
+        "identifier": 2498,
+        "type": 849,
+        "operator": 1532,
+        "literal": 1683,
+        "punctuation": 1474,
+        "comment": 0,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.078,
+        "comment_ratio": 0,
+        "punctuation_ratio": 0.169,
+        "complexity_per_loc": 3.67,
+        "complexity_per_file": 6002
+      }
+    }
   },
   {
     "implementation": "nim",
@@ -3048,7 +3927,38 @@
     "issues": [
       "Missing CONCURRENCY: payload"
     ],
-    "payload": null
+    "payload": null,
+    "size": {
+      "source_loc": 1339,
+      "source_files": 1
+    },
+    "metrics": {
+      "tokens_count": 10036,
+      "metric_version": "tokens-v2"
+    },
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 5748,
+      "total_tokens": 7345,
+      "semantic_tokens": 7252,
+      "by_category": {
+        "keyword": 1064,
+        "identifier": 2932,
+        "type": 248,
+        "operator": 1939,
+        "literal": 1069,
+        "punctuation": 0,
+        "comment": 93,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.147,
+        "comment_ratio": 0.013,
+        "punctuation_ratio": 0,
+        "complexity_per_loc": 4.29,
+        "complexity_per_file": 5748
+      }
+    }
   },
   {
     "language": "dart",
@@ -3093,7 +4003,7 @@
         "memory_mb": 111.22265625,
         "peak_memory_mb": 111.22265625,
         "avg_memory_mb": 94.6640625,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 5,
         "psutil_available": true
       },
@@ -3122,13 +4032,13 @@
         "memory_mb": 32.45703125,
         "peak_memory_mb": 62.21875,
         "avg_memory_mb": 60.3673422029703,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 101,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 3295,
+      "source_loc": 3308,
       "source_files": 13
     },
     "metrics": {
@@ -3188,7 +4098,30 @@
       "failed": []
     },
     "errors": [],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 10100.25,
+      "total_tokens": 13220,
+      "semantic_tokens": 13192,
+      "by_category": {
+        "keyword": 1193,
+        "identifier": 6306,
+        "type": 81,
+        "operator": 2067,
+        "literal": 2402,
+        "punctuation": 1143,
+        "comment": 28,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.09,
+        "comment_ratio": 0.002,
+        "punctuation_ratio": 0.087,
+        "complexity_per_loc": 3.05,
+        "complexity_per_file": 776.94
+      }
+    }
   },
   {
     "implementation": "python",
@@ -3219,6 +4152,37 @@
       "timeouts": 0,
       "elapsed_ms": 282,
       "ops_total": 320
+    },
+    "size": {
+      "source_loc": 3678,
+      "source_files": 13
+    },
+    "metrics": {
+      "tokens_count": 26934,
+      "metric_version": "tokens-v2"
+    },
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 9146.5,
+      "total_tokens": 14587,
+      "semantic_tokens": 14477,
+      "by_category": {
+        "keyword": 1314,
+        "identifier": 3871,
+        "type": 304,
+        "operator": 2004,
+        "literal": 3638,
+        "punctuation": 3346,
+        "comment": 110,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.091,
+        "comment_ratio": 0.008,
+        "punctuation_ratio": 0.231,
+        "complexity_per_loc": 2.49,
+        "complexity_per_file": 703.58
+      }
     }
   },
   {
@@ -3246,6 +4210,37 @@
       "timeouts": 0,
       "elapsed_ms": 133,
       "ops_total": 780
+    },
+    "size": {
+      "source_loc": 3308,
+      "source_files": 13
+    },
+    "metrics": {
+      "tokens_count": 21057,
+      "metric_version": "tokens-v2"
+    },
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 10100.25,
+      "total_tokens": 13220,
+      "semantic_tokens": 13192,
+      "by_category": {
+        "keyword": 1193,
+        "identifier": 6306,
+        "type": 81,
+        "operator": 2067,
+        "literal": 2402,
+        "punctuation": 1143,
+        "comment": 28,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.09,
+        "comment_ratio": 0.002,
+        "punctuation_ratio": 0.087,
+        "complexity_per_loc": 3.05,
+        "complexity_per_file": 776.94
+      }
     }
   },
   {
@@ -3287,6 +4282,37 @@
       "timeouts": 0,
       "elapsed_ms": 132,
       "ops_total": 320
+    },
+    "size": {
+      "source_loc": 3445,
+      "source_files": 10
+    },
+    "metrics": {
+      "tokens_count": 26871,
+      "metric_version": "tokens-v2"
+    },
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 9808.25,
+      "total_tokens": 15321,
+      "semantic_tokens": 15076,
+      "by_category": {
+        "keyword": 1535,
+        "identifier": 4571,
+        "type": 21,
+        "operator": 3200,
+        "literal": 2576,
+        "punctuation": 3173,
+        "comment": 245,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.102,
+        "comment_ratio": 0.016,
+        "punctuation_ratio": 0.21,
+        "complexity_per_loc": 2.85,
+        "complexity_per_file": 980.83
+      }
     }
   },
   {
@@ -3297,7 +4323,38 @@
     "issues": [
       "Missing CONCURRENCY: payload"
     ],
-    "payload": null
+    "payload": null,
+    "size": {
+      "source_loc": 820,
+      "source_files": 4
+    },
+    "metrics": {
+      "tokens_count": 7472,
+      "metric_version": "tokens-v2"
+    },
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 2661,
+      "total_tokens": 4468,
+      "semantic_tokens": 4149,
+      "by_category": {
+        "keyword": 393,
+        "identifier": 1256,
+        "type": 1,
+        "operator": 731,
+        "literal": 814,
+        "punctuation": 954,
+        "comment": 319,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.095,
+        "comment_ratio": 0.071,
+        "punctuation_ratio": 0.23,
+        "complexity_per_loc": 3.25,
+        "complexity_per_file": 665.25
+      }
+    }
   },
   {
     "language": "rescript",
@@ -3343,7 +4400,7 @@
         "memory_mb": 110.3828125,
         "peak_memory_mb": 110.3828125,
         "avg_memory_mb": 89.6689453125,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 4,
         "psutil_available": true
       },
@@ -3372,13 +4429,13 @@
         "memory_mb": 32.171875,
         "peak_memory_mb": 62.1796875,
         "avg_memory_mb": 60.217569986979164,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 96,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 1678,
+      "source_loc": 1688,
       "source_files": 11
     },
     "metrics": {
@@ -3435,8 +4492,31 @@
       ]
     },
     "errors": [
-      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting rescript implementation at implementations/rescript\n----------------------------------------\nRunning test: Hash Command Baseline \u2713\nRunning test: Hash Command After Move \u2713\nRunning test: Draws Command \u2717\nRunning test: Go Movetime \u2717\nRunning test: PGN Show \u2717\nRunning test: PGN Fixture Morphy \u2717\nRunning test: PGN Fixture Byrne-Fischer \u2717\nRunning test: Book Load Stats \u2717\nRunning test: Book AI Move \u2717\nRunning test: UCI Handshake"
+      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting rescript implementation at implementations/rescript\n----------------------------------------\nRunning test: Hash Command Baseline ✓\nRunning test: Hash Command After Move ✓\nRunning test: Draws Command ✗\nRunning test: Go Movetime ✗\nRunning test: PGN Show ✗\nRunning test: PGN Fixture Morphy ✗\nRunning test: PGN Fixture Byrne-Fischer ✗\nRunning test: Book Load Stats ✗\nRunning test: Book AI Move ✗\nRunning test: UCI Handshake"
     ],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 4903.75,
+      "total_tokens": 6701,
+      "semantic_tokens": 6685,
+      "by_category": {
+        "keyword": 695,
+        "identifier": 2732,
+        "type": 298,
+        "operator": 1113,
+        "literal": 642,
+        "punctuation": 1205,
+        "comment": 16,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.104,
+        "comment_ratio": 0.002,
+        "punctuation_ratio": 0.18,
+        "complexity_per_loc": 2.91,
+        "complexity_per_file": 445.8
+      }
+    }
   }
 ]

--- a/reports/php.json
+++ b/reports/php.json
@@ -43,7 +43,7 @@
         "memory_mb": 116.51171875,
         "peak_memory_mb": 116.51171875,
         "avg_memory_mb": 92.1982421875,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 4,
         "psutil_available": true
       },
@@ -72,13 +72,13 @@
         "memory_mb": 32.78125,
         "peak_memory_mb": 62.55078125,
         "avg_memory_mb": 61.08642578125,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 128,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 3435,
+      "source_loc": 3445,
       "source_files": 10
     },
     "metrics": {
@@ -86,7 +86,7 @@
       "metric_version": "tokens-v2"
     },
     "normalized": {
-      "build_ms_per_kloc": 0.0,
+      "build_ms_per_kloc": 0,
       "analyze_ms_per_kloc": 81.70642880546647,
       "runtime_ms_per_kloc": 48.80626128750597
     },
@@ -138,6 +138,29 @@
       "failed": []
     },
     "errors": [],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 9808.25,
+      "total_tokens": 15321,
+      "semantic_tokens": 15076,
+      "by_category": {
+        "keyword": 1535,
+        "identifier": 4571,
+        "type": 21,
+        "operator": 3200,
+        "literal": 2576,
+        "punctuation": 3173,
+        "comment": 245,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.102,
+        "comment_ratio": 0.016,
+        "punctuation_ratio": 0.21,
+        "complexity_per_loc": 2.85,
+        "complexity_per_file": 980.83
+      }
+    }
   }
 ]

--- a/reports/python.json
+++ b/reports/python.json
@@ -44,7 +44,7 @@
         "memory_mb": 116.7265625,
         "peak_memory_mb": 116.7265625,
         "avg_memory_mb": 100.17643229166667,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 6,
         "psutil_available": true
       },
@@ -73,21 +73,21 @@
         "memory_mb": 32.50390625,
         "peak_memory_mb": 62.2421875,
         "avg_memory_mb": 61.0767578125,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 160,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 3672,
+      "source_loc": 3678,
       "source_files": 13
     },
     "metrics": {
-      "tokens_count": 26928,
+      "tokens_count": 26934,
       "metric_version": "tokens-v2"
     },
     "normalized": {
-      "build_ms_per_kloc": 0.0,
+      "build_ms_per_kloc": 0,
       "analyze_ms_per_kloc": 59.84566050676998,
       "runtime_ms_per_kloc": 51.7470254877294
     },
@@ -139,6 +139,29 @@
       "failed": []
     },
     "errors": [],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 9146.5,
+      "total_tokens": 14587,
+      "semantic_tokens": 14477,
+      "by_category": {
+        "keyword": 1314,
+        "identifier": 3871,
+        "type": 304,
+        "operator": 2004,
+        "literal": 3638,
+        "punctuation": 3346,
+        "comment": 110,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.091,
+        "comment_ratio": 0.008,
+        "punctuation_ratio": 0.231,
+        "complexity_per_loc": 2.49,
+        "complexity_per_file": 703.58
+      }
+    }
   }
 ]

--- a/reports/rescript.json
+++ b/reports/rescript.json
@@ -43,7 +43,7 @@
         "memory_mb": 110.3828125,
         "peak_memory_mb": 110.3828125,
         "avg_memory_mb": 89.6689453125,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 4,
         "psutil_available": true
       },
@@ -72,13 +72,13 @@
         "memory_mb": 32.171875,
         "peak_memory_mb": 62.1796875,
         "avg_memory_mb": 60.217569986979164,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 96,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 1678,
+      "source_loc": 1688,
       "source_files": 11
     },
     "metrics": {
@@ -135,8 +135,31 @@
       ]
     },
     "errors": [
-      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting rescript implementation at implementations/rescript\n----------------------------------------\nRunning test: Hash Command Baseline \u2713\nRunning test: Hash Command After Move \u2713\nRunning test: Draws Command \u2717\nRunning test: Go Movetime \u2717\nRunning test: PGN Show \u2717\nRunning test: PGN Fixture Morphy \u2717\nRunning test: PGN Fixture Byrne-Fischer \u2717\nRunning test: Book Load Stats \u2717\nRunning test: Book AI Move \u2717\nRunning test: UCI Handshake"
+      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting rescript implementation at implementations/rescript\n----------------------------------------\nRunning test: Hash Command Baseline ✓\nRunning test: Hash Command After Move ✓\nRunning test: Draws Command ✗\nRunning test: Go Movetime ✗\nRunning test: PGN Show ✗\nRunning test: PGN Fixture Morphy ✗\nRunning test: PGN Fixture Byrne-Fischer ✗\nRunning test: Book Load Stats ✗\nRunning test: Book AI Move ✗\nRunning test: UCI Handshake"
     ],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 4903.75,
+      "total_tokens": 6701,
+      "semantic_tokens": 6685,
+      "by_category": {
+        "keyword": 695,
+        "identifier": 2732,
+        "type": 298,
+        "operator": 1113,
+        "literal": 642,
+        "punctuation": 1205,
+        "comment": 16,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.104,
+        "comment_ratio": 0.002,
+        "punctuation_ratio": 0.18,
+        "complexity_per_loc": 2.91,
+        "complexity_per_file": 445.8
+      }
+    }
   }
 ]

--- a/reports/ruby.json
+++ b/reports/ruby.json
@@ -43,7 +43,7 @@
         "memory_mb": 116.0703125,
         "peak_memory_mb": 116.0703125,
         "avg_memory_mb": 93.64296875,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 5,
         "psutil_available": true
       },
@@ -72,21 +72,21 @@
         "memory_mb": 32.26171875,
         "peak_memory_mb": 62.1953125,
         "avg_memory_mb": 60.581256734913794,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 116,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 1906,
+      "source_loc": 1908,
       "source_files": 10
     },
     "metrics": {
-      "tokens_count": 9600,
+      "tokens_count": 9603,
       "metric_version": "tokens-v2"
     },
     "normalized": {
-      "build_ms_per_kloc": 0.0,
+      "build_ms_per_kloc": 0,
       "analyze_ms_per_kloc": 1220.912147794165,
       "runtime_ms_per_kloc": 157.0988301840559
     },
@@ -135,8 +135,31 @@
       ]
     },
     "errors": [
-      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting ruby implementation at implementations/ruby\n----------------------------------------\nRunning test: Hash Command Baseline \u2713\nRunning test: Hash Command After Move \u2713\nRunning test: Draws Command \u2717\nRunning test: Go Movetime \u2717\nRunning test: PGN Show \u2717\nRunning test: PGN Fixture Morphy \u2717\nRunning test: PGN Fixture Byrne-Fischer \u2717\nRunning test: Book Load Stats \u2717\nRunning test: Book AI Move \u2717\nRunning test: UCI Handshake \u2717\nRunni"
+      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting ruby implementation at implementations/ruby\n----------------------------------------\nRunning test: Hash Command Baseline ✓\nRunning test: Hash Command After Move ✓\nRunning test: Draws Command ✗\nRunning test: Go Movetime ✗\nRunning test: PGN Show ✗\nRunning test: PGN Fixture Morphy ✗\nRunning test: PGN Fixture Byrne-Fischer ✗\nRunning test: Book Load Stats ✗\nRunning test: Book AI Move ✗\nRunning test: UCI Handshake ✗\nRunni"
     ],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 4133.25,
+      "total_tokens": 5810,
+      "semantic_tokens": 5713,
+      "by_category": {
+        "keyword": 821,
+        "identifier": 2142,
+        "type": 23,
+        "operator": 816,
+        "literal": 1046,
+        "punctuation": 865,
+        "comment": 97,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.144,
+        "comment_ratio": 0.017,
+        "punctuation_ratio": 0.151,
+        "complexity_per_loc": 2.17,
+        "complexity_per_file": 413.33
+      }
+    }
   }
 ]

--- a/reports/rust.json
+++ b/reports/rust.json
@@ -42,7 +42,7 @@
         "memory_mb": 111.58203125,
         "peak_memory_mb": 111.58203125,
         "avg_memory_mb": 90.685546875,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 4,
         "psutil_available": true
       },
@@ -69,15 +69,15 @@
       },
       "test_chess_engine": {
         "memory_mb": 32.31640625,
-        "peak_memory_mb": 62.0,
+        "peak_memory_mb": 62,
         "avg_memory_mb": 60.037582236842105,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 95,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 1852,
+      "source_loc": 1854,
       "source_files": 9
     },
     "metrics": {
@@ -134,8 +134,31 @@
       ]
     },
     "errors": [
-      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting rust implementation at implementations/rust\n----------------------------------------\nRunning test: Hash Command Baseline \u2713\nRunning test: Hash Command After Move \u2713\nRunning test: Draws Command \u2717\nRunning test: Go Movetime \u2717\nRunning test: PGN Show \u2717\nRunning test: PGN Fixture Morphy \u2717\nRunning test: PGN Fixture Byrne-Fischer \u2717\nRunning test: Book Load Stats \u2717\nRunning test: Book AI Move \u2717\nRunning test: UCI Handshake \u2717\nRunni"
+      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting rust implementation at implementations/rust\n----------------------------------------\nRunning test: Hash Command Baseline ✓\nRunning test: Hash Command After Move ✓\nRunning test: Draws Command ✗\nRunning test: Go Movetime ✗\nRunning test: PGN Show ✗\nRunning test: PGN Fixture Morphy ✗\nRunning test: PGN Fixture Byrne-Fischer ✗\nRunning test: Book Load Stats ✗\nRunning test: Book AI Move ✗\nRunning test: UCI Handshake ✗\nRunni"
     ],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 6761,
+      "total_tokens": 9569,
+      "semantic_tokens": 9513,
+      "by_category": {
+        "keyword": 963,
+        "identifier": 3103,
+        "type": 807,
+        "operator": 2300,
+        "literal": 612,
+        "punctuation": 1728,
+        "comment": 56,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.101,
+        "comment_ratio": 0.006,
+        "punctuation_ratio": 0.182,
+        "complexity_per_loc": 3.65,
+        "complexity_per_file": 751.22
+      }
+    }
   }
 ]

--- a/reports/swift.json
+++ b/reports/swift.json
@@ -42,7 +42,7 @@
         "memory_mb": 115.7578125,
         "peak_memory_mb": 115.7578125,
         "avg_memory_mb": 100.23763020833333,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 6,
         "psutil_available": true
       },
@@ -69,7 +69,7 @@
       }
     },
     "size": {
-      "source_loc": 929,
+      "source_loc": 932,
       "source_files": 3
     },
     "metrics": {
@@ -128,6 +128,29 @@
     "errors": [
       "track v2-full suite timeout after 180.1s"
     ],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 3387,
+      "total_tokens": 4654,
+      "semantic_tokens": 4614,
+      "by_category": {
+        "keyword": 486,
+        "identifier": 1926,
+        "type": 120,
+        "operator": 747,
+        "literal": 591,
+        "punctuation": 744,
+        "comment": 40,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.105,
+        "comment_ratio": 0.009,
+        "punctuation_ratio": 0.161,
+        "complexity_per_loc": 3.63,
+        "complexity_per_file": 1129
+      }
+    }
   }
 ]

--- a/reports/typescript.json
+++ b/reports/typescript.json
@@ -43,7 +43,7 @@
         "memory_mb": 17.4921875,
         "peak_memory_mb": 110.98046875,
         "avg_memory_mb": 67.3212890625,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 4,
         "psutil_available": true
       },
@@ -72,17 +72,17 @@
         "memory_mb": 31.9375,
         "peak_memory_mb": 61.9140625,
         "avg_memory_mb": 59.93112664473684,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 95,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 1838,
-      "source_files": 11
+      "source_loc": 2038,
+      "source_files": 21
     },
     "metrics": {
-      "tokens_count": 13192,
+      "tokens_count": 14364,
       "metric_version": "tokens-v2"
     },
     "normalized": {
@@ -135,8 +135,31 @@
       ]
     },
     "errors": [
-      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting typescript implementation at implementations/typescript\n----------------------------------------\nRunning test: Hash Command Baseline \u2713\nRunning test: Hash Command After Move \u2713\nRunning test: Draws Command \u2717\nRunning test: Go Movetime \u2717\nRunning test: PGN Show \u2717\nRunning test: PGN Fixture Morphy \u2717\nRunning test: PGN Fixture Byrne-Fischer \u2717\nRunning test: Book Load Stats \u2717\nRunning test: Book AI Move \u2717\nRunning test: UCI Hands"
+      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting typescript implementation at implementations/typescript\n----------------------------------------\nRunning test: Hash Command Baseline ✓\nRunning test: Hash Command After Move ✓\nRunning test: Draws Command ✗\nRunning test: Go Movetime ✗\nRunning test: PGN Show ✗\nRunning test: PGN Fixture Morphy ✗\nRunning test: PGN Fixture Byrne-Fischer ✗\nRunning test: Book Load Stats ✗\nRunning test: Book AI Move ✗\nRunning test: UCI Hands"
     ],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 6211,
+      "total_tokens": 9433,
+      "semantic_tokens": 9409,
+      "by_category": {
+        "keyword": 1012,
+        "identifier": 2767,
+        "type": 425,
+        "operator": 1445,
+        "literal": 1378,
+        "punctuation": 2382,
+        "comment": 24,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.108,
+        "comment_ratio": 0.003,
+        "punctuation_ratio": 0.253,
+        "complexity_per_loc": 3.05,
+        "complexity_per_file": 295.76
+      }
+    }
   }
 ]

--- a/reports/zig.json
+++ b/reports/zig.json
@@ -42,7 +42,7 @@
         "memory_mb": 111.0546875,
         "peak_memory_mb": 111.0546875,
         "avg_memory_mb": 90.814453125,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 4,
         "psutil_available": true
       },
@@ -71,13 +71,13 @@
         "memory_mb": 32.1015625,
         "peak_memory_mb": 61.96484375,
         "avg_memory_mb": 61.59710122526978,
-        "avg_cpu_percent": 0.0,
+        "avg_cpu_percent": 0,
         "samples": 556,
         "psutil_available": true
       }
     },
     "size": {
-      "source_loc": 1625,
+      "source_loc": 1633,
       "source_files": 8
     },
     "metrics": {
@@ -134,8 +134,31 @@
       ]
     },
     "errors": [
-      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting zig implementation at implementations/zig\n----------------------------------------\nRunning test: Hash Command Baseline \u2717\nRunning test: Hash Command After Move \u2717\nRunning test: Draws Command \u2717\nRunning test: Go Movetime \u2717\nRunning test: PGN Show \u2717\nRunning test: PGN Fixture Morphy \u2717\nRunning test: PGN Fixture Byrne-Fischer \u2717\nRunning test: Book Load Stats \u2717\nRunning test: Book AI Move \u2717\nRunning test: UCI Handshake \u2717\nRunning"
+      "track v2-full suite failed: Found 1 implementation(s)\nLoaded 16 tests from test/suites/v2_full.json\n\nTesting zig implementation at implementations/zig\n----------------------------------------\nRunning test: Hash Command Baseline ✗\nRunning test: Hash Command After Move ✗\nRunning test: Draws Command ✗\nRunning test: Go Movetime ✗\nRunning test: PGN Show ✗\nRunning test: PGN Fixture Morphy ✗\nRunning test: PGN Fixture Byrne-Fischer ✗\nRunning test: Book Load Stats ✗\nRunning test: Book AI Move ✗\nRunning test: UCI Handshake ✗\nRunning"
     ],
-    "status": "completed"
+    "status": "completed",
+    "semantic_metrics": {
+      "metric_version": "tokens-v3",
+      "complexity_score": 8232.75,
+      "total_tokens": 10783,
+      "semantic_tokens": 10670,
+      "by_category": {
+        "keyword": 1300,
+        "identifier": 5510,
+        "type": 17,
+        "operator": 1100,
+        "literal": 680,
+        "punctuation": 2063,
+        "comment": 113,
+        "unknown": 0
+      },
+      "ratios": {
+        "keyword_density": 0.122,
+        "comment_ratio": 0.01,
+        "punctuation_ratio": 0.193,
+        "complexity_per_loc": 5.04,
+        "complexity_per_file": 1029.09
+      }
+    }
   }
 ]

--- a/test/README_PERFORMANCE_TESTING.md
+++ b/test/README_PERFORMANCE_TESTING.md
@@ -13,6 +13,7 @@ Useful variants:
 ./workflow benchmark-stress --track v2-full --profile full
 ./workflow benchmark-concurrency --impl implementations/rust --profile quick
 ./workflow code-size-metrics --impl implementations/rust
+./workflow refresh-report-metrics
 ```
 
 The benchmark JSON keeps `tokens-v2` under `metrics` and adds optional `tokens-v3` semantic data under `semantic_metrics`.

--- a/test/refresh_report_metrics.test.ts
+++ b/test/refresh_report_metrics.test.ts
@@ -1,0 +1,68 @@
+import { join } from "node:path";
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { makeTempDir, removePath, readJsonFile, writeJsonFile } from "../tooling/shared.ts";
+import { refreshSemanticReportMetrics } from "../tooling/refresh-report-metrics.ts";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      await removePath(dir);
+    }
+  }
+});
+
+describe("refresh report metrics", () => {
+  test("enriches per-implementation reports and performance_data with semantic metrics", async () => {
+    const reportDir = makeTempDir("tgac-refresh-report-metrics-");
+    tempDirs.push(reportDir);
+
+    await writeJsonFile(join(reportDir, "python.json"), [
+      {
+        language: "python",
+        path: "implementations/python",
+        metrics: {
+          tokens_count: 1,
+          metric_version: "tokens-v2",
+        },
+        semantic_metrics: null,
+      },
+    ]);
+
+    await writeJsonFile(join(reportDir, "performance_data.json"), [
+      {
+        language: "python",
+        path: "implementations/python",
+        metrics: {
+          tokens_count: 1,
+          metric_version: "tokens-v2",
+        },
+        semantic_metrics: null,
+      },
+      {
+        implementation: "missing-language",
+        payload: null,
+      },
+    ]);
+
+    const stats = await refreshSemanticReportMetrics(reportDir);
+    expect(stats.filesTouched).toBe(2);
+    expect(stats.entriesUpdated).toBe(2);
+    expect(stats.entriesSkipped).toBe(1);
+
+    const pythonReport = await readJsonFile<any[]>(join(reportDir, "python.json"));
+    expect(pythonReport[0].size.source_loc).toBeGreaterThan(0);
+    expect(pythonReport[0].metrics.tokens_count).toBeGreaterThan(0);
+    expect(pythonReport[0].semantic_metrics.metric_version).toBe("tokens-v3");
+    expect(pythonReport[0].semantic_metrics.complexity_score).toBeGreaterThan(0);
+
+    const performanceData = await readJsonFile<any[]>(join(reportDir, "performance_data.json"));
+    expect(performanceData[0].size.source_files).toBeGreaterThan(0);
+    expect(performanceData[0].semantic_metrics.semantic_tokens).toBeGreaterThan(0);
+    expect(performanceData[1].semantic_metrics ?? null).toBeNull();
+  });
+});

--- a/tooling/cli.ts
+++ b/tooling/cli.ts
@@ -37,6 +37,7 @@ import { runUpdateReadme } from "./update-readme.ts";
 import { triageIssue } from "./issue-triage.ts";
 import { runSemanticTokensCli } from "./semantic-tokens.ts";
 import { runCodeSizeMetricsCli } from "./code-size-metrics.ts";
+import { runRefreshReportMetricsCli } from "./refresh-report-metrics.ts";
 
 async function runMetadataPhaseCli(args: string[]): Promise<number> {
   const { values } = parseArgs({
@@ -167,6 +168,7 @@ function helpText(): string {
     "  check-statistics-freshness",
     "  semantic-tokens",
     "  code-size-metrics",
+    "  refresh-report-metrics",
     "",
     "CI/public commands:",
     "  detect-changes",
@@ -325,6 +327,10 @@ export async function main(argv: string[]): Promise<number> {
 
   if (command === "code-size-metrics") {
     return await runCodeSizeMetricsCli(args);
+  }
+
+  if (command === "refresh-report-metrics") {
+    return await runRefreshReportMetricsCli(args);
   }
 
   if (command === "benchmark-stress" || command === "run-benchmark") {

--- a/tooling/refresh-report-metrics.ts
+++ b/tooling/refresh-report-metrics.ts
@@ -1,0 +1,153 @@
+import { basename, join, resolve } from "node:path";
+import { existsSync } from "node:fs";
+import { parseArgs } from "node:util";
+
+import { collectCodeSizeMetricsForImpl } from "./code-size-metrics.ts";
+import {
+  IMPLEMENTATIONS_DIR,
+  REPO_ROOT,
+  REPORTS_DIR,
+  readJsonFile,
+  writeJsonFile,
+} from "./shared.ts";
+
+function resolveImplementationPath(entry: Record<string, unknown>, fallbackName: string | null = null): string | null {
+  const pathCandidates: string[] = [];
+  if (typeof entry.path === "string" && entry.path.trim() !== "") {
+    pathCandidates.push(resolve(REPO_ROOT, entry.path));
+  }
+
+  for (const candidate of pathCandidates) {
+    if (existsSync(candidate) && existsSync(join(candidate, "Dockerfile"))) {
+      return candidate;
+    }
+  }
+
+  const nameCandidates = [
+    typeof entry.implementation === "string" ? entry.implementation : null,
+    typeof entry.language === "string" ? entry.language : null,
+    fallbackName,
+  ].filter((value): value is string => typeof value === "string" && value.trim() !== "");
+
+  for (const name of nameCandidates) {
+    const implPath = join(IMPLEMENTATIONS_DIR, name.toLowerCase());
+    if (existsSync(implPath) && existsSync(join(implPath, "Dockerfile"))) {
+      return implPath;
+    }
+  }
+
+  return null;
+}
+
+function fallbackNameForReportFile(file: string): string | null {
+  const stem = basename(file, ".json");
+  if (stem === "performance_data" || stem.endsWith("-concurrency")) {
+    return null;
+  }
+  return stem;
+}
+
+type RefreshStats = {
+  filesTouched: number;
+  entriesUpdated: number;
+  entriesSkipped: number;
+};
+
+export async function refreshSemanticReportMetrics(reportDir = REPORTS_DIR): Promise<RefreshStats> {
+  const stats: RefreshStats = {
+    filesTouched: 0,
+    entriesUpdated: 0,
+    entriesSkipped: 0,
+  };
+  const metricCache = new Map<string, Promise<Record<string, unknown>>>();
+
+  async function loadMetricsForImpl(implPath: string): Promise<Record<string, unknown>> {
+    if (!metricCache.has(implPath)) {
+      metricCache.set(implPath, collectCodeSizeMetricsForImpl(implPath));
+    }
+    return await metricCache.get(implPath)!;
+  }
+
+  async function refreshEntry(entry: unknown, fallbackName: string | null): Promise<unknown> {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      stats.entriesSkipped += 1;
+      return entry;
+    }
+
+    const typedEntry = entry as Record<string, unknown>;
+    const implPath = resolveImplementationPath(typedEntry, fallbackName);
+    if (!implPath) {
+      stats.entriesSkipped += 1;
+      return typedEntry;
+    }
+
+    const metrics = await loadMetricsForImpl(implPath);
+    const updated = { ...typedEntry };
+    updated.size = {
+      ...(typeof typedEntry.size === "object" && typedEntry.size ? typedEntry.size as Record<string, unknown> : {}),
+      source_loc: metrics.source_loc ?? null,
+      source_files: metrics.source_files ?? null,
+    };
+    updated.metrics = {
+      ...(typeof typedEntry.metrics === "object" && typedEntry.metrics ? typedEntry.metrics as Record<string, unknown> : {}),
+      tokens_count: metrics.tokens_count ?? null,
+      metric_version: metrics.metric_version ?? null,
+    };
+    updated.semantic_metrics = metrics.semantic_metrics ?? null;
+    stats.entriesUpdated += 1;
+    return updated;
+  }
+
+  const reportFiles = [
+    "performance_data.json",
+    ...await (async () => {
+      const files: string[] = [];
+      const glob = new Bun.Glob("*.json");
+      for await (const file of glob.scan({ cwd: reportDir, onlyFiles: true })) {
+        if (file === "performance_data.json" || file.endsWith("-concurrency.json")) {
+          continue;
+        }
+        files.push(file);
+      }
+      return files.sort();
+    })(),
+  ];
+
+  for (const file of reportFiles) {
+    const filePath = join(reportDir, file);
+    if (!existsSync(filePath)) {
+      continue;
+    }
+
+    const fallbackName = fallbackNameForReportFile(file);
+    const data = await readJsonFile<unknown>(filePath);
+    const refreshed = Array.isArray(data)
+      ? await Promise.all(data.map((entry) => refreshEntry(entry, fallbackName)))
+      : await refreshEntry(data, fallbackName);
+
+    if (JSON.stringify(data) === JSON.stringify(refreshed)) {
+      continue;
+    }
+
+    await writeJsonFile(filePath, refreshed);
+    stats.filesTouched += 1;
+  }
+
+  return stats;
+}
+
+export async function runRefreshReportMetricsCli(args: string[]): Promise<number> {
+  const { values } = parseArgs({
+    args,
+    options: {
+      "report-dir": { type: "string" },
+    },
+  });
+
+  const reportDir = values["report-dir"] ? resolve(values["report-dir"]) : REPORTS_DIR;
+  const stats = await refreshSemanticReportMetrics(reportDir);
+  console.log(
+    `✅ Refreshed report metrics in ${stats.filesTouched} file(s); updated ${stats.entriesUpdated} entr${stats.entriesUpdated === 1 ? "y" : "ies"}, skipped ${stats.entriesSkipped}.`,
+  );
+  return 0;
+}

--- a/tooling/update-readme.ts
+++ b/tooling/update-readme.ts
@@ -4,8 +4,6 @@ import { existsSync } from "node:fs";
 import {
   IMPLEMENTATIONS_DIR,
   REPO_ROOT,
-  TOKEN_METRIC_VERSION,
-  collectImplMetricsFromMetadata,
   discoverImplementationDirs,
   formatGroupedInt,
   formatStepMetric,
@@ -17,6 +15,7 @@ import {
   writeGithubOutput,
   writeTextFile,
 } from "./shared.ts";
+import { collectCodeSizeMetricsForImpl } from "./code-size-metrics.ts";
 import { verifyImplementation } from "./verify.ts";
 
 const CUSTOM_EMOJIS: Record<string, string> = {
@@ -164,6 +163,45 @@ function formatFeatureSummary(metadata: Record<string, unknown>): string {
   return `${matchedCount}/${catalog.length}`;
 }
 
+function formatGroupedNumber(value: number | null | undefined): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return "-";
+  }
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 }).format(value);
+}
+
+interface LocalMetricSnapshot {
+  sourceLoc: number | null;
+  complexityScore: number | null;
+}
+
+const localMetricCache = new Map<string, Promise<LocalMetricSnapshot>>();
+
+async function getLocalMetricSnapshot(implPath: string, language: string): Promise<LocalMetricSnapshot> {
+  if (!localMetricCache.has(implPath)) {
+    localMetricCache.set(implPath, (async () => {
+      try {
+        const localMetrics = await collectCodeSizeMetricsForImpl(implPath);
+        const semantic = (
+          localMetrics.semantic_metrics &&
+          typeof localMetrics.semantic_metrics === "object" &&
+          typeof (localMetrics.semantic_metrics as Record<string, unknown>).complexity_score === "number"
+        )
+          ? localMetrics.semantic_metrics as Record<string, unknown>
+          : null;
+        return {
+          sourceLoc: Number.isInteger(localMetrics.source_loc) ? Number(localMetrics.source_loc) : null,
+          complexityScore: semantic ? Number(semantic.complexity_score) : null,
+        };
+      } catch (error) {
+        console.log(`⚠️ ${language}: could not compute local metric fallback: ${error instanceof Error ? error.message : String(error)}`);
+        return { sourceLoc: null, complexityScore: null };
+      }
+    })());
+  }
+  return await localMetricCache.get(implPath)!;
+}
+
 async function loadPerformanceData(): Promise<Record<string, any>[]> {
   const reportsDir = join(REPO_ROOT, "reports");
   if (!existsSync(reportsDir)) {
@@ -197,25 +235,28 @@ async function getVerificationStatus(): Promise<Record<string, string>> {
   return status;
 }
 
-async function resolveTokensCount(implData: Record<string, any>, implPath: string, metadata: Record<string, unknown>, language: string): Promise<number | null> {
-  const metrics = implData.metrics ?? {};
-  if (Number.isInteger(metrics.tokens_count) && metrics.tokens_count >= 0) {
-    if (metrics.metric_version && metrics.metric_version !== TOKEN_METRIC_VERSION) {
-      console.log(`⚠️ ${language}: metric version is ${metrics.metric_version}, expected ${TOKEN_METRIC_VERSION}. Using reported value anyway.`);
-    }
-    return metrics.tokens_count;
+async function resolveSourceLoc(implData: Record<string, any>, implPath: string, language: string): Promise<number | null> {
+  const size = implData.size ?? {};
+  if (Number.isInteger(size.source_loc) && size.source_loc >= 0) {
+    return Number(size.source_loc);
   }
-  try {
-    const localMetrics = await collectImplMetricsFromMetadata(implPath, metadata);
-    const localTokens = localMetrics.tokens_count;
-    if (Number.isInteger(localTokens) && localTokens >= 0) {
-      console.log(`⚠️ ${language}: missing report TOKENS, using local fallback (${TOKEN_METRIC_VERSION})`);
-      return Number(localTokens);
-    }
-  } catch (error) {
-    console.log(`⚠️ ${language}: could not compute TOKENS fallback: ${error instanceof Error ? error.message : String(error)}`);
+  const local = await getLocalMetricSnapshot(implPath, language);
+  if (local.sourceLoc != null) {
+    console.log(`⚠️ ${language}: missing report LOC, using local fallback`);
   }
-  return null;
+  return local.sourceLoc;
+}
+
+async function resolveComplexityScore(implData: Record<string, any>, implPath: string, language: string): Promise<number | null> {
+  const semantic = implData.semantic_metrics ?? {};
+  if (typeof semantic.complexity_score === "number" && Number.isFinite(semantic.complexity_score)) {
+    return Number(semantic.complexity_score);
+  }
+  const local = await getLocalMetricSnapshot(implPath, language);
+  if (local.complexityScore != null) {
+    console.log(`⚠️ ${language}: missing report semantic metrics, using local fallback`);
+  }
+  return local.complexityScore;
 }
 
 function resolveTestChessEngineSeconds(implData: Record<string, any>): number | null {
@@ -276,7 +317,8 @@ export async function updateReadmeStatusTable(): Promise<boolean> {
     const implData = combinedData.get(language) ?? {};
     const implPath = join(IMPLEMENTATIONS_DIR, language);
     const metadata = await getMetadata(implPath);
-    const tokensCount = await resolveTokensCount(implData, implPath, metadata, language);
+    const complexityScore = await resolveComplexityScore(implData, implPath, language);
+    const sourceLoc = await resolveSourceLoc(implData, implPath, language);
     const entrypointFile = await resolveEntrypointFile(implPath, language, metadata);
     const status = verificationData[language] ?? "needs_work";
     const emoji = status === "excellent" ? "🟢" : status === "good" ? "🟡" : "🔴";
@@ -293,23 +335,24 @@ export async function updateReadmeStatusTable(): Promise<boolean> {
     const testMemory = Number(memory.test?.peak_memory_mb ?? 0);
     const ceMemory = Number(memory.test_chess_engine?.peak_memory_mb ?? 0);
 
-    let tokensDisplay = "-";
-    if (typeof tokensCount === "number" && tokensCount >= 0) {
-      tokensDisplay = formatGroupedInt(tokensCount);
+    let complexityDisplay = "-";
+    if (typeof complexityScore === "number" && Number.isFinite(complexityScore)) {
+      complexityDisplay = formatGroupedNumber(complexityScore);
     }
-    if (entrypointFile && typeof tokensCount === "number" && tokensCount >= 0) {
+    if (entrypointFile && typeof complexityScore === "number" && Number.isFinite(complexityScore)) {
       const repoPath = normalizeRelPath(relative(REPO_ROOT, join(implPath, entrypointFile)));
-      tokensDisplay = `[${formatGroupedInt(tokensCount)}](${repoPath})`;
+      complexityDisplay = `[${formatGroupedNumber(complexityScore)}](${repoPath})`;
     }
+    const locDisplay = sourceLoc == null ? "-" : formatGroupedInt(sourceLoc);
 
     rows.push(
-      `| ${languageEmoji} ${language.charAt(0).toUpperCase()}${language.slice(1)} | ${tokensDisplay} | ${formatStepMetric(buildStep, buildMemory)} | ${formatStepMetric(analyzeStep, analyzeMemory)} | ${formatStepMetric(testStep, testMemory)} | ${formatStepMetric(ceStep, ceMemory)} | ${emoji} ${formatFeatureSummary(metadata)} |`,
+      `| ${languageEmoji} ${language.charAt(0).toUpperCase()}${language.slice(1)} | ${complexityDisplay} | ${locDisplay} | ${formatStepMetric(buildStep, buildMemory)} | ${formatStepMetric(analyzeStep, analyzeMemory)} | ${formatStepMetric(testStep, testMemory)} | ${formatStepMetric(ceStep, ceMemory)} | ${emoji} ${formatFeatureSummary(metadata)} |`,
     );
   }
 
   const newTable = [
-    "| Language | TOKENS | make build | make analyze | make test | make test-chess-engine | Features |",
-    "|----------|--------|------------|--------------|-----------|------------------------|----------|",
+    "| Language | Complexity | LOC | make build | make analyze | make test | make test-chess-engine | Features |",
+    "|----------|------------|-----|------------|--------------|-----------|------------------------|----------|",
     ...rows,
   ].join("\n");
 


### PR DESCRIPTION
## Summary
- replace the README `TOKENS` column with semantic `tokens-v3` complexity and add `LOC`
- add a reusable `refresh-report-metrics` workflow command to enrich versioned benchmark reports with semantic metrics and refreshed code-size data
- regenerate the versioned report JSON files and refresh the root README matrix

## Validation
- `./workflow refresh-report-metrics`
- `./workflow analyze-tools`
- `bun test test/semantic_tokens.test.ts test/refresh_report_metrics.test.ts`
- `./workflow update-readme`

## Notes
- `./workflow update-readme` is now idempotent after the report refresh pass (`changed=false` on the second run).
- `./workflow validate-results` still reports pre-existing schema mismatches on `*-concurrency.json` artifacts, which are outside the scope of this change.

Fixes #135
