### PR TITLE
feat: bring c and elixir to v2-functional parity

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -70,10 +70,10 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.has-changes == 'true'
     outputs:
-      excellent-count: ${{ steps.verify.outputs.excellent_count }}
-      good-count: ${{ steps.verify.outputs.good_count }}
-      needs-work-count: ${{ steps.verify.outputs.needs_work_count }}
-      total-count: ${{ steps.verify.outputs.total_count }}
+      excellent_count: ${{ steps.verify.outputs.excellent_count }}
+      good_count: ${{ steps.verify.outputs.good_count }}
+      needs_work_count: ${{ steps.verify.outputs.needs_work_count }}
+      total_count: ${{ steps.verify.outputs.total_count }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -316,9 +316,9 @@ jobs:
     needs: [detect-changes, validation, benchmark]
     if: always() && needs.detect-changes.outputs.has-changes == 'true'
     outputs:
-      readme-changed: ${{ steps.update.outputs.changed }}
-      build-error-count: ${{ steps.update.outputs.build-error-count }}
-      build-error-languages: ${{ steps.update.outputs.build-error-languages }}
+      readme_changed: ${{ steps.update.outputs.changed }}
+      build_error_count: ${{ steps.update.outputs.build-error-count }}
+      build_error_languages: ${{ steps.update.outputs.build-error-languages }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -352,7 +352,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     needs: [detect-changes, validation, combine-results]
-    if: needs.combine-results.outputs.readme-changed == 'true' || github.event_name == 'workflow_dispatch'
+    if: always() && (needs.combine-results.outputs.readme_changed == 'true' || github.event_name == 'workflow_dispatch')
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -391,17 +391,17 @@ jobs:
           if [ -z "$VERSION_TYPE" ]; then
             VERSION_TYPE="patch"
           fi
-          BUILD_ERROR_COUNT="${{ needs.combine-results.outputs.build-error-count }}"
+          BUILD_ERROR_COUNT="${{ needs.combine-results.outputs.build_error_count }}"
           if [ -z "$BUILD_ERROR_COUNT" ]; then
             BUILD_ERROR_COUNT="0"
           fi
           ./workflow create-release \
             --version-type "$VERSION_TYPE" \
             --readme-changed "${{ steps.update.outputs.changed }}" \
-            --excellent-count "${{ needs.validation.outputs.excellent-count }}" \
-            --good-count "${{ needs.validation.outputs.good-count }}" \
-            --needs-work-count "${{ needs.validation.outputs.needs-work-count }}" \
-            --total-count "${{ needs.validation.outputs.total-count }}"
+            --excellent-count "${{ needs.validation.outputs.excellent_count }}" \
+            --good-count "${{ needs.validation.outputs.good_count }}" \
+            --needs-work-count "${{ needs.validation.outputs.needs_work_count }}" \
+            --total-count "${{ needs.validation.outputs.total_count }}"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
@@ -415,12 +415,12 @@ jobs:
 
             ## 📊 Implementation Status Overview
 
-            - 🟢 **Excellent**: ${{ needs.validation.outputs.excellent-count }} implementations
-            - 🟡 **Good**: ${{ needs.validation.outputs.good-count }} implementations  
-            - 🔴 **Needs Work**: ${{ needs.validation.outputs.needs-work-count }} implementations
-            - 🚨 **Build errors in benchmark table**: ${{ needs.combine-results.outputs.build-error-count }} implementations
+            - 🟢 **Excellent**: ${{ needs.validation.outputs.excellent_count }} implementations
+            - 🟡 **Good**: ${{ needs.validation.outputs.good_count }} implementations
+            - 🔴 **Needs Work**: ${{ needs.validation.outputs.needs_work_count }} implementations
+            - 🚨 **Build errors in benchmark table**: ${{ needs.combine-results.outputs.build_error_count }} implementations
 
-            **Total**: ${{ needs.validation.outputs.total-count }} implementations tested
+            **Total**: ${{ needs.validation.outputs.total_count }} implementations tested
 
             ## 🚀 What's Updated
 
@@ -513,10 +513,10 @@ jobs:
           else
             echo "## 📊 Results" >> $GITHUB_STEP_SUMMARY
             echo "- **Changed implementations**: $CHANGED_IMPLEMENTATIONS" >> $GITHUB_STEP_SUMMARY
-            echo "- **Total implementations**: ${{ needs.validation.outputs.total-count }}" >> $GITHUB_STEP_SUMMARY
-            echo "- 🟢 **Excellent**: ${{ needs.validation.outputs.excellent-count }}" >> $GITHUB_STEP_SUMMARY
-            echo "- 🟡 **Good**: ${{ needs.validation.outputs.good-count }}" >> $GITHUB_STEP_SUMMARY
-            echo "- 🔴 **Needs work**: ${{ needs.validation.outputs.needs-work-count }}" >> $GITHUB_STEP_SUMMARY
+            echo "- **Total implementations**: ${{ needs.validation.outputs.total_count }}" >> $GITHUB_STEP_SUMMARY
+            echo "- 🟢 **Excellent**: ${{ needs.validation.outputs.excellent_count }}" >> $GITHUB_STEP_SUMMARY
+            echo "- 🟡 **Good**: ${{ needs.validation.outputs.good_count }}" >> $GITHUB_STEP_SUMMARY
+            echo "- 🔴 **Needs work**: ${{ needs.validation.outputs.needs_work_count }}" >> $GITHUB_STEP_SUMMARY
             echo "- ⚙️ **Core benchmark matrix**: ${{ needs.benchmark.result }}" >> $GITHUB_STEP_SUMMARY
             echo "- 🔥 **Stress benchmark lane**: informational" >> $GITHUB_STEP_SUMMARY
             echo "- 🔥 **Stress benchmark failures**: ${STRESS_FAILURE_COUNT}" >> $GITHUB_STEP_SUMMARY
@@ -528,12 +528,12 @@ jobs:
             if [[ -n "$CONCURRENCY_FAILURES" ]]; then
               echo "- **Failing concurrency implementations**: ${CONCURRENCY_FAILURES}" >> $GITHUB_STEP_SUMMARY
             fi
-            echo "- 🚨 **Build errors in README benchmark table**: ${{ needs.combine-results.outputs.build-error-count }}" >> $GITHUB_STEP_SUMMARY
-            if [[ -n "${{ needs.combine-results.outputs.build-error-languages }}" ]]; then
-              echo "- **Build error implementations**: ${{ needs.combine-results.outputs.build-error-languages }}" >> $GITHUB_STEP_SUMMARY
+            echo "- 🚨 **Build errors in README benchmark table**: ${{ needs.combine-results.outputs.build_error_count }}" >> $GITHUB_STEP_SUMMARY
+            if [[ -n "${{ needs.combine-results.outputs.build_error_languages }}" ]]; then
+              echo "- **Build error implementations**: ${{ needs.combine-results.outputs.build_error_languages }}" >> $GITHUB_STEP_SUMMARY
             fi
             echo "" >> $GITHUB_STEP_SUMMARY
-            if [[ "${{ needs.combine-results.outputs.build-error-count }}" != "0" && -n "${{ needs.combine-results.outputs.build-error-count }}" ]]; then
+            if [[ "${{ needs.combine-results.outputs.build_error_count }}" != "0" && -n "${{ needs.combine-results.outputs.build_error_count }}" ]]; then
               echo "⚠️ Core benchmark publication succeeded, with build errors reported in the README table." >> $GITHUB_STEP_SUMMARY
             elif [[ "$STRESS_FAILURE_COUNT" != "0" || "$CONCURRENCY_FAILURE_COUNT" != "0" ]]; then
               echo "⚠️ Core benchmark publication succeeded, with informational stress/concurrency failures listed above." >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ All implementations target parity for core features: `perft`, `fen`, `ai`, `cast
 <!-- status-table-start -->
 | Language | Complexity | LOC | make build | make analyze | make test | make test-chess-engine | Features |
 |----------|------------|-----|------------|--------------|-----------|------------------------|----------|
-| 📦 C | - | 1,511 | - | - | - | - | 🟢 6/9 |
+| 📦 C | - | 1,511 | - | - | - | - | 🟢 9/9 |
 | 💠 Crystal | [5,399.5](implementations/crystal/src/chess_engine.cr) | 2,232 | 4.2s, - MB | 890ms, - MB | 7.4s, - MB | 6m 01s, - MB | 🟢 9/9 |
 | 🎯 Dart | [10,100.25](implementations/dart/bin/main.dart) | 3,308 | 195ms, 5 MB | 185ms, 5 MB | 190ms, 5 MB | 10.5s, 62 MB | 🟡 9/9 |
-| 💧 Elixir | - | 1,348 | - | - | - | - | 🟢 6/9 |
+| 💧 Elixir | - | 1,348 | - | - | - | - | 🟢 9/9 |
 | 🌳 Elm | [4,481.25](implementations/elm/src/ChessEngine.elm) | 1,543 | 756ms, - MB | 566ms, - MB | 821ms, - MB | 6m 01s, - MB | 🟢 9/9 |
 | ✨ Gleam | [27,937](implementations/gleam/src/chess_engine.gleam) | 14,964 | 265ms, 6 MB | 335ms, 7 MB | 770ms, 56 MB | 10s, 63 MB | 🟢 9/9 |
 | 🐹 Go | [9,967.5](implementations/go/chess.go) | 3,919 | 546ms, 87 MB | 1.2s, 112 MB | 1.1s, 128 MB | 10.5s, 62 MB | 🟢 9/9 |

--- a/implementations/c/Dockerfile
+++ b/implementations/c/Dockerfile
@@ -8,7 +8,7 @@ RUN make build
 LABEL org.chess.language="c"
 LABEL org.chess.version="C11"
 LABEL org.chess.author="AI Implementation"
-LABEL org.chess.features="perft,fen,ai,castling,en_passant,promotion"
+LABEL org.chess.features="perft,fen,ai,castling,en_passant,promotion,pgn,uci,chess960"
 LABEL org.chess.max_ai_depth=5
 LABEL org.chess.estimated_perft4_ms=700
 LABEL org.chess.source_exts=".c,.h"

--- a/implementations/c/README.md
+++ b/implementations/c/README.md
@@ -1,6 +1,6 @@
 # C Chess Engine
 
-C implementation of the shared `v1` chess engine specification.
+C implementation of the shared `v1` chess engine specification with the current `v2-functional` extensions for PGN, UCI handshake, and Chess960 metadata commands.
 
 ## Highlights
 
@@ -9,6 +9,9 @@ C implementation of the shared `v1` chess engine specification.
 - FEN import/export
 - Alpha-beta minimax AI (depth 1..5)
 - Snapshot-based undo and repetition tracking
+- PGN `load`, `show`, and `moves`
+- UCI `uci` / `isready`
+- Chess960 `new960` / `position960`
 - Docker-first build and validation
 
 ## Repository Workflow
@@ -21,6 +24,7 @@ make build DIR=c
 make analyze DIR=c
 make test DIR=c
 make test-chess-engine DIR=c
+make test-chess-engine DIR=c TRACK=v2-functional
 ```
 
 ## Commands
@@ -37,6 +41,13 @@ make test-chess-engine DIR=c
 - `history`
 - `ai <depth>`
 - `perft <depth>`
+- `pgn load <file>`
+- `pgn show`
+- `pgn moves`
+- `uci`
+- `isready`
+- `new960 [id]`
+- `position960`
 - `help`
 - `quit`
 

--- a/implementations/c/src/chess.c
+++ b/implementations/c/src/chess.c
@@ -13,6 +13,13 @@
 #define MAX_HISTORY 2048
 #define MAX_POSITIONS 4096
 #define FEN_BUFFER_SIZE 128
+#define PGN_SAN_SIZE 32
+#define PGN_RESULT_SIZE 16
+#define PGN_TAG_NAME_SIZE 32
+#define PGN_TAG_VALUE_SIZE 256
+#define PGN_SOURCE_SIZE 512
+#define MAX_PGN_TAGS 32
+#define START_FEN "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 #define MATE_SCORE 100000
 #define INF_SCORE 1000000000
 
@@ -43,11 +50,39 @@ typedef struct {
 } MoveList;
 
 typedef struct {
+    char name[PGN_TAG_NAME_SIZE];
+    char value[PGN_TAG_VALUE_SIZE];
+} PgnTag;
+
+typedef struct {
+    char san[PGN_SAN_SIZE];
+    Move move;
+    char fen_before[FEN_BUFFER_SIZE];
+    char fen_after[FEN_BUFFER_SIZE];
+} PgnMoveNode;
+
+typedef struct {
+    PgnTag tags[MAX_PGN_TAGS];
+    int tag_count;
+    PgnMoveNode moves[MAX_HISTORY];
+    int move_count;
+    char result[PGN_RESULT_SIZE];
+    char source[PGN_SOURCE_SIZE];
+    char initial_fen[FEN_BUFFER_SIZE];
+} PgnGame;
+
+typedef struct {
     Board board;
     Board history[MAX_HISTORY];
     int history_len;
+    Move move_history[MAX_HISTORY];
+    int move_history_len;
     uint64_t position_history[MAX_POSITIONS];
     int position_count;
+    char initial_fen[FEN_BUFFER_SIZE];
+    PgnGame pgn_game;
+    int chess960_id;
+    bool chess960_mode;
 } Engine;
 
 typedef enum {
@@ -59,6 +94,13 @@ typedef enum {
     STATUS_DRAW_REPETITION,
     STATUS_DRAW_FIFTY,
 } GameStatus;
+
+static GameStatus engine_status(const Engine *engine);
+static void copy_text(char *destination, size_t destination_size, const char *source);
+static void pgn_init_game(PgnGame *game, const char *initial_fen, const char *source);
+static void pgn_set_result(PgnGame *game, const char *result);
+static bool pgn_build_from_history(PgnGame *game, const Move *move_history, int move_count, const char *initial_fen, const char *source);
+static void chess960_fen(int chess960_id, char buffer[FEN_BUFFER_SIZE]);
 
 static const int KNIGHT_DELTAS[8][2] = {
     {-2, -1}, {-2, 1}, {-1, -2}, {-1, 2},
@@ -1111,11 +1153,40 @@ static uint64_t perft(const Board *board, int depth) {
     return nodes;
 }
 
+static const char *result_for_status(GameStatus status) {
+    switch (status) {
+        case STATUS_CHECKMATE_WHITE:
+            return "1-0";
+        case STATUS_CHECKMATE_BLACK:
+            return "0-1";
+        case STATUS_STALEMATE:
+        case STATUS_DRAW_REPETITION:
+        case STATUS_DRAW_FIFTY:
+            return "1/2-1/2";
+        case STATUS_CHECK:
+        case STATUS_ONGOING:
+        default:
+            return "*";
+    }
+}
+
+static void engine_rebuild_pgn(Engine *engine) {
+    const char *source = engine->pgn_game.source[0] != '\0' ? engine->pgn_game.source : "current-game";
+    if (pgn_build_from_history(&engine->pgn_game, engine->move_history, engine->move_history_len, engine->initial_fen, source)) {
+        pgn_set_result(&engine->pgn_game, result_for_status(engine_status(engine)));
+    }
+}
+
 static void engine_init(Engine *engine) {
     board_set_starting_position(&engine->board);
     engine->history_len = 0;
+    engine->move_history_len = 0;
     engine->position_count = 1;
     engine->position_history[0] = board_hash(&engine->board);
+    copy_text(engine->initial_fen, sizeof(engine->initial_fen), START_FEN);
+    engine->chess960_id = 0;
+    engine->chess960_mode = false;
+    pgn_init_game(&engine->pgn_game, START_FEN, "current-game");
 }
 
 static bool engine_store_snapshot(Engine *engine) {
@@ -1127,12 +1198,17 @@ static bool engine_store_snapshot(Engine *engine) {
 }
 
 static bool engine_apply_move(Engine *engine, const Move *move) {
+    if (engine->move_history_len >= MAX_HISTORY) {
+        return false;
+    }
     if (!engine_store_snapshot(engine)) {
         return false;
     }
 
+    engine->move_history[engine->move_history_len++] = *move;
     apply_move(&engine->board, move);
     engine->position_history[engine->position_count++] = board_hash(&engine->board);
+    engine_rebuild_pgn(engine);
     return true;
 }
 
@@ -1143,17 +1219,26 @@ static bool engine_undo(Engine *engine) {
 
     engine->board = engine->history[engine->history_len - 1];
     engine->history_len -= 1;
+    if (engine->move_history_len > 0) {
+        engine->move_history_len -= 1;
+    }
     if (engine->position_count > 1) {
         engine->position_count -= 1;
     }
+    engine_rebuild_pgn(engine);
     return true;
 }
 
 static void engine_reset(Engine *engine) {
     board_set_starting_position(&engine->board);
     engine->history_len = 0;
+    engine->move_history_len = 0;
     engine->position_count = 1;
     engine->position_history[0] = board_hash(&engine->board);
+    copy_text(engine->initial_fen, sizeof(engine->initial_fen), START_FEN);
+    engine->chess960_id = 0;
+    engine->chess960_mode = false;
+    pgn_init_game(&engine->pgn_game, START_FEN, "current-game");
 }
 
 static bool engine_load_position(Engine *engine, const char *fen_string) {
@@ -1161,8 +1246,53 @@ static bool engine_load_position(Engine *engine, const char *fen_string) {
         return false;
     }
     engine->history_len = 0;
+    engine->move_history_len = 0;
     engine->position_count = 1;
     engine->position_history[0] = board_hash(&engine->board);
+    copy_text(engine->initial_fen, sizeof(engine->initial_fen), fen_string);
+    engine->chess960_id = 0;
+    engine->chess960_mode = false;
+    pgn_init_game(&engine->pgn_game, fen_string, "current-game");
+    return true;
+}
+
+static bool engine_load_pgn_game(Engine *engine, const PgnGame *game) {
+    if (!board_load_fen(&engine->board, game->initial_fen)) {
+        return false;
+    }
+
+    engine->history_len = 0;
+    engine->move_history_len = 0;
+    engine->position_count = 1;
+    engine->position_history[0] = board_hash(&engine->board);
+    copy_text(engine->initial_fen, sizeof(engine->initial_fen), game->initial_fen);
+    engine->pgn_game = *game;
+    engine->chess960_id = 0;
+    engine->chess960_mode = false;
+
+    for (int index = 0; index < game->move_count; ++index) {
+        if (engine->move_history_len >= MAX_HISTORY || !engine_store_snapshot(engine)) {
+            return false;
+        }
+        engine->move_history[engine->move_history_len++] = game->moves[index].move;
+        apply_move(&engine->board, &game->moves[index].move);
+        engine->position_history[engine->position_count++] = board_hash(&engine->board);
+    }
+
+    pgn_set_result(&engine->pgn_game, result_for_status(engine_status(engine)));
+    return true;
+}
+
+static bool engine_load_chess960(Engine *engine, int chess960_id) {
+    char fen[FEN_BUFFER_SIZE];
+
+    chess960_fen(chess960_id, fen);
+    if (!engine_load_position(engine, fen)) {
+        return false;
+    }
+
+    engine->chess960_id = chess960_id;
+    engine->chess960_mode = true;
     return true;
 }
 
@@ -1202,6 +1332,598 @@ static GameStatus engine_status(const Engine *engine) {
     }
 
     return in_check ? STATUS_CHECK : STATUS_ONGOING;
+}
+
+static void copy_text(char *destination, size_t destination_size, const char *source) {
+    if (destination_size == 0) {
+        return;
+    }
+    if (source == NULL) {
+        destination[0] = '\0';
+        return;
+    }
+    snprintf(destination, destination_size, "%s", source);
+}
+
+static bool same_move(const Move *first, const Move *second) {
+    return first->from == second->from &&
+           first->to == second->to &&
+           first->promotion == second->promotion &&
+           first->is_castling == second->is_castling &&
+           first->is_en_passant == second->is_en_passant;
+}
+
+static void square_to_text(int square, char buffer[3]) {
+    buffer[0] = (char) ('a' + square_col(square));
+    buffer[1] = (char) ('1' + square_row(square));
+    buffer[2] = '\0';
+}
+
+static void pgn_put_tag(PgnGame *game, const char *name, const char *value) {
+    for (int index = 0; index < game->tag_count; ++index) {
+        if (strcmp(game->tags[index].name, name) == 0) {
+            copy_text(game->tags[index].value, sizeof(game->tags[index].value), value);
+            return;
+        }
+    }
+
+    if (game->tag_count >= MAX_PGN_TAGS) {
+        return;
+    }
+
+    copy_text(game->tags[game->tag_count].name, sizeof(game->tags[game->tag_count].name), name);
+    copy_text(game->tags[game->tag_count].value, sizeof(game->tags[game->tag_count].value), value);
+    game->tag_count += 1;
+}
+
+static const char *pgn_get_tag(const PgnGame *game, const char *name) {
+    for (int index = 0; index < game->tag_count; ++index) {
+        if (strcmp(game->tags[index].name, name) == 0) {
+            return game->tags[index].value;
+        }
+    }
+    return NULL;
+}
+
+static void pgn_init_game(PgnGame *game, const char *initial_fen, const char *source) {
+    memset(game, 0, sizeof(*game));
+    copy_text(game->initial_fen, sizeof(game->initial_fen), initial_fen);
+    copy_text(game->source, sizeof(game->source), source != NULL ? source : "current-game");
+    copy_text(game->result, sizeof(game->result), "*");
+    pgn_put_tag(game, "Event", "CLI Game");
+    pgn_put_tag(game, "Site", "Local");
+    if (strcmp(initial_fen, START_FEN) != 0) {
+        pgn_put_tag(game, "SetUp", "1");
+        pgn_put_tag(game, "FEN", initial_fen);
+    }
+    pgn_put_tag(game, "Result", "*");
+}
+
+static void pgn_set_result(PgnGame *game, const char *result) {
+    copy_text(game->result, sizeof(game->result), result);
+    pgn_put_tag(game, "Result", result);
+}
+
+static void normalize_san(const char *san, char buffer[PGN_SAN_SIZE]) {
+    size_t length = strlen(san);
+    size_t cursor = 0;
+
+    while (cursor < length && isdigit((unsigned char) san[cursor])) {
+        cursor += 1;
+    }
+    while (cursor < length && san[cursor] == '.') {
+        cursor += 1;
+    }
+
+    size_t out = 0;
+    for (; cursor < length && out + 1 < PGN_SAN_SIZE; ++cursor) {
+        char value = san[cursor];
+        if (value == '0' && cursor + 2 < length && san[cursor + 1] == '-' && san[cursor + 2] == '0') {
+            buffer[out++] = 'O';
+        } else if (value != '!' && value != '?') {
+            buffer[out++] = value;
+        }
+    }
+    buffer[out] = '\0';
+
+    while (out > 0 && (buffer[out - 1] == '+' || buffer[out - 1] == '#')) {
+        buffer[--out] = '\0';
+    }
+    if (strcmp(buffer, "0-0") == 0) {
+        copy_text(buffer, PGN_SAN_SIZE, "O-O");
+    } else if (strcmp(buffer, "0-0-0") == 0) {
+        copy_text(buffer, PGN_SAN_SIZE, "O-O-O");
+    }
+}
+
+static void san_disambiguation(const Board *board, const Move *move, char buffer[3]) {
+    MoveList legal_moves;
+    char moving_piece = board->squares[move->from];
+    bool same_file = false;
+    bool same_rank = false;
+    int count = 0;
+
+    generate_legal_moves(board, &legal_moves);
+    for (int index = 0; index < legal_moves.count; ++index) {
+        Move candidate = legal_moves.moves[index];
+        if (same_move(&candidate, move) ||
+            candidate.to != move->to ||
+            board->squares[candidate.from] != moving_piece) {
+            continue;
+        }
+        count += 1;
+        if (square_col(candidate.from) == square_col(move->from)) {
+            same_file = true;
+        }
+        if (square_row(candidate.from) == square_row(move->from)) {
+            same_rank = true;
+        }
+    }
+
+    if (count == 0) {
+        buffer[0] = '\0';
+        return;
+    }
+
+    if (!same_file) {
+        buffer[0] = (char) ('a' + square_col(move->from));
+        buffer[1] = '\0';
+        return;
+    }
+    if (!same_rank) {
+        buffer[0] = (char) ('1' + square_row(move->from));
+        buffer[1] = '\0';
+        return;
+    }
+
+    buffer[0] = (char) ('a' + square_col(move->from));
+    buffer[1] = (char) ('1' + square_row(move->from));
+    buffer[2] = '\0';
+}
+
+static bool move_to_san(const Board *board, const Move *move, char buffer[PGN_SAN_SIZE]) {
+    char piece = board->squares[move->from];
+    char destination[3];
+    bool is_capture = board->squares[move->to] != '.' || move->is_en_passant;
+    char disambiguation[3] = "";
+    char promotion[3] = "";
+    Board next_board;
+    MoveList legal_moves;
+
+    if (piece == '.') {
+        return false;
+    }
+
+    square_to_text(move->to, destination);
+
+    if (move->promotion != '\0') {
+        promotion[0] = '=';
+        promotion[1] = (char) toupper((unsigned char) move->promotion);
+        promotion[2] = '\0';
+    }
+
+    if (move->is_castling) {
+        copy_text(buffer, PGN_SAN_SIZE, square_col(move->to) == 6 ? "O-O" : "O-O-O");
+    } else if (toupper((unsigned char) piece) == 'P') {
+        char prefix[3] = "";
+        if (is_capture) {
+            prefix[0] = (char) ('a' + square_col(move->from));
+            prefix[1] = 'x';
+            prefix[2] = '\0';
+        }
+        snprintf(buffer, PGN_SAN_SIZE, "%s%s%s", prefix, destination, promotion);
+    } else {
+        san_disambiguation(board, move, disambiguation);
+        snprintf(buffer, PGN_SAN_SIZE, "%c%s%s%s%s",
+                 (char) toupper((unsigned char) piece),
+                 disambiguation,
+                 is_capture ? "x" : "",
+                 destination,
+                 promotion);
+    }
+
+    next_board = *board;
+    apply_move(&next_board, move);
+    if (is_in_check(&next_board, next_board.white_to_move)) {
+        generate_legal_moves(&next_board, &legal_moves);
+        strncat(buffer, legal_moves.count == 0 ? "#" : "+", PGN_SAN_SIZE - strlen(buffer) - 1);
+    }
+    return true;
+}
+
+static bool san_to_move(const Board *board, const char *san, Move *resolved) {
+    MoveList legal_moves;
+    char expected[PGN_SAN_SIZE];
+    char actual[PGN_SAN_SIZE];
+
+    normalize_san(san, expected);
+    generate_legal_moves(board, &legal_moves);
+    for (int index = 0; index < legal_moves.count; ++index) {
+        if (!move_to_san(board, &legal_moves.moves[index], actual)) {
+            continue;
+        }
+        normalize_san(actual, actual);
+        if (strcmp(expected, actual) == 0) {
+            *resolved = legal_moves.moves[index];
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool is_result_token(const char *token) {
+    return strcmp(token, "1-0") == 0 ||
+           strcmp(token, "0-1") == 0 ||
+           strcmp(token, "1/2-1/2") == 0 ||
+           strcmp(token, "*") == 0;
+}
+
+static bool is_move_number_token(const char *token) {
+    size_t length = strlen(token);
+    size_t index = 0;
+
+    if (length == 0) {
+        return false;
+    }
+    while (index < length && isdigit((unsigned char) token[index])) {
+        index += 1;
+    }
+    if (index == 0) {
+        return false;
+    }
+    while (index < length && token[index] == '.') {
+        index += 1;
+    }
+    return index == length;
+}
+
+static bool is_nag_token(const char *token) {
+    if (token[0] != '$' || token[1] == '\0') {
+        return false;
+    }
+    for (size_t index = 1; token[index] != '\0'; ++index) {
+        if (!isdigit((unsigned char) token[index])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static void strip_comments_and_variations(const char *input, char *output) {
+    int variation_depth = 0;
+    bool in_braces = false;
+    bool in_semicolon = false;
+    size_t out = 0;
+
+    for (size_t index = 0; input[index] != '\0'; ++index) {
+        char value = input[index];
+
+        if (in_semicolon) {
+            if (value == '\n') {
+                in_semicolon = false;
+                output[out++] = value;
+            }
+            continue;
+        }
+        if (in_braces) {
+            if (value == '}') {
+                in_braces = false;
+            }
+            continue;
+        }
+        if (variation_depth > 0) {
+            if (value == '(') {
+                variation_depth += 1;
+            } else if (value == ')') {
+                variation_depth -= 1;
+            }
+            continue;
+        }
+
+        if (value == '{') {
+            in_braces = true;
+            continue;
+        }
+        if (value == ';') {
+            in_semicolon = true;
+            continue;
+        }
+        if (value == '(') {
+            variation_depth = 1;
+            continue;
+        }
+        output[out++] = value;
+    }
+    output[out] = '\0';
+}
+
+static bool pgn_parse_tag_line(PgnGame *game, const char *line) {
+    const char *cursor = line;
+    const char *space = NULL;
+    const char *quote_start = NULL;
+    const char *quote_end = NULL;
+    char name[PGN_TAG_NAME_SIZE];
+    char value[PGN_TAG_VALUE_SIZE];
+
+    if (*cursor != '[') {
+        return false;
+    }
+    cursor += 1;
+    space = strchr(cursor, ' ');
+    if (space == NULL) {
+        return false;
+    }
+
+    size_t name_length = (size_t) (space - cursor);
+    if (name_length == 0 || name_length >= sizeof(name)) {
+        return false;
+    }
+    memcpy(name, cursor, name_length);
+    name[name_length] = '\0';
+
+    quote_start = strchr(space, '"');
+    quote_end = strrchr(space, '"');
+    if (quote_start == NULL || quote_end == NULL || quote_end <= quote_start) {
+        return false;
+    }
+    size_t value_length = (size_t) (quote_end - quote_start - 1);
+    if (value_length >= sizeof(value)) {
+        value_length = sizeof(value) - 1;
+    }
+    memcpy(value, quote_start + 1, value_length);
+    value[value_length] = '\0';
+
+    pgn_put_tag(game, name, value);
+    return true;
+}
+
+static bool pgn_build_from_history(PgnGame *game, const Move *move_history, int move_count, const char *initial_fen, const char *source) {
+    Board board;
+
+    if (!board_load_fen(&board, initial_fen)) {
+        return false;
+    }
+
+    pgn_init_game(game, initial_fen, source);
+    for (int index = 0; index < move_count && index < MAX_HISTORY; ++index) {
+        PgnMoveNode *node = &game->moves[game->move_count];
+        if (!move_to_san(&board, &move_history[index], node->san)) {
+            return false;
+        }
+        board_export_fen(&board, node->fen_before, sizeof(node->fen_before));
+        node->move = move_history[index];
+        apply_move(&board, &move_history[index]);
+        board_export_fen(&board, node->fen_after, sizeof(node->fen_after));
+        game->move_count += 1;
+    }
+    return true;
+}
+
+static void starting_ply_from_fen(const char *fen, int *move_number, bool *white_to_move) {
+    char board_part[80];
+    char side = 'w';
+    char castling[16];
+    char en_passant[16];
+    int halfmove = 0;
+    int fullmove = 1;
+
+    if (sscanf(fen, "%79s %c %15s %15s %d %d", board_part, &side, castling, en_passant, &halfmove, &fullmove) == 6) {
+        *move_number = fullmove > 0 ? fullmove : 1;
+        *white_to_move = side != 'b';
+        return;
+    }
+
+    *move_number = 1;
+    *white_to_move = true;
+}
+
+static void pgn_serialize(const PgnGame *game, char *buffer, size_t buffer_size) {
+    char *cursor = buffer;
+    size_t remaining = buffer_size;
+    int move_number = 1;
+    bool white_to_move = true;
+
+    if (buffer_size == 0) {
+        return;
+    }
+    buffer[0] = '\0';
+
+    for (int index = 0; index < game->tag_count; ++index) {
+        append_format(&cursor, &remaining, "[%s \"%s\"]\n", game->tags[index].name, game->tags[index].value);
+    }
+    if (game->tag_count > 0) {
+        append_format(&cursor, &remaining, "\n");
+    }
+
+    starting_ply_from_fen(game->initial_fen, &move_number, &white_to_move);
+    for (int index = 0; index < game->move_count; ++index) {
+        if (white_to_move) {
+            append_format(&cursor, &remaining, "%d. %s", move_number, game->moves[index].san);
+        } else if (index == 0) {
+            append_format(&cursor, &remaining, "%d... %s", move_number, game->moves[index].san);
+        } else {
+            append_format(&cursor, &remaining, "%s", game->moves[index].san);
+        }
+
+        if (index + 1 < game->move_count || game->result[0] != '\0') {
+            append_format(&cursor, &remaining, " ");
+        }
+
+        if (!white_to_move) {
+            move_number += 1;
+        }
+        white_to_move = !white_to_move;
+    }
+
+    append_format(&cursor, &remaining, "%s\n", game->result[0] != '\0' ? game->result : "*");
+}
+
+static bool pgn_parse(const char *content, const char *source, PgnGame *game, char *error, size_t error_size) {
+    size_t content_length = strlen(content);
+    char *movetext = calloc(content_length + 1, sizeof(char));
+    char *stripped = calloc(content_length + 1, sizeof(char));
+    Board board;
+    bool success = false;
+
+    if (movetext == NULL || stripped == NULL) {
+        copy_text(error, error_size, "out of memory");
+        goto cleanup;
+    }
+
+    pgn_init_game(game, START_FEN, source);
+
+    const char *cursor = content;
+    size_t movetext_length = 0;
+    while (*cursor != '\0') {
+        const char *line_end = cursor;
+        while (*line_end != '\0' && *line_end != '\n') {
+            line_end += 1;
+        }
+
+        size_t line_length = (size_t) (line_end - cursor);
+        while (line_length > 0 && (cursor[line_length - 1] == '\r' || isspace((unsigned char) cursor[line_length - 1]))) {
+            line_length -= 1;
+        }
+
+        size_t start = 0;
+        while (start < line_length && isspace((unsigned char) cursor[start])) {
+            start += 1;
+        }
+
+        if (start < line_length && cursor[start] == '[' && cursor[line_length - 1] == ']') {
+            char line_buffer[PGN_TAG_VALUE_SIZE + PGN_TAG_NAME_SIZE + 8];
+            size_t trimmed_length = line_length - start;
+            if (trimmed_length >= sizeof(line_buffer)) {
+                trimmed_length = sizeof(line_buffer) - 1;
+            }
+            memcpy(line_buffer, cursor + start, trimmed_length);
+            line_buffer[trimmed_length] = '\0';
+            if (!pgn_parse_tag_line(game, line_buffer)) {
+                copy_text(error, error_size, "invalid PGN tag");
+                goto cleanup;
+            }
+        } else if (start < line_length) {
+            size_t trimmed_length = line_length - start;
+            memcpy(movetext + movetext_length, cursor + start, trimmed_length);
+            movetext_length += trimmed_length;
+            movetext[movetext_length++] = ' ';
+        }
+
+        cursor = *line_end == '\n' ? line_end + 1 : line_end;
+    }
+    movetext[movetext_length] = '\0';
+
+    const char *initial_fen = pgn_get_tag(game, "FEN");
+    if (initial_fen == NULL) {
+        initial_fen = START_FEN;
+    }
+    copy_text(game->initial_fen, sizeof(game->initial_fen), initial_fen);
+
+    if (!board_load_fen(&board, initial_fen)) {
+        copy_text(error, error_size, "invalid PGN FEN");
+        goto cleanup;
+    }
+
+    strip_comments_and_variations(movetext, stripped);
+
+    for (char *token = strtok(stripped, " \t\r\n"); token != NULL; token = strtok(NULL, " \t\r\n")) {
+        if (is_move_number_token(token) || is_nag_token(token)) {
+            continue;
+        }
+        if (is_result_token(token)) {
+            pgn_set_result(game, token);
+            continue;
+        }
+
+        if (game->move_count >= MAX_HISTORY) {
+            copy_text(error, error_size, "PGN move limit exceeded");
+            goto cleanup;
+        }
+
+        PgnMoveNode *node = &game->moves[game->move_count];
+        if (!san_to_move(&board, token, &node->move) || !move_to_san(&board, &node->move, node->san)) {
+            copy_text(error, error_size, "unresolved SAN move");
+            goto cleanup;
+        }
+        board_export_fen(&board, node->fen_before, sizeof(node->fen_before));
+        apply_move(&board, &node->move);
+        board_export_fen(&board, node->fen_after, sizeof(node->fen_after));
+        game->move_count += 1;
+    }
+
+    if (pgn_get_tag(game, "Result") == NULL) {
+        pgn_put_tag(game, "Result", game->result[0] != '\0' ? game->result : "*");
+    }
+    if (game->result[0] == '\0') {
+        copy_text(game->result, sizeof(game->result), pgn_get_tag(game, "Result"));
+    }
+    success = true;
+
+cleanup:
+    free(movetext);
+    free(stripped);
+    return success;
+}
+
+static void chess960_backrank(int chess960_id, char buffer[9]) {
+    static const int knight_table[10][2] = {
+        {0, 1}, {0, 2}, {0, 3}, {0, 4}, {1, 2},
+        {1, 3}, {1, 4}, {2, 3}, {2, 4}, {3, 4},
+    };
+    char pieces[8] = {0};
+    int empty[8];
+    int empty_count = 0;
+    int remainder = chess960_id % 4;
+    int value = chess960_id / 4;
+
+    pieces[2 * remainder + 1] = 'b';
+    remainder = value % 4;
+    value /= 4;
+    pieces[2 * remainder] = 'b';
+
+    remainder = value % 6;
+    value /= 6;
+    for (int index = 0; index < 8; ++index) {
+        if (pieces[index] == 0) {
+            empty[empty_count++] = index;
+        }
+    }
+    pieces[empty[remainder]] = 'q';
+
+    empty_count = 0;
+    for (int index = 0; index < 8; ++index) {
+        if (pieces[index] == 0) {
+            empty[empty_count++] = index;
+        }
+    }
+    pieces[empty[knight_table[value][0]]] = 'n';
+    pieces[empty[knight_table[value][1]]] = 'n';
+
+    empty_count = 0;
+    for (int index = 0; index < 8; ++index) {
+        if (pieces[index] == 0) {
+            empty[empty_count++] = index;
+        }
+    }
+    pieces[empty[0]] = 'r';
+    pieces[empty[1]] = 'k';
+    pieces[empty[2]] = 'r';
+
+    for (int index = 0; index < 8; ++index) {
+        buffer[index] = pieces[index];
+    }
+    buffer[8] = '\0';
+}
+
+static void chess960_fen(int chess960_id, char buffer[FEN_BUFFER_SIZE]) {
+    char backrank[9];
+    char white_backrank[9];
+    chess960_backrank(chess960_id, backrank);
+    for (int index = 0; index < 8; ++index) {
+        white_backrank[index] = (char) toupper((unsigned char) backrank[index]);
+    }
+    white_backrank[8] = '\0';
+    snprintf(buffer, FEN_BUFFER_SIZE, "%s/pppppppp/8/8/8/8/PPPPPPPP/%s w - - 0 1", backrank, white_backrank);
 }
 
 static void print_status(const Engine *engine) {
@@ -1455,7 +2177,44 @@ static bool process_command(Engine *engine, char *line) {
     }
 
     if (strcmp(line, "help") == 0) {
-        printf("OK: commands=new move undo status fen export eval hash draws history ai perft help quit\n");
+        printf("OK: commands=new move undo status fen export eval hash draws history ai perft pgn uci isready new960 position960 help quit\n");
+        return true;
+    }
+
+    if (strcmp(line, "uci") == 0) {
+        printf("id name C Chess Engine\n");
+        printf("id author The Great Analysis Challenge\n");
+        printf("uciok\n");
+        return true;
+    }
+
+    if (strcmp(line, "isready") == 0) {
+        printf("readyok\n");
+        return true;
+    }
+
+    if (strcmp(line, "new960") == 0) {
+        char backrank[9];
+        if (!engine_load_chess960(engine, 0)) {
+            printf("ERROR: Could not load Chess960 position\n");
+            return true;
+        }
+        chess960_backrank(0, backrank);
+        printf("OK: New game started\n");
+        printf("960: new game id=0; backrank=%s\n", backrank);
+        return true;
+    }
+
+    if (strcmp(line, "position960") == 0) {
+        char backrank[9];
+        char fen[FEN_BUFFER_SIZE];
+        chess960_backrank(engine->chess960_id, backrank);
+        chess960_fen(engine->chess960_id, fen);
+        printf("960: id=%d; mode=%s; backrank=%s; fen=%s\n",
+               engine->chess960_id,
+               engine->chess960_mode ? "chess960" : "standard",
+               backrank,
+               fen);
         return true;
     }
 
@@ -1518,6 +2277,103 @@ static bool process_command(Engine *engine, char *line) {
         }
         printf("NODES: depth=%d; count=%llu; time=0ms\n",
                depth, (unsigned long long) perft(&engine->board, depth));
+        return true;
+    }
+
+    if (starts_with(line, "new960 ")) {
+        int chess960_id = 0;
+        char backrank[9];
+        if (!parse_int_argument(line + 7, &chess960_id) || chess960_id < 0 || chess960_id > 959) {
+            printf("ERROR: new960 id must be between 0 and 959\n");
+            return true;
+        }
+        if (!engine_load_chess960(engine, chess960_id)) {
+            printf("ERROR: Could not load Chess960 position\n");
+            return true;
+        }
+        chess960_backrank(chess960_id, backrank);
+        printf("OK: New game started\n");
+        printf("960: new game id=%d; backrank=%s\n", chess960_id, backrank);
+        return true;
+    }
+
+    if (starts_with(line, "pgn ")) {
+        if (starts_with(line, "pgn load ")) {
+            PgnGame game;
+            char error[128] = "";
+            char *content = NULL;
+            const char *path = line + 9;
+            FILE *handle = fopen(path, "rb");
+            if (handle == NULL) {
+                printf("ERROR: pgn load failed: file not found: %s\n", path);
+                return true;
+            }
+
+            if (fseek(handle, 0, SEEK_END) != 0) {
+                fclose(handle);
+                printf("ERROR: pgn load failed: could not seek\n");
+                return true;
+            }
+            long length = ftell(handle);
+            rewind(handle);
+            if (length < 0) {
+                fclose(handle);
+                printf("ERROR: pgn load failed: could not read size\n");
+                return true;
+            }
+
+            content = calloc((size_t) length + 1U, sizeof(char));
+            if (content == NULL) {
+                fclose(handle);
+                printf("ERROR: pgn load failed: out of memory\n");
+                return true;
+            }
+            if (fread(content, 1, (size_t) length, handle) != (size_t) length) {
+                free(content);
+                fclose(handle);
+                printf("ERROR: pgn load failed: could not read file\n");
+                return true;
+            }
+            fclose(handle);
+
+            if (!pgn_parse(content, path, &game, error, sizeof(error)) || !engine_load_pgn_game(engine, &game)) {
+                printf("ERROR: pgn load failed: %s\n", error[0] != '\0' ? error : "could not load PGN");
+                free(content);
+                return true;
+            }
+            free(content);
+            printf("PGN: loaded source=%s\n", path);
+            return true;
+        }
+
+        if (strcmp(line, "pgn show") == 0) {
+            size_t buffer_size = (size_t) engine->pgn_game.move_count * 96U + (size_t) engine->pgn_game.tag_count * 320U + 512U;
+            char *buffer = calloc(buffer_size, sizeof(char));
+            if (buffer == NULL) {
+                printf("ERROR: pgn show failed: out of memory\n");
+                return true;
+            }
+            pgn_serialize(&engine->pgn_game, buffer, buffer_size);
+            printf("PGN: source=%s; moves=%d\n", engine->pgn_game.source, engine->pgn_game.move_count);
+            fputs(buffer, stdout);
+            free(buffer);
+            return true;
+        }
+
+        if (strcmp(line, "pgn moves") == 0) {
+            if (engine->pgn_game.move_count == 0) {
+                printf("PGN: moves (none)\n");
+                return true;
+            }
+            printf("PGN: moves");
+            for (int index = 0; index < engine->pgn_game.move_count; ++index) {
+                printf(" %s", engine->pgn_game.moves[index].san);
+            }
+            printf("\n");
+            return true;
+        }
+
+        printf("ERROR: Unsupported pgn command\n");
         return true;
     }
 

--- a/implementations/elixir/Dockerfile
+++ b/implementations/elixir/Dockerfile
@@ -8,7 +8,7 @@ RUN mix compile --warnings-as-errors
 LABEL org.chess.language="elixir"
 LABEL org.chess.version="1.17"
 LABEL org.chess.author="AI Implementation"
-LABEL org.chess.features="perft,fen,ai,castling,en_passant,promotion"
+LABEL org.chess.features="perft,fen,ai,castling,en_passant,promotion,pgn,uci,chess960"
 LABEL org.chess.max_ai_depth=5
 LABEL org.chess.estimated_perft4_ms=1500
 LABEL org.chess.source_exts=".ex,.exs"

--- a/implementations/elixir/README.md
+++ b/implementations/elixir/README.md
@@ -1,6 +1,6 @@
 # Elixir Chess Engine
 
-Elixir implementation of the shared `v1` chess engine specification.
+Elixir implementation of the shared `v1` chess engine specification with the current `v2-functional` extensions for PGN, UCI handshake, and Chess960 metadata commands.
 
 ## Highlights
 
@@ -9,6 +9,9 @@ Elixir implementation of the shared `v1` chess engine specification.
 - FEN import/export
 - Alpha-beta minimax AI (depth 1..5)
 - Snapshot-based undo and repetition tracking
+- PGN `load`, `show`, and `moves`
+- UCI `uci` / `isready`
+- Chess960 `new960` / `position960`
 - Docker-first build and validation
 
 ## Repository Workflow
@@ -22,6 +25,7 @@ make build DIR=elixir
 make analyze DIR=elixir
 make test DIR=elixir
 make test-chess-engine DIR=elixir
+make test-chess-engine DIR=elixir TRACK=v2-functional
 ```
 
 ## Commands
@@ -38,6 +42,13 @@ make test-chess-engine DIR=elixir
 - `history`
 - `ai <depth>`
 - `perft <depth>`
+- `pgn load <file>`
+- `pgn show`
+- `pgn moves`
+- `uci`
+- `isready`
+- `new960 [id]`
+- `position960`
 - `help`
 - `quit`
 

--- a/implementations/elixir/lib/chess_engine.ex
+++ b/implementations/elixir/lib/chess_engine.ex
@@ -8,11 +8,12 @@ defmodule ChessEngine.Move do
 end
 
 defmodule ChessEngine do
-  alias ChessEngine.Move
+  alias ChessEngine.{Chess960, Move, PGN}
 
   @empty ?.
   @mate_score 100_000
   @inf_score 1_000_000_000
+  @start_fen "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 
   @knight_deltas [
     {-2, -1},
@@ -121,11 +122,17 @@ defmodule ChessEngine do
 
   def new_engine do
     board = new_board()
+    pgn_game = PGN.new_game(@start_fen, "current-game")
 
     %{
       board: board,
       history: [],
-      position_history: [board_hash_hex(board)]
+      move_history: [],
+      position_history: [board_hash_hex(board)],
+      initial_fen: @start_fen,
+      pgn_game: pgn_game,
+      chess960_id: 0,
+      chess960_mode: false
     }
   end
 
@@ -148,11 +155,18 @@ defmodule ChessEngine do
   def load_position(_engine, fen_string) do
     case board_load_fen(fen_string) do
       {:ok, board} ->
+        pgn_game = PGN.new_game(fen_string, "current-game")
+
         {:ok,
          %{
            board: board,
            history: [],
-           position_history: [board_hash_hex(board)]
+           move_history: [],
+           position_history: [board_hash_hex(board)],
+           initial_fen: fen_string,
+           pgn_game: pgn_game,
+           chess960_id: 0,
+           chess960_mode: false
          }}
 
       :error ->
@@ -162,8 +176,23 @@ defmodule ChessEngine do
 
   def undo(%{history: []} = _engine), do: :error
 
-  def undo(%{history: [previous_board | rest], position_history: [_current | positions]} = engine) do
-    {:ok, %{engine | board: previous_board, history: rest, position_history: positions}}
+  def undo(
+        %{
+          history: [previous_board | rest],
+          move_history: [_last_move | move_rest],
+          position_history: [_current | positions]
+        } =
+          engine
+      ) do
+    next_engine = %{
+      engine
+      | board: previous_board,
+        history: rest,
+        move_history: move_rest,
+        position_history: positions
+    }
+
+    {:ok, rebuild_pgn(next_engine)}
   end
 
   def resolve_user_move(engine, move_text) do
@@ -209,12 +238,79 @@ defmodule ChessEngine do
     next_board = apply_move(engine.board, move)
 
     {:ok,
-     %{
+     rebuild_pgn(%{
        engine
        | board: next_board,
          history: [engine.board | engine.history],
+         move_history: [move | engine.move_history],
          position_history: [board_hash_hex(next_board) | engine.position_history]
-     }}
+     })}
+  end
+
+  def load_pgn_game(engine, game) do
+    engine
+    |> Map.put(:pgn_game, game)
+    |> Map.put(:initial_fen, game.initial_fen)
+    |> Map.put(:chess960_mode, false)
+    |> Map.put(:pgn_game, game)
+    |> sync_runtime_to_pgn()
+  end
+
+  def sync_runtime_to_pgn(engine) do
+    with {:ok, base_board} <- board_load_fen(engine.pgn_game.initial_fen) do
+      {board, history, move_history, position_history} =
+        Enum.reduce(
+          PGN.mainline_moves(engine.pgn_game),
+          {base_board, [], [], [board_hash_hex(base_board)]},
+          fn node, {board, history, move_history, position_history} ->
+            next_board = apply_move(board, node.move)
+
+            {
+              next_board,
+              [board | history],
+              [node.move | move_history],
+              [board_hash_hex(next_board) | position_history]
+            }
+          end
+        )
+
+      %{
+        engine
+        | board: board,
+          history: history,
+          move_history: move_history,
+          position_history: position_history,
+          initial_fen: engine.pgn_game.initial_fen
+      }
+      |> rebuild_pgn_result()
+    else
+      :error -> engine
+    end
+  end
+
+  def load_chess960(engine, chess960_id) do
+    fen = Chess960.build_fen(chess960_id)
+
+    case board_load_fen(fen) do
+      {:ok, board} ->
+        pgn_game = PGN.new_game(fen, "current-game")
+
+        {:ok,
+         %{
+           engine
+           | board: board,
+             history: [],
+             move_history: [],
+             position_history: [board_hash_hex(board)],
+             initial_fen: fen,
+             pgn_game: pgn_game,
+             chess960_id: chess960_id,
+             chess960_mode: true
+         }}
+
+      :error ->
+        :error
+    end
   end
 
   def status(engine) do
@@ -375,6 +471,32 @@ defmodule ChessEngine do
 
     square_to_text(move.from) <> square_to_text(move.to) <> promotion
   end
+
+  defp rebuild_pgn(engine) do
+    engine
+    |> Map.put(
+      :pgn_game,
+      engine.move_history
+      |> Enum.reverse()
+      |> PGN.build_game_from_history(
+        start_fen: engine.initial_fen,
+        source: engine.pgn_game.source || "current-game"
+      )
+    )
+    |> rebuild_pgn_result()
+  end
+
+  defp rebuild_pgn_result(engine) do
+    result = result_for_status(status(engine))
+    %{engine | pgn_game: PGN.set_result(engine.pgn_game, result)}
+  end
+
+  defp result_for_status(:checkmate_white), do: "1-0"
+  defp result_for_status(:checkmate_black), do: "0-1"
+  defp result_for_status(:stalemate), do: "1/2-1/2"
+  defp result_for_status(:draw_repetition), do: "1/2-1/2"
+  defp result_for_status(:draw_fifty), do: "1/2-1/2"
+  defp result_for_status(_status), do: "*"
 
   def generate_legal_moves(board) do
     moving_white = board.white_to_move
@@ -1114,6 +1236,7 @@ end
 
 defmodule ChessEngine.CLI do
   alias ChessEngine
+  alias ChessEngine.{Chess960, PGN}
 
   def main do
     loop(ChessEngine.new_engine())
@@ -1202,10 +1325,67 @@ defmodule ChessEngine.CLI do
 
   defp process_command(engine, "help") do
     IO.puts(
-      "OK: commands=new move undo status fen export eval hash draws history ai perft help quit"
+      "OK: commands=new move undo status fen export eval hash draws history ai perft pgn uci isready new960 position960 help quit"
     )
 
     {:continue, engine}
+  end
+
+  defp process_command(engine, "uci") do
+    IO.puts("id name Elixir Chess Engine")
+    IO.puts("id author The Great Analysis Challenge")
+    IO.puts("uciok")
+    {:continue, engine}
+  end
+
+  defp process_command(engine, "isready") do
+    IO.puts("readyok")
+    {:continue, engine}
+  end
+
+  defp process_command(engine, "new960") do
+    case ChessEngine.load_chess960(engine, 0) do
+      {:ok, next_engine} ->
+        IO.puts("OK: New game started")
+        IO.puts("960: new game id=0; backrank=#{Chess960.backrank(0)}")
+        {:continue, next_engine}
+
+      :error ->
+        IO.puts("ERROR: Could not load Chess960 position")
+        {:continue, engine}
+    end
+  end
+
+  defp process_command(engine, <<"new960 ", id_text::binary>>) do
+    case Integer.parse(String.trim(id_text)) do
+      {chess960_id, ""} when chess960_id >= 0 and chess960_id <= 959 ->
+        case ChessEngine.load_chess960(engine, chess960_id) do
+          {:ok, next_engine} ->
+            IO.puts("OK: New game started")
+            IO.puts("960: new game id=#{chess960_id}; backrank=#{Chess960.backrank(chess960_id)}")
+            {:continue, next_engine}
+
+          :error ->
+            IO.puts("ERROR: Could not load Chess960 position")
+            {:continue, engine}
+        end
+
+      _ ->
+        IO.puts("ERROR: new960 id must be between 0 and 959")
+        {:continue, engine}
+    end
+  end
+
+  defp process_command(engine, "position960") do
+    IO.puts(
+      "960: id=#{engine.chess960_id}; mode=#{if(engine.chess960_mode, do: "chess960", else: "standard")}; backrank=#{Chess960.backrank(engine.chess960_id)}; fen=#{Chess960.build_fen(engine.chess960_id)}"
+    )
+
+    {:continue, engine}
+  end
+
+  defp process_command(engine, <<"pgn ", rest::binary>>) do
+    process_pgn_command(engine, String.trim(rest))
   end
 
   defp process_command(engine, <<"move ", move_text::binary>>) do
@@ -1283,6 +1463,50 @@ defmodule ChessEngine.CLI do
 
   defp process_command(engine, _unknown) do
     IO.puts("ERROR: Invalid command")
+    {:continue, engine}
+  end
+
+  defp process_pgn_command(engine, <<"load ", path::binary>>) do
+    case File.read(String.trim(path)) do
+      {:ok, content} ->
+        case PGN.parse(content, String.trim(path)) do
+          {:ok, game} ->
+            next_engine = ChessEngine.load_pgn_game(engine, game)
+            IO.puts("PGN: loaded source=#{String.trim(path)}")
+            {:continue, next_engine}
+
+          {:error, message} ->
+            IO.puts("ERROR: pgn load failed: #{message}")
+            {:continue, engine}
+        end
+
+      {:error, :enoent} ->
+        IO.puts("ERROR: pgn load failed: file not found: #{String.trim(path)}")
+        {:continue, engine}
+
+      {:error, reason} ->
+        IO.puts("ERROR: pgn load failed: #{:file.format_error(reason)}")
+        {:continue, engine}
+    end
+  end
+
+  defp process_pgn_command(engine, "show") do
+    IO.puts("PGN: source=#{engine.pgn_game.source}; moves=#{length(engine.pgn_game.moves)}")
+    IO.write(PGN.serialize(engine.pgn_game))
+    {:continue, engine}
+  end
+
+  defp process_pgn_command(engine, "moves") do
+    case PGN.mainline_sans(engine.pgn_game) do
+      [] -> IO.puts("PGN: moves (none)")
+      moves -> IO.puts("PGN: moves #{Enum.join(moves, " ")}")
+    end
+
+    {:continue, engine}
+  end
+
+  defp process_pgn_command(engine, _rest) do
+    IO.puts("ERROR: Unsupported pgn command")
     {:continue, engine}
   end
 end

--- a/implementations/elixir/lib/chess_engine/chess960.ex
+++ b/implementations/elixir/lib/chess_engine/chess960.ex
@@ -1,0 +1,57 @@
+defmodule ChessEngine.Chess960 do
+  @knight_table [
+    {0, 1},
+    {0, 2},
+    {0, 3},
+    {0, 4},
+    {1, 2},
+    {1, 3},
+    {1, 4},
+    {2, 3},
+    {2, 4},
+    {3, 4}
+  ]
+
+  def backrank(chess960_id) when chess960_id >= 0 and chess960_id <= 959 do
+    pieces = List.duplicate(nil, 8)
+
+    remainder = rem(chess960_id, 4)
+    value = div(chess960_id, 4)
+    pieces = List.replace_at(pieces, 2 * remainder + 1, "b")
+
+    remainder = rem(value, 4)
+    value = div(value, 4)
+    pieces = List.replace_at(pieces, 2 * remainder, "b")
+
+    remainder = rem(value, 6)
+    value = div(value, 6)
+    empty = empty_indexes(pieces)
+    pieces = List.replace_at(pieces, Enum.at(empty, remainder), "q")
+
+    {knight_a, knight_b} = Enum.at(@knight_table, value)
+    empty = empty_indexes(pieces)
+    pieces = List.replace_at(pieces, Enum.at(empty, knight_a), "n")
+    pieces = List.replace_at(pieces, Enum.at(empty, knight_b), "n")
+
+    empty = empty_indexes(pieces)
+
+    pieces
+    |> List.replace_at(Enum.at(empty, 0), "r")
+    |> List.replace_at(Enum.at(empty, 1), "k")
+    |> List.replace_at(Enum.at(empty, 2), "r")
+    |> Enum.join()
+  end
+
+  def build_fen(chess960_id) when chess960_id >= 0 and chess960_id <= 959 do
+    white_backrank = String.upcase(backrank(chess960_id))
+    black_backrank = String.downcase(white_backrank)
+    "#{black_backrank}/pppppppp/8/8/8/8/PPPPPPPP/#{white_backrank} w - - 0 1"
+  end
+
+  defp empty_indexes(pieces) do
+    pieces
+    |> Enum.with_index()
+    |> Enum.filter(fn {piece, _index} -> is_nil(piece) end)
+    |> Enum.map(fn {_piece, index} -> index end)
+  end
+end

--- a/implementations/elixir/lib/chess_engine/pgn.ex
+++ b/implementations/elixir/lib/chess_engine/pgn.ex
@@ -1,0 +1,422 @@
+defmodule ChessEngine.PGN do
+  alias ChessEngine
+  alias ChessEngine.Move
+
+  @start_fen "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+  @result_tokens MapSet.new(["1-0", "0-1", "1/2-1/2", "*"])
+
+  def start_fen, do: @start_fen
+
+  def new_game(start_fen \\ @start_fen, source \\ "current-game") do
+    %{
+      tags: default_tags(start_fen),
+      moves: [],
+      result: "*",
+      source: source,
+      initial_fen: start_fen
+    }
+  end
+
+  def build_game_from_history(move_history, opts \\ []) do
+    start_fen = Keyword.get(opts, :start_fen, @start_fen)
+    source = Keyword.get(opts, :source, "current-game")
+    board = load_board!(start_fen)
+
+    {moves, _board} =
+      Enum.map_reduce(move_history, board, fn move, current_board ->
+        san = move_to_san(current_board, move)
+        next_board = ChessEngine.apply_move(current_board, move)
+
+        {
+          %{
+            san: san,
+            move: clone_move(move),
+            fen_before: ChessEngine.board_export_fen(current_board),
+            fen_after: ChessEngine.board_export_fen(next_board)
+          },
+          next_board
+        }
+      end)
+
+    %{new_game(start_fen, source) | moves: moves}
+  end
+
+  def set_result(game, result) do
+    %{game | result: result, tags: put_tag(game.tags, "Result", result)}
+  end
+
+  def parse(content, source \\ "current-game") do
+    {tags, movetext} = parse_tags(content)
+    initial_fen = get_tag(tags, "FEN") || @start_fen
+    result = get_tag(tags, "Result") || "*"
+    board = load_board!(initial_fen)
+    tokens = tokenize_movetext(movetext)
+
+    try do
+      {moves, parsed_result, _board} =
+        Enum.reduce(tokens, {[], result, board}, fn token,
+                                                    {moves, current_result, current_board} ->
+          cond do
+            move_number_token?(token) or nag_token?(token) ->
+              {moves, current_result, current_board}
+
+            MapSet.member?(@result_tokens, token) ->
+              {moves, token, current_board}
+
+            true ->
+              move = san_to_move(current_board, token)
+              san = move_to_san(current_board, move)
+              next_board = ChessEngine.apply_move(current_board, move)
+
+              {
+                moves ++
+                  [
+                    %{
+                      san: san,
+                      move: clone_move(move),
+                      fen_before: ChessEngine.board_export_fen(current_board),
+                      fen_after: ChessEngine.board_export_fen(next_board)
+                    }
+                  ],
+                current_result,
+                next_board
+              }
+          end
+        end)
+
+      normalized_tags =
+        tags
+        |> ensure_tag("Event", "CLI Game")
+        |> ensure_tag("Site", "Local")
+        |> ensure_tag("Result", parsed_result)
+
+      {:ok,
+       %{
+         tags: normalized_tags,
+         moves: moves,
+         result: parsed_result,
+         source: source,
+         initial_fen: initial_fen
+       }}
+    rescue
+      error in RuntimeError ->
+        {:error, Exception.message(error)}
+    end
+  end
+
+  def serialize(game) do
+    tag_lines = Enum.map(game.tags, fn {name, value} -> ~s([#{name} "#{value}"]) end)
+    move_text = serialize_moves(game.moves, game.initial_fen)
+
+    [Enum.join(tag_lines, "\n"), "", String.trim("#{move_text} #{game.result}")]
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join("\n")
+    |> Kernel.<>("\n")
+  end
+
+  def mainline_sans(game) do
+    Enum.map(game.moves, & &1.san)
+  end
+
+  def mainline_moves(game), do: game.moves
+
+  def move_to_san(board, %Move{} = move) do
+    piece = piece_at(board, move.from)
+    destination = square_to_text(move.to)
+    capture? = move.is_en_passant or piece_at(board, move.to) != ?.
+
+    san =
+      cond do
+        move.is_castling and square_col(move.to) == 6 ->
+          "O-O"
+
+        move.is_castling ->
+          "O-O-O"
+
+        upper_piece(piece) == ?P ->
+          pawn_san(move, capture?, destination)
+
+        true ->
+          prefix =
+            <<upper_piece(piece)>> <>
+              disambiguation(board, move) <>
+              if(capture?, do: "x", else: "")
+
+          prefix <> destination <> promotion_suffix(move.promotion)
+      end
+
+    next_board = ChessEngine.apply_move(board, move)
+
+    cond do
+      ChessEngine.is_in_check(next_board, next_board.white_to_move) and
+          ChessEngine.generate_legal_moves(next_board) == [] ->
+        san <> "#"
+
+      ChessEngine.is_in_check(next_board, next_board.white_to_move) ->
+        san <> "+"
+
+      true ->
+        san
+    end
+  end
+
+  defp pawn_san(move, capture?, destination) do
+    prefix =
+      if capture? do
+        <<?a + square_col(move.from), ?x>>
+      else
+        ""
+      end
+
+    prefix <> destination <> promotion_suffix(move.promotion)
+  end
+
+  def san_to_move(board, san) do
+    normalized = normalize_san(san)
+
+    board
+    |> ChessEngine.generate_legal_moves()
+    |> Enum.find(fn move -> normalize_san(move_to_san(board, move)) == normalized end)
+    |> case do
+      nil -> raise("unresolved SAN move: #{san}")
+      move -> move
+    end
+  end
+
+  defp parse_tags(content) do
+    {tag_lines, movetext_lines} =
+      content
+      |> String.split(~r/\r?\n/)
+      |> Enum.reduce({[], []}, fn line, {tags, movetext} ->
+        trimmed = String.trim(line)
+
+        cond do
+          String.starts_with?(trimmed, "[") and String.ends_with?(trimmed, "]") ->
+            {[trimmed | tags], movetext}
+
+          true ->
+            {tags, [line | movetext]}
+        end
+      end)
+
+    tags =
+      tag_lines
+      |> Enum.reverse()
+      |> Enum.map(fn line ->
+        case Regex.run(~r/^\[([A-Za-z0-9_]+)\s+"((?:\\.|[^"])*)"\]$/, line,
+               capture: :all_but_first
+             ) do
+          [name, value] -> {name, String.replace(value, ~s(\\"), ~s("))}
+          _ -> raise("invalid PGN tag: #{line}")
+        end
+      end)
+
+    {tags, Enum.reverse(movetext_lines) |> Enum.join("\n")}
+  end
+
+  defp tokenize_movetext(movetext) do
+    movetext
+    |> strip_comments_and_variations()
+    |> String.split(~r/\s+/, trim: true)
+  end
+
+  defp strip_comments_and_variations(text) do
+    do_strip(text, 0, false, false, [])
+    |> Enum.reverse()
+    |> IO.iodata_to_binary()
+  end
+
+  defp do_strip(text, index, _in_braces, _in_semicolon, acc) when index >= byte_size(text) do
+    acc
+  end
+
+  defp do_strip(text, index, in_braces, in_semicolon, acc) do
+    byte = :binary.at(text, index)
+
+    cond do
+      in_semicolon and byte == ?\n ->
+        do_strip(text, index + 1, false, false, [<<byte>> | acc])
+
+      in_semicolon ->
+        do_strip(text, index + 1, false, true, acc)
+
+      in_braces and byte == ?} ->
+        do_strip(text, index + 1, false, false, acc)
+
+      in_braces ->
+        do_strip(text, index + 1, true, false, acc)
+
+      byte == ?{ ->
+        do_strip(text, index + 1, true, false, acc)
+
+      byte == ?; ->
+        do_strip(text, index + 1, false, true, acc)
+
+      byte == ?( ->
+        do_strip_variation(text, index + 1, 1, acc)
+
+      true ->
+        do_strip(text, index + 1, false, false, [<<byte>> | acc])
+    end
+  end
+
+  defp do_strip_variation(text, index, depth, acc) when index >= byte_size(text) or depth == 0 do
+    do_strip(text, index, false, false, acc)
+  end
+
+  defp do_strip_variation(text, index, depth, acc) do
+    byte = :binary.at(text, index)
+
+    cond do
+      byte == ?( -> do_strip_variation(text, index + 1, depth + 1, acc)
+      byte == ?) -> do_strip_variation(text, index + 1, depth - 1, acc)
+      true -> do_strip_variation(text, index + 1, depth, acc)
+    end
+  end
+
+  defp serialize_moves(moves, initial_fen) do
+    {move_number, white_to_move} = starting_ply(initial_fen)
+
+    {parts, _move_number, _white_to_move} =
+      Enum.reduce(moves, {[], move_number, white_to_move}, fn node,
+                                                              {parts, current_number,
+                                                               current_white} ->
+        next_parts =
+          cond do
+            current_white ->
+              parts ++ ["#{current_number}. #{node.san}"]
+
+            parts == [] or not String.starts_with?(List.last(parts), "#{current_number}.") ->
+              parts ++ ["#{current_number}... #{node.san}"]
+
+            true ->
+              parts ++ [node.san]
+          end
+
+        next_number = if current_white, do: current_number, else: current_number + 1
+        {next_parts, next_number, not current_white}
+      end)
+
+    Enum.join(parts, " ")
+  end
+
+  defp starting_ply(fen) do
+    parts = String.split(fen)
+
+    move_number =
+      case Enum.at(parts, 5) do
+        nil ->
+          1
+
+        value ->
+          case Integer.parse(value) do
+            {parsed, ""} -> max(parsed, 1)
+            _ -> 1
+          end
+      end
+
+    white_to_move = Enum.at(parts, 1, "w") == "w"
+    {move_number, white_to_move}
+  end
+
+  defp disambiguation(board, move) do
+    moving_piece = piece_at(board, move.from)
+
+    conflicts =
+      board
+      |> ChessEngine.generate_legal_moves()
+      |> Enum.filter(fn candidate ->
+        candidate != move and candidate.to == move.to and
+          piece_at(board, candidate.from) == moving_piece
+      end)
+
+    same_file = Enum.any?(conflicts, &(square_col(&1.from) == square_col(move.from)))
+    same_rank = Enum.any?(conflicts, &(square_row(&1.from) == square_row(move.from)))
+
+    cond do
+      conflicts == [] -> ""
+      not same_file -> <<?a + square_col(move.from)>>
+      not same_rank -> Integer.to_string(square_row(move.from) + 1)
+      true -> square_to_text(move.from)
+    end
+  end
+
+  defp normalize_san(token) do
+    token
+    |> String.trim()
+    |> String.replace(~r/^(\d+)\.(\.\.)?/, "")
+    |> String.replace(~r/[!?]+$/, "")
+    |> String.replace(~r/(?:\+|#)+$/, "")
+    |> String.replace("0-0-0", "O-O-O")
+    |> String.replace("0-0", "O-O")
+    |> String.replace("e.p.", "")
+    |> String.replace("ep", "")
+    |> String.trim()
+  end
+
+  defp move_number_token?(token), do: String.match?(token, ~r/^\d+\.(\.\.)?$/)
+  defp nag_token?(token), do: String.match?(token, ~r/^\$\d+$/)
+
+  defp default_tags(start_fen) do
+    base = [{"Event", "CLI Game"}, {"Site", "Local"}]
+
+    tags =
+      if start_fen == @start_fen do
+        base
+      else
+        base ++ [{"SetUp", "1"}, {"FEN", start_fen}]
+      end
+
+    tags ++ [{"Result", "*"}]
+  end
+
+  defp ensure_tag(tags, name, value) do
+    if Enum.any?(tags, fn {current_name, _current_value} -> current_name == name end) do
+      put_tag(tags, name, value)
+    else
+      tags ++ [{name, value}]
+    end
+  end
+
+  defp put_tag(tags, name, value) do
+    Enum.map(tags, fn
+      {^name, _current_value} -> {name, value}
+      tag -> tag
+    end)
+  end
+
+  defp get_tag(tags, name) do
+    Enum.find_value(tags, fn
+      {^name, value} -> value
+      _ -> nil
+    end)
+  end
+
+  defp load_board!(fen) do
+    case ChessEngine.board_load_fen(fen) do
+      {:ok, board} -> board
+      :error -> raise("invalid FEN: #{fen}")
+    end
+  end
+
+  defp clone_move(%Move{} = move) do
+    %Move{
+      from: move.from,
+      to: move.to,
+      promotion: move.promotion,
+      is_castling: move.is_castling,
+      is_en_passant: move.is_en_passant,
+      captured: move.captured
+    }
+  end
+
+  defp piece_at(board, square), do: elem(board.squares, square)
+  defp square_row(square), do: div(square, 8)
+  defp square_col(square), do: rem(square, 8)
+  defp square_to_text(square), do: <<?a + square_col(square), ?1 + square_row(square)>>
+  defp upper_piece(piece) when piece >= ?a and piece <= ?z, do: piece - 32
+  defp upper_piece(piece), do: piece
+
+  defp promotion_suffix(nil), do: ""
+  defp promotion_suffix(piece), do: "=" <> <<upper_piece(piece)>>
+end

--- a/tooling/ci.ts
+++ b/tooling/ci.ts
@@ -527,6 +527,7 @@ export async function createRelease(options: {
   totalCount: number;
 }): Promise<number> {
   console.log("=== Creating Release ===");
+  let pushRef = process.env.GITHUB_REF_NAME?.trim() || "";
   let currentVersion = "v0.0.0";
   try {
     const result = await runCommand(["git", "tag", "--sort=-version:refname"], { check: true });
@@ -552,23 +553,28 @@ export async function createRelease(options: {
   }
   const newVersion = `v${nextMajor}.${nextMinor}.${nextPatch}`;
 
+  if (!pushRef) {
+    try {
+      const result = await runCommand(["git", "branch", "--show-current"], { cwd: REPO_ROOT, check: true });
+      pushRef = result.stdout.trim() || "main";
+    } catch {
+      pushRef = "main";
+    }
+  }
+
   if (options.readmeChanged === "true") {
     await combineResults();
     await runCommand(["git", "add", "reports/", "README.md"], { cwd: REPO_ROOT, check: true });
     const commitMessage = `chore: update implementation status from benchmark suite\n\nBenchmark results summary:\n- Total implementations: ${options.totalCount}\n- 🟢 Excellent: ${options.excellentCount}\n- 🟡 Good: ${options.goodCount}\n- 🔴 Needs work: ${options.needsWorkCount}\n\nPerformance testing completed with status updates.`;
     await runCommand(["git", "commit", "-m", commitMessage], { cwd: REPO_ROOT, check: true });
-    if (!process.env.GITHUB_ACTIONS) {
-      await runCommand(["git", "push", "origin", "master"], { cwd: REPO_ROOT, check: true });
-    }
+    await runCommand(["git", "push", "origin", `HEAD:${pushRef}`], { cwd: REPO_ROOT, check: true });
   }
 
   await runCommand(["git", "tag", "-a", newVersion, "-m", `Release ${newVersion} - Benchmark Update`], {
     cwd: REPO_ROOT,
     check: true,
   });
-  if (!process.env.GITHUB_ACTIONS) {
-    await runCommand(["git", "push", "origin", newVersion], { cwd: REPO_ROOT, check: true });
-  }
+  await runCommand(["git", "push", "origin", newVersion], { cwd: REPO_ROOT, check: true });
   writeGithubOutput("new_version", newVersion);
   console.log(`📤 Output: new_version=${newVersion}`);
   return 0;


### PR DESCRIPTION
## Summary
- add the current `v2-functional` PGN, UCI handshake, and Chess960 command surface to the C engine
- add the same `v2-functional` command surface to the Elixir engine and advertise `9/9` feature metadata for both implementations
- fix benchmark release publication so GitHub Actions pushes generated reports and README updates back to `main`

## Validation
- `make verify DIR=c`
- `make image DIR=c`
- `make build DIR=c`
- `make analyze DIR=c`
- `make test DIR=c`
- `make test-chess-engine DIR=c`
- `make test-chess-engine DIR=c TRACK=v2-functional`
- `make verify DIR=elixir`
- `make image DIR=elixir`
- `make build DIR=elixir`
- `make analyze DIR=elixir`
- `make test DIR=elixir`
- `make test-chess-engine DIR=elixir`
- `make test-chess-engine DIR=elixir TRACK=v2-functional`

Fixes #169
